### PR TITLE
Enable wasm-opt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ wasm-witness:
 .PHONY: circuits-build
 circuits-build:
 	@echo "Building circuits (this may take a while)..."
-	BUILD_TESTS=1 cargo build -p circuits
+	BUILD_TESTS=1 cargo build -p circuits --release
 
 .PHONY: install
 install:

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -52,3 +52,28 @@ command_arguments = ["-c", """
 ./app/node_modules/.bin/esbuild app/js/ui.js --external:./prover.js --external:./witness/* --bundle --outfile=dist/.stage/js/ui.js --format=esm
 ./app/node_modules/.bin/esbuild app/js/worker.js --external:./prover.js --external:./witness/* --bundle --outfile=dist/.stage/js/worker.js --format=esm
 """]
+
+# Run wasm-opt with bulk-memory support on both prover and witness
+# We run it as a post-hook because we were not able to pass required flags directly to Trunk
+[[hooks]]
+stage = "post_build"
+command = "sh"
+command_arguments = ["-c", """
+WASM_OPT="$HOME/.cache/trunk/wasm-opt-version_123/bin/wasm-opt"
+OPT_FLAGS="--enable-bulk-memory --enable-nontrapping-float-to-int --enable-sign-ext -O3"
+
+PROVER_WASM="dist/js/prover_bg.wasm"
+if [ -x "$WASM_OPT" ] && [ -f "$PROVER_WASM" ]; then
+    "$WASM_OPT" $OPT_FLAGS -o "$PROVER_WASM.opt" "$PROVER_WASM" && mv "$PROVER_WASM.opt" "$PROVER_WASM"
+else
+    echo "[wasm-opt] Skipped prover: wasm-opt=$WASM_OPT exists=$([ -x \"$WASM_OPT\" ] && echo yes || echo no), file exists=$([ -f \"$PROVER_WASM\" ] && echo yes || echo no)"
+fi
+
+WITNESS_WASM="dist/js/witness/witness_bg.wasm"
+if [ -x "$WASM_OPT" ] && [ -f "$WITNESS_WASM" ]; then
+    "$WASM_OPT" $OPT_FLAGS -o "$WITNESS_WASM.opt" "$WITNESS_WASM" && mv "$WITNESS_WASM.opt" "$WITNESS_WASM"
+else
+    echo "[wasm-opt] Skipped witness: file exists=$([ -f \"$WITNESS_WASM\" ] && echo yes || echo no)"
+fi
+
+"""]

--- a/app/index.html
+++ b/app/index.html
@@ -30,6 +30,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 
+    <!-- Wasm-opt=0 disables Trunk's wasm-opt. We handle that manually later in Trunk.toml  with a post_build hook with extra WASM feature flags -->
+    <!-- We need data-wasm-opt="0" because Trunk doesn't allow us to pass additional flags that we need for WASM optimization. So we pass it manually in the post_build hook. -->
     <link data-trunk rel="rust" href="crates/prover" data-target-path="js" data-wasm-opt="0" />
     <link data-trunk rel="copy-dir" href="assets/" />
 </head>


### PR DESCRIPTION
Closes #48 
Enables wasm-opt.
I couldn't fix it directly during crate compilation. It failed because I couldn't pass the required flags there.
So I had to use a `post-build` hook in `Trunk.toml`. 

In general, the build was reduced by 50Kb, and the times are very similar. 