### PR TITLE
Force cargo-deny installation

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -6,10 +6,6 @@ on:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
 
-env:
-  CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: 0
-
 jobs:
   security_audit:
     timeout-minutes: 10
@@ -20,20 +16,6 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v4
-
-      - name: Cache audit-check build
-        id: cache-audit-check
-        uses: actions/cache@v4
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Run audit-check action
         uses: EmbarkStudios/cargo-deny-action@v2

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -36,6 +36,4 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Run audit-check action
-        run: |
-          cargo install cargo-deny --locked --version 0.18.9
-          cargo deny check
+        uses: EmbarkStudios/cargo-deny-action@v2

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -37,5 +37,5 @@ jobs:
 
       - name: Run audit-check action
         run: |
-          which cargo-deny || cargo install cargo-deny --locked --version 0.18.9
+          cargo install cargo-deny --locked --version 0.18.9
           cargo deny check


### PR DESCRIPTION
The current workflow checks if cargo deny is installed before installing the new version. This is generally good, but it's causing the old version to remain and cause an error. This error is already solved in newer versions of cargo deny. 

This PR tries to solve this by using the official action from cargo deny developers.
