### PR TITLE
fix(app): encrypt note secrets at rest and reuse session keys per account

### DIFF
--- a/app/js/__tests__/notes-store.test.js
+++ b/app/js/__tests__/notes-store.test.js
@@ -1,0 +1,229 @@
+const base64FromBytes = (bytes) => Buffer.from(Uint8Array.from(bytes)).toString('base64');
+
+describe('notes-store issue regression coverage', () => {
+  let notesStore;
+  let userNotes;
+  let signWalletMessage;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    userNotes = new Map();
+    signWalletMessage = jest.fn().mockResolvedValue({
+      signedMessage: base64FromBytes(new Array(64).fill(9)),
+    });
+
+    jest.doMock('../state/db.js', () => ({
+      __esModule: true,
+      get: jest.fn(async (_storeName, key) => userNotes.get(key)),
+      getAll: jest.fn(async () => Array.from(userNotes.values())),
+      getAllByIndex: jest.fn(async (_storeName, indexName, value) => {
+        if (indexName !== 'by_owner') {
+          return [];
+        }
+        return Array.from(userNotes.values()).filter((note) => note.owner === value);
+      }),
+      put: jest.fn(async (_storeName, value) => {
+        userNotes.set(value.id, { ...value });
+        return value.id;
+      }),
+      del: jest.fn(async (_storeName, key) => {
+        userNotes.delete(key);
+      }),
+      clear: jest.fn(async () => {
+        userNotes.clear();
+      }),
+    }));
+
+    jest.doMock('../wallet.js', () => ({
+      __esModule: true,
+      signWalletMessage,
+    }));
+
+    jest.doMock('../bridge.js', () => ({
+      __esModule: true,
+      deriveEncryptionKeypairFromSignature: jest.fn((signature) => ({
+        publicKey: new Uint8Array([signature[0], signature[1]]),
+        privateKey: new Uint8Array([signature[2], signature[3]]),
+      })),
+      deriveNotePrivateKeyFromSignature: jest.fn((signature) => (
+        new Uint8Array([signature[0], signature[1]])
+      )),
+      derivePublicKey: jest.fn((privateKey) => (
+        new Uint8Array(Array.from(privateKey, (value) => value + 10))
+      )),
+    }));
+
+    jest.doMock('../state/crypto.js', () => ({
+      __esModule: true,
+      deriveStorageKey: jest.fn(async (privateKeyBytes) => (
+        `storage:${Array.from(privateKeyBytes).join(',')}`
+      )),
+      encryptField: jest.fn(async (hexValue, aesKey) => `enc(${aesKey})::${hexValue}`),
+      decryptField: jest.fn(async (encryptedValue) => encryptedValue.split('::')[1]),
+    }));
+
+    notesStore = await import('../state/notes-store.js');
+  });
+
+  test('saveNote encrypts secrets at rest and returns plaintext to callers', async () => {
+    notesStore.handleAccountChange('GA111');
+    notesStore.setAuthenticatedKeys({
+      encryptionKeypair: {
+        publicKey: new Uint8Array([1, 2]),
+        privateKey: new Uint8Array([3, 4]),
+      },
+      notePrivateKey: new Uint8Array([5, 6]),
+      notePublicKey: new Uint8Array([7, 8]),
+    });
+
+    const saved = await notesStore.saveNote({
+      commitment: '0x0001',
+      privateKey: '0x0011',
+      blinding: '0x0022',
+      amount: 5,
+      leafIndex: 9,
+      ledger: 12,
+    });
+
+    expect(saved.privateKey).toBe('0x0011');
+    expect(saved.blinding).toBe('0x0022');
+
+    const raw = userNotes.get('0x0001');
+    expect(raw.privateKey).toBe('enc(storage:3,4)::0x0011');
+    expect(raw.blinding).toBe('enc(storage:3,4)::0x0022');
+    expect(raw.encrypted).toBe(true);
+  });
+
+  test('getNotes redacts encrypted secrets when the active account has no cached keys', async () => {
+    notesStore.handleAccountChange('GA111');
+    notesStore.setAuthenticatedKeys({
+      encryptionKeypair: {
+        publicKey: new Uint8Array([1, 2]),
+        privateKey: new Uint8Array([3, 4]),
+      },
+      notePrivateKey: new Uint8Array([5, 6]),
+      notePublicKey: new Uint8Array([7, 8]),
+    });
+
+    await notesStore.saveNote({
+      commitment: '0x0002',
+      privateKey: '0x00aa',
+      blinding: '0x00bb',
+      amount: 7,
+      leafIndex: 11,
+      ledger: 13,
+    });
+
+    notesStore.clearKeypairCaches();
+
+    const notes = await notesStore.getNotes();
+
+    expect(notes).toHaveLength(1);
+    expect(notes[0].privateKey).toBeNull();
+    expect(notes[0].blinding).toBeNull();
+    expect(notes[0].amount).toBe('7');
+  });
+
+  test('exportNotes rejects when encrypted notes exist but no storage key is available', async () => {
+    notesStore.handleAccountChange('GA111');
+    notesStore.setAuthenticatedKeys({
+      encryptionKeypair: {
+        publicKey: new Uint8Array([1, 2]),
+        privateKey: new Uint8Array([3, 4]),
+      },
+      notePrivateKey: new Uint8Array([5, 6]),
+      notePublicKey: new Uint8Array([7, 8]),
+    });
+
+    await notesStore.saveNote({
+      commitment: '0x0003',
+      privateKey: '0x00cc',
+      blinding: '0x00dd',
+      amount: 9,
+      leafIndex: 14,
+      ledger: 15,
+    });
+
+    notesStore.clearKeypairCaches();
+
+    await expect(notesStore.exportNotes()).rejects.toThrow('Cannot export');
+  });
+
+  test('importNotes rejects when the active account has no storage key', async () => {
+    notesStore.handleAccountChange('GA111');
+
+    const file = {
+      text: async () => JSON.stringify({
+        version: 1,
+        notes: [{
+          id: '0x0010',
+          owner: 'GA111',
+          privateKey: '0x0011',
+          blinding: '0x0012',
+          amount: '3',
+          leafIndex: 2,
+          createdAt: '2026-03-07T00:00:00.000Z',
+          createdAtLedger: 22,
+          spent: false,
+          isReceived: false,
+        }],
+      }),
+    };
+
+    await expect(notesStore.importNotes(file)).rejects.toThrow('Cannot import notes');
+  });
+
+  test('preserves cached keys per account across A to B to A switches', async () => {
+    const accountAKeys = {
+      encryptionKeypair: {
+        publicKey: new Uint8Array([11, 12]),
+        privateKey: new Uint8Array([13, 14]),
+      },
+      notePrivateKey: new Uint8Array([15, 16]),
+      notePublicKey: new Uint8Array([17, 18]),
+    };
+    const accountBKeys = {
+      encryptionKeypair: {
+        publicKey: new Uint8Array([21, 22]),
+        privateKey: new Uint8Array([23, 24]),
+      },
+      notePrivateKey: new Uint8Array([25, 26]),
+      notePublicKey: new Uint8Array([27, 28]),
+    };
+
+    notesStore.handleAccountChange('GA111');
+    notesStore.setAuthenticatedKeys(accountAKeys);
+
+    notesStore.handleAccountChange('GB222');
+    notesStore.setAuthenticatedKeys(accountBKeys);
+
+    signWalletMessage.mockClear();
+
+    notesStore.handleAccountChange('GA111');
+
+    expect(notesStore.hasAuthenticatedKeys()).toBe(true);
+    await expect(notesStore.getUserEncryptionKeypair()).resolves.toEqual(accountAKeys.encryptionKeypair);
+    await expect(notesStore.getUserNoteKeypair()).resolves.toEqual({
+      privateKey: accountAKeys.notePrivateKey,
+      publicKey: accountAKeys.notePublicKey,
+    });
+    expect(signWalletMessage).not.toHaveBeenCalled();
+  });
+
+  test('clears all account caches on disconnect', async () => {
+    notesStore.handleAccountChange('GA111');
+    notesStore.setAuthenticatedKeys({
+      encryptionKeypair: {
+        publicKey: new Uint8Array([11, 12]),
+        privateKey: new Uint8Array([13, 14]),
+      },
+      notePrivateKey: new Uint8Array([15, 16]),
+      notePublicKey: new Uint8Array([17, 18]),
+    });
+
+    notesStore.handleAccountChange(null);
+    notesStore.handleAccountChange('GA111');
+
+    expect(notesStore.hasAuthenticatedKeys()).toBe(false);
+  });
+});

--- a/app/js/__tests__/ui.test.js
+++ b/app/js/__tests__/ui.test.js
@@ -9,6 +9,7 @@ jest.mock('../wallet.js', () => ({
   __esModule: true,
   connectWallet: jest.fn(),
   getWalletNetwork: jest.fn(),
+  signWalletMessage: jest.fn(),
 }));
 
 jest.mock('../stellar.js', () => ({
@@ -68,5 +69,96 @@ describe('ui module', () => {
       'DOMContentLoaded',
       expect.any(Function)
     );
+  });
+
+  test('deriveKeysFromWallet derives and caches keys on first use', async () => {
+    const { signWalletMessage } = await import('../wallet.js');
+    const notesStore = {
+      hasAuthenticatedKeys: jest.fn().mockReturnValue(false),
+      getUserEncryptionKeypair: jest.fn(),
+      getUserNoteKeypair: jest.fn(),
+      setAuthenticatedKeys: jest.fn(),
+    };
+
+    jest.doMock('../state/index.js', () => ({
+      __esModule: true,
+      notesStore,
+    }));
+
+    jest.doMock('../bridge.js', () => ({
+      __esModule: true,
+      deriveNotePrivateKeyFromSignature: jest.fn((signature) => (
+        new Uint8Array([signature[0], signature[1]])
+      )),
+      deriveEncryptionKeypairFromSignature: jest.fn((signature) => ({
+        publicKey: new Uint8Array([signature[0], signature[1]]),
+        privateKey: new Uint8Array([signature[2], signature[3]]),
+      })),
+      derivePublicKey: jest.fn((privateKey) => (
+        new Uint8Array(Array.from(privateKey, (value) => value + 9))
+      )),
+    }));
+
+    const base64FromBytes = (bytes) => Buffer.from(Uint8Array.from(bytes)).toString('base64');
+    signWalletMessage
+      .mockResolvedValueOnce({ signedMessage: base64FromBytes(new Array(64).fill(1)) })
+      .mockResolvedValueOnce({ signedMessage: base64FromBytes(new Array(64).fill(2)) });
+
+    const { deriveKeysFromWallet } = await import('../ui/core.js');
+    const result = await deriveKeysFromWallet({});
+
+    expect(signWalletMessage).toHaveBeenCalledTimes(2);
+    expect(notesStore.setAuthenticatedKeys).toHaveBeenCalledTimes(1);
+    expect(result.privKeyBytes).toEqual(new Uint8Array([1, 1]));
+    expect(result.pubKeyBytes).toEqual(new Uint8Array([10, 10]));
+    expect(result.encryptionKeypair).toEqual({
+      publicKey: new Uint8Array([2, 2]),
+      privateKey: new Uint8Array([2, 2]),
+    });
+  });
+
+  test('deriveKeysFromWallet reuses cached keys for repeated calls on the same account', async () => {
+    const { signWalletMessage } = await import('../wallet.js');
+    const notesStore = {
+      hasAuthenticatedKeys: jest.fn().mockReturnValue(true),
+      getUserEncryptionKeypair: jest.fn().mockResolvedValue({
+        publicKey: new Uint8Array([7, 8]),
+        privateKey: new Uint8Array([9, 10]),
+      }),
+      getUserNoteKeypair: jest.fn().mockResolvedValue({
+        privateKey: new Uint8Array([1, 2]),
+        publicKey: new Uint8Array([3, 4]),
+      }),
+      setAuthenticatedKeys: jest.fn(),
+    };
+
+    jest.doMock('../state/index.js', () => ({
+      __esModule: true,
+      notesStore,
+    }));
+
+    jest.doMock('../bridge.js', () => ({
+      __esModule: true,
+      deriveNotePrivateKeyFromSignature: jest.fn(),
+      deriveEncryptionKeypairFromSignature: jest.fn(),
+      derivePublicKey: jest.fn(),
+    }));
+
+    const { deriveKeysFromWallet } = await import('../ui/core.js');
+    const first = await deriveKeysFromWallet({});
+    const second = await deriveKeysFromWallet({});
+
+    expect(signWalletMessage).not.toHaveBeenCalled();
+    expect(notesStore.getUserEncryptionKeypair).toHaveBeenCalledTimes(2);
+    expect(notesStore.getUserNoteKeypair).toHaveBeenCalledTimes(2);
+    expect(first).toEqual(second);
+    expect(first).toEqual({
+      privKeyBytes: new Uint8Array([1, 2]),
+      pubKeyBytes: new Uint8Array([3, 4]),
+      encryptionKeypair: {
+        publicKey: new Uint8Array([7, 8]),
+        privateKey: new Uint8Array([9, 10]),
+      },
+    });
   });
 });

--- a/app/js/state/crypto.js
+++ b/app/js/state/crypto.js
@@ -1,0 +1,70 @@
+/**
+ * Web Crypto helpers for encrypting note secrets at rest in IndexedDB.
+ *
+ * An AES-256-GCM storage key is derived from the user's X25519 private key
+ * via HKDF-SHA-256 with a domain-specific info string. This makes the storage
+ * key cryptographically independent from the on-chain encryption key while
+ * requiring no additional Freighter prompts.
+ *
+ * Encrypted field format: "<ivHex>:<ciphertextHex>"
+ *   - IV:         12 random bytes (96-bit), hex-encoded with 0x prefix
+ *   - Ciphertext: AES-GCM output (plaintext + 16-byte auth tag), hex-encoded
+ *
+ * @module state/crypto
+ */
+
+import { hexToBytes, bytesToHex } from './utils.js';
+
+const STORAGE_KEY_INFO = new TextEncoder().encode('IndexedDB note encryption v1');
+const EMPTY_SALT = new Uint8Array(32);
+
+/**
+ * Derive a non-exportable AES-256-GCM key from X25519 private key bytes
+ * using HKDF-SHA-256. The info string domain-separates this key from the
+ * on-chain X25519 usage.
+ *
+ * @param {Uint8Array} privateKeyBytes - 32-byte X25519 private key
+ * @returns {Promise<CryptoKey>} AES-GCM key usable only for encrypt/decrypt
+ */
+export async function deriveStorageKey(privateKeyBytes) {
+    const keyMaterial = await crypto.subtle.importKey(
+        'raw', privateKeyBytes, 'HKDF', false, ['deriveKey']
+    );
+    return crypto.subtle.deriveKey(
+        { name: 'HKDF', hash: 'SHA-256', salt: EMPTY_SALT, info: STORAGE_KEY_INFO },
+        keyMaterial,
+        { name: 'AES-GCM', length: 256 },
+        false,
+        ['encrypt', 'decrypt']
+    );
+}
+
+/**
+ * Encrypt a hex-encoded field value with AES-256-GCM.
+ * A fresh 12-byte random IV is generated per call.
+ *
+ * @param {string} hexValue - Hex string to encrypt (with or without 0x prefix)
+ * @param {CryptoKey} aesKey - AES-256-GCM key from deriveStorageKey()
+ * @returns {Promise<string>} Encrypted string in "<ivHex>:<ciphertextHex>" format
+ */
+export async function encryptField(hexValue, aesKey) {
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const plaintext = hexToBytes(hexValue);
+    const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, aesKey, plaintext);
+    return bytesToHex(iv) + ':' + bytesToHex(new Uint8Array(ciphertext));
+}
+
+/**
+ * Decrypt an AES-256-GCM encrypted field back to a hex string.
+ *
+ * @param {string} encryptedValue - "<ivHex>:<ciphertextHex>" from encryptField()
+ * @param {CryptoKey} aesKey - AES-256-GCM key from deriveStorageKey()
+ * @returns {Promise<string>} Original hex string (with 0x prefix)
+ */
+export async function decryptField(encryptedValue, aesKey) {
+    const sep = encryptedValue.indexOf(':');
+    const iv = hexToBytes(encryptedValue.slice(0, sep));
+    const ct = hexToBytes(encryptedValue.slice(sep + 1));
+    const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, aesKey, ct);
+    return bytesToHex(new Uint8Array(plaintext));
+}

--- a/app/js/state/notes-store.js
+++ b/app/js/state/notes-store.js
@@ -20,11 +20,12 @@
 import * as db from './db.js';
 import { toHex, normalizeHex, bytesToHex, hexToBytes } from './utils.js';
 import { signWalletMessage } from '../wallet.js';
-import { 
-    deriveEncryptionKeypairFromSignature, 
+import {
+    deriveEncryptionKeypairFromSignature,
     deriveNotePrivateKeyFromSignature,
     derivePublicKey,
 } from '../bridge.js';
+import { deriveStorageKey, encryptField, decryptField } from './crypto.js';
 
 /**
  * @typedef {Object} UserNote
@@ -85,11 +86,23 @@ export async function saveNote(params) {
         console.warn('[NotesStore] Saving note without owner - will not be filtered by account');
     }
     
+    const storageKey = await getStorageKey();
+    if (!storageKey) {
+        throw new Error(
+            '[NotesStore] Cannot save note: encryption key not yet derived. ' +
+            'Call initializeKeypairs() or perform a transaction to derive keys first.'
+        );
+    }
+
+    const privateKeyHex = toHex(params.privateKey);
+    const blindingHex   = toHex(params.blinding);
+
     const note = {
         id: normalizeHex(params.commitment).toLowerCase(),
         owner: owner || '',
-        privateKey: toHex(params.privateKey),
-        blinding: toHex(params.blinding),
+        privateKey: await encryptField(privateKeyHex, storageKey),
+        blinding:   await encryptField(blindingHex,   storageKey),
+        encrypted:  true,
         amount: String(params.amount),
         leafIndex: params.leafIndex,
         createdAt: new Date().toISOString(),
@@ -97,11 +110,11 @@ export async function saveNote(params) {
         spent: false,
         isReceived: params.isReceived || false,
     };
-    
+
     await db.put('user_notes', note);
     const noteType = note.isReceived ? 'received' : 'created';
     console.log(`[NotesStore] Saved ${noteType} note ${note.id.slice(0, 10)}... at index ${note.leafIndex} for ${owner ? owner.slice(0, 8) + '...' : 'unknown'}`);
-    return note;
+    return await decryptNote(note, storageKey);
 }
 
 /**
@@ -113,15 +126,18 @@ export async function saveNote(params) {
 export async function markNoteSpent(commitment, ledger) {
     const id = normalizeHex(commitment).toLowerCase();
     const note = await db.get('user_notes', id);
-    
+
     if (!note) {
         return false;
     }
-    
+
+    // Update spent fields on the raw (potentially encrypted) record directly —
+    // the secret fields (privateKey, blinding) are not touched, so encryption
+    // state is preserved without needing to decrypt and re-encrypt.
     note.spent = true;
     note.spentAtLedger = ledger;
     await db.put('user_notes', note);
-    
+
     console.log(`[NotesStore] Marked note ${id.slice(0, 10)}... as spent`);
     return true;
 }
@@ -137,7 +153,7 @@ export async function markNoteSpent(commitment, ledger) {
 export async function getNotes(options = {}) {
     let notes;
     const owner = options.owner ?? currentOwner;
-    
+
     if (options.allOwners) {
         notes = await db.getAll('user_notes');
     } else if (owner) {
@@ -147,12 +163,13 @@ export async function getNotes(options = {}) {
         console.warn('[NotesStore] getNotes called without owner, returning empty');
         return [];
     }
-    
+
     if (options.unspentOnly) {
-        return notes.filter(n => !n.spent);
+        notes = notes.filter(n => !n.spent);
     }
-    
-    return notes;
+
+    const storageKey = await getStorageKey();
+    return Promise.all(notes.map(n => decryptNoteWithMigration(n, storageKey)));
 }
 
 /**
@@ -162,7 +179,10 @@ export async function getNotes(options = {}) {
  */
 export async function getNoteByCommitment(commitment) {
     const id = normalizeHex(commitment).toLowerCase();
-    return await db.get('user_notes', id) || null;
+    const note = await db.get('user_notes', id) || null;
+    if (!note) return null;
+    const storageKey = await getStorageKey();
+    return decryptNoteWithMigration(note, storageKey);
 }
 
 /**
@@ -171,6 +191,19 @@ export async function getNoteByCommitment(commitment) {
  */
 export async function getUnspentNotes() {
     return getNotes({ unspentOnly: true });
+}
+
+/**
+ * Returns true if the current owner has any notes stored without encryption.
+ * Used at wallet connect to detect whether a one-time migration is needed.
+ * @returns {Promise<boolean>}
+ */
+export async function hasUnencryptedNotes() {
+    const owner = currentOwner;
+    const notes = owner
+        ? await db.getAllByIndex('user_notes', 'by_owner', owner)
+        : await db.getAll('user_notes');
+    return notes.some(n => !n.encrypted);
 }
 
 /**
@@ -187,13 +220,25 @@ export async function getBalance() {
  * @returns {Promise<Blob>}
  */
 export async function exportNotes() {
-    const notes = await db.getAll('user_notes');
+    const storageKey = await getStorageKey();
+    const rawNotes = await db.getAll('user_notes');
+
+    const hasEncryptedNotes = rawNotes.some(n => n.encrypted);
+    if (hasEncryptedNotes && !storageKey) {
+        throw new Error(
+            'Cannot export: encryption key not yet derived. ' +
+            'Please perform a transaction first to derive your keys, then export.'
+        );
+    }
+
+    // Decrypt before export so the file is portable (not tied to this user's derived key)
+    const notes = await Promise.all(rawNotes.map(n => decryptNote(n, storageKey)));
     const data = JSON.stringify({
         version: 1,
         exportedAt: new Date().toISOString(),
         notes,
     }, null, 2);
-    
+
     return new Blob([data], { type: 'application/json' });
 }
 
@@ -211,13 +256,29 @@ export async function importNotes(file) {
     }
     
     // Import notes: add new ones, update spent status if import shows spent
+    const storageKey = await getStorageKey();
+    if (!storageKey) {
+        throw new Error(
+            '[NotesStore] Cannot import notes: encryption key not yet derived. ' +
+            'Call initializeKeypairs() or perform a transaction to derive keys first.'
+        );
+    }
+
     let imported = 0;
     for (const note of json.notes) {
         const existing = await db.get('user_notes', note.id);
         if (!existing) {
-            await db.put('user_notes', note);
+            // Encrypt secret fields before storing. Exports are decrypted plaintext
+            // (see exportNotes), so imported notes always arrive unencrypted.
+            await db.put('user_notes', {
+                ...note,
+                privateKey: await encryptField(note.privateKey, storageKey),
+                blinding:   await encryptField(note.blinding,   storageKey),
+                encrypted:  true,
+            });
             imported++;
         } else if (!existing.spent && note.spent) {
+            // Update metadata only; preserve the existing note's encryption state.
             existing.spent = true;
             existing.spentAtLedger = note.spentAtLedger;
             await db.put('user_notes', existing);
@@ -256,9 +317,99 @@ const ENCRYPTION_MESSAGE = "Sign to access Privacy Pool [v1]";
 // Message signed to derive the BN254 note identity keypair
 const SPENDING_KEY_MESSAGE = "Privacy Pool Spending Key [v1]";
 
-// In-memory key caches to avoid repeated Freighter usage
-let cachedEncryptionKeypair = null;
-let cachedNoteKeypair = null;
+// In-memory key caches to avoid repeated Freighter usage.
+// Keys stay in memory only, but are scoped per account so A -> B -> A switches
+// can reuse previously-derived keys without re-prompting.
+const DEFAULT_CACHE_KEY = '__default__';
+const accountKeyCache = new Map();
+
+function getAccountCacheKey(owner = currentOwner) {
+    return owner || DEFAULT_CACHE_KEY;
+}
+
+function getAccountCache(owner = currentOwner) {
+    return accountKeyCache.get(getAccountCacheKey(owner)) || null;
+}
+
+function ensureAccountCache(owner = currentOwner) {
+    const cacheKey = getAccountCacheKey(owner);
+    let cache = accountKeyCache.get(cacheKey);
+    if (!cache) {
+        cache = {
+            encryptionKeypair: null,
+            noteKeypair: null,
+            storageKey: null,
+        };
+        accountKeyCache.set(cacheKey, cache);
+    }
+    return cache;
+}
+
+/**
+ * Get (or lazily derive) the AES-256-GCM key used to encrypt note secrets at rest.
+ * Derived from the X25519 private key via HKDF — no extra Freighter prompt needed.
+ * Returns null if the encryption keypair is not yet available.
+ * @returns {Promise<CryptoKey|null>}
+ */
+async function getStorageKey() {
+    const cache = getAccountCache();
+    if (cache?.storageKey) return cache.storageKey;
+    // Only derive from the already-cached keypair. Do NOT call getUserEncryptionKeypair()
+    // here — that would trigger a Freighter signature prompt in unexpected places (e.g.
+    // wallet connect, note table refresh). The storage key becomes available after the
+    // first explicit key-derivation call (transaction flow or initializeKeypairs()).
+    if (!cache?.encryptionKeypair) return null;
+    cache.storageKey = await deriveStorageKey(cache.encryptionKeypair.privateKey);
+    return cache.storageKey;
+}
+
+/**
+ * Decrypt a note's encrypted fields back to plaintext hex.
+ * If the note is not marked as encrypted (legacy row), it is returned unchanged.
+ * If the storage key is unavailable, the note is returned as-is (degraded).
+ * @param {Object} note - Raw note from IndexedDB
+ * @param {CryptoKey|null} storageKey
+ * @returns {Promise<Object>} Note with plaintext privateKey and blinding
+ */
+async function decryptNote(note, storageKey) {
+    if (!note || !note.encrypted) return note;
+    if (!storageKey) {
+        // Return the note without the secret fields so callers never accidentally
+        // receive raw ciphertext as if it were plaintext. The note remains usable
+        // for display (amount, id, spent, leafIndex are all unencrypted) but cannot
+        // be used for proof generation until keys are derived.
+        const { privateKey, blinding, ...rest } = note;
+        return { ...rest, privateKey: null, blinding: null };
+    }
+    return {
+        ...note,
+        privateKey: await decryptField(note.privateKey, storageKey),
+        blinding:   await decryptField(note.blinding,   storageKey),
+        encrypted:  false,
+    };
+}
+
+/**
+ * Decrypt a note, migrating plaintext legacy rows to encrypted storage on first access.
+ * @param {Object} note - Raw note from IndexedDB
+ * @param {CryptoKey|null} storageKey
+ * @returns {Promise<Object>} Note with plaintext privateKey and blinding
+ */
+async function decryptNoteWithMigration(note, storageKey) {
+    if (!note) return note;
+    if (!note.encrypted && storageKey) {
+        // Legacy plaintext row — encrypt in place so it's protected going forward
+        const migrated = {
+            ...note,
+            privateKey: await encryptField(note.privateKey, storageKey),
+            blinding:   await encryptField(note.blinding,   storageKey),
+            encrypted:  true,
+        };
+        await db.put('user_notes', migrated);
+        return note; // return original plaintext to caller
+    }
+    return decryptNote(note, storageKey);
+}
 
 
 /**
@@ -270,8 +421,9 @@ let cachedNoteKeypair = null;
  * @returns {Promise<{publicKey: Uint8Array, privateKey: Uint8Array}|null>}
  */
 export async function getUserEncryptionKeypair() {
-    if (cachedEncryptionKeypair) {
-        return cachedEncryptionKeypair;
+    const cached = getAccountCache();
+    if (cached?.encryptionKeypair) {
+        return cached.encryptionKeypair;
     }
     
     const signature = await requestSignature(ENCRYPTION_MESSAGE, 'encryption');
@@ -280,7 +432,9 @@ export async function getUserEncryptionKeypair() {
     }
     
     const keypair = deriveEncryptionKeypairFromSignature(signature);
-    cachedEncryptionKeypair = keypair;
+    const cache = ensureAccountCache();
+    cache.encryptionKeypair = keypair;
+    cache.storageKey = null;
     
     console.log('[NotesStore] Derived encryption keypair');
     return keypair;
@@ -310,8 +464,9 @@ export async function getEncryptionPublicKeyHex() {
  * @returns {Promise<{publicKey: Uint8Array, privateKey: Uint8Array}|null>}
  */
 export async function getUserNoteKeypair() {
-    if (cachedNoteKeypair) {
-        return cachedNoteKeypair;
+    const cached = getAccountCache();
+    if (cached?.noteKeypair) {
+        return cached.noteKeypair;
     }
     
     const signature = await requestSignature(SPENDING_KEY_MESSAGE, 'spending');
@@ -325,10 +480,11 @@ export async function getUserNoteKeypair() {
     // Derive public key via Poseidon2
     const publicKey = derivePublicKey(privateKey);
     
-    cachedNoteKeypair = { publicKey, privateKey };
+    const keypair = { publicKey, privateKey };
+    ensureAccountCache().noteKeypair = keypair;
     
     console.log('[NotesStore] Derived note identity keypair');
-    return cachedNoteKeypair;
+    return keypair;
 }
 
 /**
@@ -359,22 +515,24 @@ export async function getNotePrivateKey() {
 
 // Cache management
 /**
- * Clear all cached keypairs (call on logout, wallet disconnect, or account change).
+ * Clear all cached keypairs for all accounts in this session.
+ * Call on logout or wallet disconnect.
  */
 export function clearKeypairCaches() {
-    cachedEncryptionKeypair = null;
-    cachedNoteKeypair = null;
+    accountKeyCache.clear();
     console.log('[NotesStore] Cleared keypair caches');
 }
 
 /**
- * Handle account change - clears caches and updates owner.
+ * Handle account change.
+ * - Switching between non-null accounts preserves per-account session caches.
+ * - Disconnecting (null owner) clears all cached keys.
  * @param {string|null} newAddress - New Stellar address or null if disconnecting
  * @returns {boolean} True if the account actually changed
  */
 export function handleAccountChange(newAddress) {
     const changed = setCurrentOwner(newAddress);
-    if (changed) {
+    if (changed && !newAddress) {
         clearKeypairCaches();
     }
     return changed;
@@ -385,7 +543,8 @@ export function handleAccountChange(newAddress) {
  * @returns {boolean}
  */
 export function hasAuthenticatedKeys() {
-    return cachedEncryptionKeypair !== null && cachedNoteKeypair !== null;
+    const cache = getAccountCache();
+    return !!(cache?.encryptionKeypair && cache?.noteKeypair);
 }
 
 /**
@@ -397,13 +556,16 @@ export function hasAuthenticatedKeys() {
  * @param {Object} keys.encryptionKeypair - X25519 keypair { publicKey, secretKey }
  * @param {Uint8Array} keys.notePrivateKey - BN254 private key
  * @param {Uint8Array} keys.notePublicKey - BN254 public key
+ * @param {string} [keys.owner] - Owner to cache for (defaults to currentOwner)
  */
-export function setAuthenticatedKeys({ encryptionKeypair, notePrivateKey, notePublicKey }) {
+export function setAuthenticatedKeys({ encryptionKeypair, notePrivateKey, notePublicKey, owner }) {
+    const cache = ensureAccountCache(owner);
     if (encryptionKeypair) {
-        cachedEncryptionKeypair = encryptionKeypair;
+        cache.encryptionKeypair = encryptionKeypair;
+        cache.storageKey = null;
     }
     if (notePrivateKey && notePublicKey) {
-        cachedNoteKeypair = { privateKey: notePrivateKey, publicKey: notePublicKey };
+        cache.noteKeypair = { privateKey: notePrivateKey, publicKey: notePublicKey };
     }
     console.log('[NotesStore] Keys cached from external derivation');
 }

--- a/app/js/ui/core.js
+++ b/app/js/ui/core.js
@@ -38,8 +38,22 @@ export const App = {
  * @throws {Error} If user rejects signature requests
  */
 export async function deriveKeysFromWallet({ onStatus, signOptions = {}, signDelay = 300 }) {
+    // Keys are derived from deterministic Freighter signatures and cached in memory for
+    // the lifetime of the session. Reuse the active account's cache when available so
+    // the user is only prompted once per account per session (until disconnect/reload).
+    if (notesStore.hasAuthenticatedKeys()) {
+        const encryptionKeypair = await notesStore.getUserEncryptionKeypair();
+        const noteKeypair = await notesStore.getUserNoteKeypair();
+        console.log('[KeyDerivation] Reusing cached keys — no signature required');
+        return {
+            privKeyBytes: noteKeypair.privateKey,
+            pubKeyBytes: noteKeypair.publicKey,
+            encryptionKeypair,
+        };
+    }
+
     onStatus?.('Sign message to derive keys (1/2)...');
-    
+
     let spendingResult;
     try {
         spendingResult = await signWalletMessage('Privacy Pool Spending Key [v1]', signOptions);
@@ -49,17 +63,17 @@ export async function deriveKeysFromWallet({ onStatus, signOptions = {}, signDel
         }
         throw e;
     }
-    
+
     if (!spendingResult?.signedMessage) {
         throw new Error('Spending key signature rejected');
     }
-    
+
     if (signDelay > 0) {
         await new Promise(r => setTimeout(r, signDelay));
     }
-    
+
     onStatus?.('Sign message to derive keys (2/2)...');
-    
+
     let encryptionResult;
     try {
         encryptionResult = await signWalletMessage('Sign to access Privacy Pool [v1]', signOptions);
@@ -69,27 +83,27 @@ export async function deriveKeysFromWallet({ onStatus, signOptions = {}, signDel
         }
         throw e;
     }
-    
+
     if (!encryptionResult?.signedMessage) {
         throw new Error('Encryption key signature rejected');
     }
-    
+
     const spendingSigBytes = Uint8Array.from(atob(spendingResult.signedMessage), c => c.charCodeAt(0));
     const encryptionSigBytes = Uint8Array.from(atob(encryptionResult.signedMessage), c => c.charCodeAt(0));
-    
+
     const privKeyBytes = deriveNotePrivateKeyFromSignature(spendingSigBytes);
     const pubKeyBytes = derivePublicKey(privKeyBytes);
     const encryptionKeypair = deriveEncryptionKeypairFromSignature(encryptionSigBytes);
-    
-    // Cache keys for note scanning (so sync can scan without prompting again)
+
+    // Populate cache so subsequent calls this session skip signing entirely.
     notesStore.setAuthenticatedKeys({
         encryptionKeypair,
         notePrivateKey: privKeyBytes,
         notePublicKey: pubKeyBytes,
     });
-    
+
     console.log('[KeyDerivation] Derived keys from wallet signatures');
-    
+
     return { privKeyBytes, pubKeyBytes, encryptionKeypair };
 }
 

--- a/app/js/ui/navigation.js
+++ b/app/js/ui/navigation.js
@@ -180,7 +180,7 @@ export const Wallet = {
                 // Update state
                 App.state.wallet.address = currentAddress;
                 
-                // Update notes store owner and clear keypairs
+                // Switch the active notes-store owner. Other accounts' session caches stay in memory.
                 notesStore.handleAccountChange(currentAddress);
                 
                 // Update UI
@@ -299,11 +299,23 @@ export const Wallet = {
         }
 
         Toast.show('Wallet connected!', 'success');
-        
+
         // Enable submit buttons
         updateSubmitButtons(true);
-        
-        // Load notes for this account
+
+        // One-time migration: if this account has pre-encryption notes in IndexedDB,
+        // derive keys now so the subsequent reload can re-encrypt them in place.
+        // This only prompts Freighter for accounts that still have plaintext notes.
+        try {
+            if (await notesStore.hasUnencryptedNotes()) {
+                Toast.show('Encrypting existing notes — please approve the signature requests.', 'info');
+                await notesStore.initializeKeypairs();
+            }
+        } catch (e) {
+            console.warn('[Wallet] Migration key derivation failed or was cancelled:', e.message);
+        }
+
+        // Load notes for this account (also triggers lazy migration for any remaining plaintext rows)
         await NotesTable.reload();
         
         // Notify registered callbacks (Withdraw, Transact prefill recipient)

--- a/app/js/ui/templates.js
+++ b/app/js/ui/templates.js
@@ -221,38 +221,48 @@ export const Templates = {
                     console.log('[Templates] Existing note lookup:', existingNote ? 'found' : 'not found');
                     
                     if (!existingNote && data.amount !== undefined) {
-                        // Save note to IndexedDB so it can be used in transactions.
-                        // Notes from other users won't have a valid privateKey for this wallet,
-                        // so proof generation will fail - but at least the UI flow works.
-                        // Use App.state.wallet.address as owner (more reliable than notesStore.getCurrentOwner)
-                        const currentOwner = App.state.wallet.address || notesStore.getCurrentOwner();
-                        console.log('[Templates] Saving note with owner:', currentOwner?.slice(0, 10));
-                        
-                        // Preserve isReceived from file if present, otherwise default to true
-                        // (most file imports are from receiving notes from others)
-                        const isReceivedFromFile = data.isReceived !== undefined ? data.isReceived : true;
-                        
-                        const savedNote = await notesStore.saveNote({
-                            commitment: noteId,
-                            privateKey: data.privateKey || new Uint8Array(32), // May be missing/invalid
-                            blinding: data.blinding || '0x' + '0'.repeat(64),
-                            amount: Number(data.amount),
-                            leafIndex: data.leafIndex ?? 0,
-                            ledger: 0,
-                            isReceived: isReceivedFromFile,
-                            owner: currentOwner,
-                        });
-                        
-                        console.log('[Templates] Note saved with ID:', savedNote.id);
-                        
-                        // Update input with the normalized ID (lowercase, with 0x prefix)
-                        noteInput.value = savedNote.id;
-                        
-                        // Reload notes to update App.state.notes
-                        await Storage.load();
-                        console.log('[Templates] App.state.notes reloaded, count:', App.state.notes.length);
-                        
-                        Toast.show('Note imported from file', 'success');
+                        if (!notesStore.hasAuthenticatedKeys()) {
+                            // Encryption keys are not yet derived (user hasn't signed a transaction
+                            // this session). The note ID is already in the input — surface a clear
+                            // error so the user knows what to do next.
+                            Toast.show(
+                                'Keys not yet derived — complete a transaction first, then re-import this note file.',
+                                'error'
+                            );
+                        } else {
+                            // Save note to IndexedDB so it can be used in transactions.
+                            // Notes from other users won't have a valid privateKey for this wallet,
+                            // so proof generation will fail - but at least the UI flow works.
+                            // Use App.state.wallet.address as owner (more reliable than notesStore.getCurrentOwner)
+                            const currentOwner = App.state.wallet.address || notesStore.getCurrentOwner();
+                            console.log('[Templates] Saving note with owner:', currentOwner?.slice(0, 10));
+
+                            // Preserve isReceived from file if present, otherwise default to true
+                            // (most file imports are from receiving notes from others)
+                            const isReceivedFromFile = data.isReceived !== undefined ? data.isReceived : true;
+
+                            const savedNote = await notesStore.saveNote({
+                                commitment: noteId,
+                                privateKey: data.privateKey || new Uint8Array(32), // May be missing/invalid
+                                blinding: data.blinding || '0x' + '0'.repeat(64),
+                                amount: Number(data.amount),
+                                leafIndex: data.leafIndex ?? 0,
+                                ledger: 0,
+                                isReceived: isReceivedFromFile,
+                                owner: currentOwner,
+                            });
+
+                            console.log('[Templates] Note saved with ID:', savedNote.id);
+
+                            // Update input with the normalized ID (lowercase, with 0x prefix)
+                            noteInput.value = savedNote.id;
+
+                            // Reload notes to update App.state.notes
+                            await Storage.load();
+                            console.log('[Templates] App.state.notes reloaded, count:', App.state.notes.length);
+
+                            Toast.show('Note imported from file', 'success');
+                        }
                     } else if (existingNote) {
                         // Use the stored ID format for consistency
                         noteInput.value = existingNote.id;

--- a/app/js/ui/transactions/transact.js
+++ b/app/js/ui/transactions/transact.js
@@ -209,11 +209,12 @@ export const Transact = {
                 if (!noteId) continue;
                 
                 const normalizedId = noteId.toLowerCase();
-                let note = App.state.notes.find(n => (n.id === normalizedId || n.id === noteId) && !n.spent);
-                
-                // If not found in memory, try fetching directly from database
+                let note = App.state.notes.find(n => (n.id === normalizedId || n.id === noteId) && !n.spent && n.blinding != null);
+
+                // If not found in memory, or secret fields are null (App.state loaded before
+                // keys were derived), fetch a freshly-decrypted copy from the database.
                 if (!note) {
-                    console.warn('[Transact] Note not in App.state, trying database lookup:', noteId.slice(0, 20));
+                    console.warn('[Transact] Note not in App.state (or not yet decrypted), trying database lookup:', noteId.slice(0, 20));
                     const dbNote = await notesStore.getNoteByCommitment(noteId);
                     if (dbNote && !dbNote.spent) {
                         note = dbNote;

--- a/app/js/ui/transactions/transfer.js
+++ b/app/js/ui/transactions/transfer.js
@@ -221,11 +221,12 @@ export const Transfer = {
                 const noteId = input.value.trim().toLowerCase();
                 if (!noteId) continue;
                 
-                let note = App.state.notes.find(n => n.id === noteId && !n.spent);
-                
-                // If not found in memory, try fetching directly from database
+                let note = App.state.notes.find(n => n.id === noteId && !n.spent && n.blinding != null);
+
+                // If not found in memory, or secret fields are null (App.state loaded before
+                // keys were derived), fetch a freshly-decrypted copy from the database.
                 if (!note) {
-                    console.warn('[Transfer] Note not in App.state, trying database lookup:', noteId.slice(0, 20));
+                    console.warn('[Transfer] Note not in App.state (or not yet decrypted), trying database lookup:', noteId.slice(0, 20));
                     const dbNote = await notesStore.getNoteByCommitment(noteId);
                     if (dbNote && !dbNote.spent) {
                         note = dbNote;

--- a/app/js/ui/transactions/withdraw.js
+++ b/app/js/ui/transactions/withdraw.js
@@ -140,11 +140,12 @@ export const Withdraw = {
                 
                 // Normalize ID for comparison (storage uses lowercase)
                 const normalizedId = noteId.toLowerCase();
-                let note = App.state.notes.find(n => n.id === normalizedId || n.id === noteId);
-                
-                // If not found in memory, try fetching directly from database
+                let note = App.state.notes.find(n => (n.id === normalizedId || n.id === noteId) && n.blinding != null);
+
+                // If not found in memory, or secret fields are null (App.state loaded before
+                // keys were derived), fetch a freshly-decrypted copy from the database.
                 if (!note) {
-                    console.warn('[Withdraw] Note not in App.state, trying database lookup:', noteId.slice(0, 20));
+                    console.warn('[Withdraw] Note not in App.state (or not yet decrypted), trying database lookup:', noteId.slice(0, 20));
                     const dbNote = await notesStore.getNoteByCommitment(noteId);
                     if (dbNote && !dbNote.spent) {
                         note = dbNote;
@@ -241,7 +242,7 @@ export const Withdraw = {
                         const noteId = input.value.trim();
                         if (!noteId) continue;
                         const normalizedId = noteId.toLowerCase();
-                        let note = App.state.notes.find(n => n.id === normalizedId || n.id === noteId);
+                        let note = App.state.notes.find(n => (n.id === normalizedId || n.id === noteId) && n.blinding != null);
                         if (!note) {
                             const dbNote = await notesStore.getNoteByCommitment(noteId);
                             if (dbNote && !dbNote.spent) note = dbNote;


### PR DESCRIPTION
Addresses #71.

## Summary

- encrypt note `privateKey` and `blinding` before storing them in IndexedDB using AES-256-GCM via the Web Crypto API; no new npm dependencies
- make `saveNote()` and `importNotes()` fail closed instead of falling back to plaintext when encryption keys are not yet derived
- migrate existing plaintext notes to encrypted storage on wallet connect when keys are available, or lazily on first note read
- keep note exports decrypted so backup files remain portable
- cache derived keys in session memory per account so a single account can make multiple spends in one session without signing again for each transaction, and switching `A -> B -> A` reuses `A`'s cached keys
- clear all cached keys on disconnect
- add regression tests for encrypted note storage, migration-adjacent flows, and session key reuse

## Trade-offs

- Derived keys are cached only in memory, bucketed per account, to avoid repeated prompts for both multiple transactions from one account and `A -> B -> A` account switching.
- Keys are not persisted to IndexedDB, `localStorage`, or `sessionStorage`, so refresh and disconnect still require signing again.
- The accepted risk is that a tab-memory compromise exposes derived keys for all accounts that signed in during the session, not just the active one, until disconnect or reload. Note secrets remain encrypted at rest regardless.


## Test Plan

- `cd app && npm test -- --runInBand js/__tests__/notes-store.test.js`
- `cd app && npm test -- --runInBand js/__tests__/ui.test.js`
- `cd app && npm test -- --runInBand`
