### PR TITLE
Updates Soroban-SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,9 +1419,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dtor"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58a0764cddb55ab28955347b45be00ade43d4d6f3ba4bf3dc354e4ec9432934"
+checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
 dependencies = [
  "dtor-proc-macro",
 ]
@@ -1787,6 +1787,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,6 +1826,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 dependencies = [
  "allocator-api2",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3266,9 +3285,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "25.0.0"
+version = "25.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba99589f3f535a6f1425ffafe94387955291e18015f1a7a3ee3181268f9eade"
+checksum = "7192e3a5551a7aeee90d2110b11b615798e81951fd8c8293c87ea7f88b0168f5"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -3278,9 +3297,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "25.0.0"
+version = "25.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d98779d733d04c89aa0883d50c7c072ba91c336689330467b55eb794be7730a"
+checksum = "bfc49a80a68fc1005847308e63b9fce39874de731940b1807b721d472de3ff01"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -3297,9 +3316,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "25.0.0"
+version = "25.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e34ece76defac3fb40a5f8e4dec69a709181f3ff591c31955f0e3e4fdd88737"
+checksum = "ea2334ba1cfe0a170ab744d96db0b4ca86934de9ff68187ceebc09dc342def55"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -3307,9 +3326,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "25.0.0"
+version = "25.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a655ba881c6a2aa4f465370367aa5dad3e34ccdc1daff504b0a2499e54ed3517"
+checksum = "43af5d53c57bc2f546e122adc0b1cca6f93942c718977379aa19ddd04f06fcec"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254 0.4.0",
@@ -3338,15 +3357,15 @@ dependencies = [
  "soroban-env-common",
  "soroban-wasmi",
  "static_assertions",
- "stellar-strkey",
+ "stellar-strkey 0.0.13",
  "wasmparser 0.116.1",
 ]
 
 [[package]]
 name = "soroban-env-macros"
-version = "25.0.0"
+version = "25.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ac49b6d8980998fdbf621148b9895cd315e6c9978c84db1bb14885df865019"
+checksum = "a989167512e3592d455b1e204d703cfe578a36672a77ed2f9e6f7e1bbfd9cc5c"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -3359,8 +3378,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "23.3.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=release%2Fv25-preview#184c1e398317ddb6d75d014b18235f7cdb59b255"
+version = "25.0.2"
+source = "git+https://github.com/stellar/rs-soroban-sdk?tag=v25.0.2#59a2e01a26f9330f8d516690911cb2ca87a6f1b3"
 dependencies = [
  "serde",
  "serde_json",
@@ -3372,8 +3391,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "23.3.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=release%2Fv25-preview#184c1e398317ddb6d75d014b18235f7cdb59b255"
+version = "25.0.2"
+source = "git+https://github.com/stellar/rs-soroban-sdk?tag=v25.0.2#59a2e01a26f9330f8d516690911cb2ca87a6f1b3"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -3389,14 +3408,14 @@ dependencies = [
  "soroban-env-host",
  "soroban-ledger-snapshot",
  "soroban-sdk-macros",
- "stellar-strkey",
+ "stellar-strkey 0.0.16",
  "visibility",
 ]
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "23.3.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=release%2Fv25-preview#184c1e398317ddb6d75d014b18235f7cdb59b255"
+version = "25.0.2"
+source = "git+https://github.com/stellar/rs-soroban-sdk?tag=v25.0.2#59a2e01a26f9330f8d516690911cb2ca87a6f1b3"
 dependencies = [
  "darling 0.20.11",
  "heck",
@@ -3414,8 +3433,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "23.3.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=release%2Fv25-preview#184c1e398317ddb6d75d014b18235f7cdb59b255"
+version = "25.0.2"
+source = "git+https://github.com/stellar/rs-soroban-sdk?tag=v25.0.2#59a2e01a26f9330f8d516690911cb2ca87a6f1b3"
 dependencies = [
  "base64",
  "stellar-xdr",
@@ -3425,8 +3444,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "23.3.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=release%2Fv25-preview#184c1e398317ddb6d75d014b18235f7cdb59b255"
+version = "25.0.2"
+source = "git+https://github.com/stellar/rs-soroban-sdk?tag=v25.0.2#59a2e01a26f9330f8d516690911cb2ca87a6f1b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -3502,6 +3521,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellar-strkey"
+version = "0.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084afcb0d458c3d5d5baa2d294b18f881e62cc258ef539d8fdf68be7dbe45520"
+dependencies = [
+ "crate-git-revision",
+ "data-encoding",
+ "heapless",
+]
+
+[[package]]
 name = "stellar-xdr"
 version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3517,7 +3547,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "stellar-strkey",
+ "stellar-strkey 0.0.13",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ num-bigint = { version = "0.4.6", default-features = false }
 num-integer = { version = "0.1.46", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 sha2 = { version = "0.10.9", default-features = false }
-soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", branch = "release/v25-preview", features = ["hazmat"] }
+soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", default-features = false, features = ["hazmat"], tag = "v25.0.2" }
 soroban-utils = { path = "contracts/soroban-utils" }
 wasm-bindgen = { version = "0.2.100", default-features = false }
 wasmer = { version = "6.1", default-features = false }

--- a/contracts/pool/src/merkle_with_history.rs
+++ b/contracts/pool/src/merkle_with_history.rs
@@ -15,7 +15,7 @@ use soroban_sdk::{Env, U256, Vec, contracttype};
 use soroban_utils::{get_zeroes, poseidon2_compress};
 
 /// Number of roots kept in history for proof verification
-const ROOT_HISTORY_SIZE: u32 = 100;
+const ROOT_HISTORY_SIZE: u32 = 90;
 
 // Errors
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Updates the Soroban-SDK dependency and closes #82 

- The update was simpler than expected. What got moved to a different [repo](https://github.com/stellar/rs-soroban-poseidon/) are the high-level wrappers around the permutation. But we still have access to the low-level Poseidon2 permutation within the Soroban SDK. So basically, this should be enough. ~~Asked the Stellar team for confirmation, and I will move out of draft when I get a response.~~ They confirmed only hash/sponged were moved to the other repo. We are fine as we only employ low-level functions.

- Updated `merkle_with_history.rs` to store fewer roots, as the new SDK has stricter enforcement of resource limits in the test environment.