### PR TITLE
chore/enable workspace lints for crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,8 +73,8 @@ witness = { path = "app/crates/core/witness" }
 zkhash = { path = "poseidon2" }
 
 [workspace.lints.rust]
-missing_docs = "deny"
-unsafe_code = "forbid"
+missing_docs = "allow"
+unsafe_code = "deny"
 
 [workspace.lints.clippy]
 arithmetic_side_effects = "deny"

--- a/contracts/asp-membership/Cargo.toml
+++ b/contracts/asp-membership/Cargo.toml
@@ -18,3 +18,6 @@ soroban-utils = { workspace = true }
 num-bigint = { workspace = true }
 soroban-sdk = { workspace = true, features = ["testutils"] }
 zkhash = { workspace = true }
+
+[lints]
+workspace = true

--- a/contracts/asp-membership/src/lib.rs
+++ b/contracts/asp-membership/src/lib.rs
@@ -43,6 +43,8 @@ pub enum Error {
     WrongLevels = 3,
     /// The contract has not been yet initialized
     NotInitialized = 4,
+    /// Arithmetic overflow occurred
+    Overflow = 5,
 }
 
 /// Event emitted when a new leaf is added to the Merkle tree
@@ -242,7 +244,10 @@ impl ASPMembership {
         .publish(&env);
 
         // Update NextIndex
-        store.set(&DataKey::NextIndex, &(actual_index.wrapping_add(1)));
+        store.set(
+            &DataKey::NextIndex,
+            &(actual_index.checked_add(1).ok_or(Error::Overflow)?),
+        );
         Ok(())
     }
 }

--- a/contracts/asp-membership/src/lib.rs
+++ b/contracts/asp-membership/src/lib.rs
@@ -94,14 +94,14 @@ impl ASPMembership {
 
         // Initialize an empty tree with zero hashes at each level
         let zeros: Vec<U256> = get_zeroes(&env);
-        for lvl in 0..levels + 1 {
-            let zero_val = zeros.get(lvl).unwrap();
+        for lvl in 0..=levels {
+            let zero_val = zeros.get(lvl).ok_or(Error::NotInitialized)?;
             store.set(&DataKey::FilledSubtrees(lvl), &zero_val);
             store.set(&DataKey::Zeroes(lvl), &zero_val);
         }
 
         // Set initial root to the zero hash at the top level
-        let root_val = zeros.get(levels).unwrap();
+        let root_val = zeros.get(levels).ok_or(Error::NotInitialized)?;
         store.set(&DataKey::Root, &root_val);
 
         Ok(())
@@ -194,16 +194,18 @@ impl ASPMembership {
         let store = env.storage().persistent();
         let admin_only: bool = store.get(&DataKey::AdminInsertOnly).unwrap_or(true);
         if admin_only {
-            let admin: Address = store.get(&DataKey::Admin).unwrap();
+            let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
             admin.require_auth();
         }
 
-        let levels: u32 = store.get(&DataKey::Levels).unwrap();
-        let actual_index: u64 = store.get(&DataKey::NextIndex).unwrap();
+        let levels: u32 = store.get(&DataKey::Levels).ok_or(Error::NotInitialized)?;
+        let actual_index: u64 = store
+            .get(&DataKey::NextIndex)
+            .ok_or(Error::NotInitialized)?;
         let mut current_index = actual_index;
 
         // Check if tree is full (capacity is 2^levels leaves)
-        if current_index >= (1 << levels) {
+        if current_index >= 1u64.checked_shl(levels).ok_or(Error::MerkleTreeFull)? {
             return Err(Error::MerkleTreeFull);
         }
         let mut current_hash = leaf.clone();
@@ -213,12 +215,16 @@ impl ASPMembership {
             let is_right = current_index & 1 == 1;
             if is_right {
                 // Leaf is right child, get the stored left sibling
-                let left: U256 = store.get(&DataKey::FilledSubtrees(lvl)).unwrap();
+                let left: U256 = store
+                    .get(&DataKey::FilledSubtrees(lvl))
+                    .ok_or(Error::NotInitialized)?;
                 current_hash = poseidon2_compress(&env, left, current_hash);
             } else {
                 // Leaf is left child, store it and pair with zero hash
                 store.set(&DataKey::FilledSubtrees(lvl), &current_hash);
-                let zero_val: U256 = store.get(&DataKey::Zeroes(lvl)).unwrap();
+                let zero_val: U256 = store
+                    .get(&DataKey::Zeroes(lvl))
+                    .ok_or(Error::NotInitialized)?;
                 current_hash = poseidon2_compress(&env, current_hash, zero_val);
             }
             current_index >>= 1;
@@ -236,7 +242,7 @@ impl ASPMembership {
         .publish(&env);
 
         // Update NextIndex
-        store.set(&DataKey::NextIndex, &(actual_index + 1));
+        store.set(&DataKey::NextIndex, &(actual_index.wrapping_add(1)));
         Ok(())
     }
 }

--- a/contracts/asp-membership/src/test.rs
+++ b/contracts/asp-membership/src/test.rs
@@ -66,10 +66,16 @@ fn test_constructor_sets_admin_and_levels() {
     let contract_id = env.register(ASPMembership, (admin.clone(), levels));
 
     let stored_admin: Address = env.as_contract(&contract_id, || {
-        env.storage().persistent().get(&DataKey::Admin).unwrap()
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Admin set in constructor")
     });
     let stored_levels: u32 = env.as_contract(&contract_id, || {
-        env.storage().persistent().get(&DataKey::Levels).unwrap()
+        env.storage()
+            .persistent()
+            .get(&DataKey::Levels)
+            .expect("Levels set in constructor")
     });
 
     assert_eq!(stored_admin, admin);
@@ -90,7 +96,10 @@ fn test_get_root() {
 
     // Verify initial root matches what's in storage
     let stored_root: U256 = env.as_contract(&contract_id, || {
-        env.storage().persistent().get(&DataKey::Root).unwrap()
+        env.storage()
+            .persistent()
+            .get(&DataKey::Root)
+            .expect("Root set in constructor")
     });
     assert_eq!(
         initial_root, stored_root,
@@ -110,7 +119,10 @@ fn test_get_root() {
 
     // Verify new root also matches storage
     let stored_new_root: U256 = env.as_contract(&contract_id, || {
-        env.storage().persistent().get(&DataKey::Root).unwrap()
+        env.storage()
+            .persistent()
+            .get(&DataKey::Root)
+            .expect("Root set after insert")
     });
     assert_eq!(
         new_root, stored_new_root,
@@ -165,7 +177,10 @@ fn test_insert_leaf() {
 
     // Check NextIndex after both insertions
     let next_index1: u64 = env.as_contract(&contract_id, || {
-        env.storage().persistent().get(&DataKey::NextIndex).unwrap()
+        env.storage()
+            .persistent()
+            .get(&DataKey::NextIndex)
+            .expect("NextIndex set after insert")
     });
     assert_eq!(next_index1, 2, "NextIndex should be 2 after two insertions");
 }
@@ -204,8 +219,8 @@ fn test_insert_leaf_merkle_tree_full() {
     env.mock_all_auths();
 
     // Insert 4 leaves
-    for i in 0..4 {
-        let leaf = U256::from_u32(&env, (i + 1) as u32);
+    for i in 0u32..4 {
+        let leaf = U256::from_u32(&env, i + 1);
         client.insert_leaf(&leaf);
     }
 
@@ -224,7 +239,10 @@ fn test_update_admin() {
 
     // Verify admin was set correctly
     let stored_admin: Address = env.as_contract(&contract_id, || {
-        env.storage().persistent().get(&DataKey::Admin).unwrap()
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Admin set in constructor")
     });
     assert_eq!(stored_admin, admin);
 
@@ -234,7 +252,10 @@ fn test_update_admin() {
 
     // Verify admin was updated in storage
     let stored_admin_after: Address = env.as_contract(&contract_id, || {
-        env.storage().persistent().get(&DataKey::Admin).unwrap()
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Admin updated")
     });
     assert_eq!(stored_admin_after, new_admin);
 }
@@ -258,7 +279,10 @@ fn test_new_admin_can_insert_after_update() {
 
     // Verify the insertion succeeded
     let next_index: u64 = env.as_contract(&contract_id, || {
-        env.storage().persistent().get(&DataKey::NextIndex).unwrap()
+        env.storage()
+            .persistent()
+            .get(&DataKey::NextIndex)
+            .expect("NextIndex set after insert")
     });
     assert_eq!(
         next_index, 1,
@@ -276,14 +300,17 @@ fn test_multiple_insertions() {
     env.mock_all_auths();
 
     // Insert 5 leaves
-    for i in 0..5 {
-        let leaf = U256::from_u32(&env, (i + 1) as u32 * 100u32);
+    for i in 0u32..5 {
+        let leaf = U256::from_u32(&env, (i + 1) * 100u32);
         client.insert_leaf(&leaf);
     }
 
     // Verify NextIndex was updated correctly
     let next_index: u64 = env.as_contract(&contract_id, || {
-        env.storage().persistent().get(&DataKey::NextIndex).unwrap()
+        env.storage()
+            .persistent()
+            .get(&DataKey::NextIndex)
+            .expect("NextIndex set after inserts")
     });
     assert_eq!(
         next_index, 5,
@@ -301,7 +328,7 @@ fn test_admin_insert_only_defaults_to_true() {
         env.storage()
             .persistent()
             .get(&DataKey::AdminInsertOnly)
-            .unwrap()
+            .expect("AdminInsertOnly set in constructor")
     });
     assert!(stored, "AdminInsertOnly should default to true");
 }
@@ -322,7 +349,7 @@ fn test_set_admin_insert_only() {
         env.storage()
             .persistent()
             .get(&DataKey::AdminInsertOnly)
-            .unwrap()
+            .expect("AdminInsertOnly updated")
     });
     assert!(!stored, "AdminInsertOnly should be false after setting it");
 
@@ -333,7 +360,7 @@ fn test_set_admin_insert_only() {
         env.storage()
             .persistent()
             .get(&DataKey::AdminInsertOnly)
-            .unwrap()
+            .expect("AdminInsertOnly re-enabled")
     });
     assert!(stored, "AdminInsertOnly should be true after re-enabling");
 }
@@ -376,7 +403,10 @@ fn test_insert_leaf_without_admin_when_permissionless() {
     client.insert_leaf(&leaf);
 
     let next_index: u64 = env.as_contract(&contract_id, || {
-        env.storage().persistent().get(&DataKey::NextIndex).unwrap()
+        env.storage()
+            .persistent()
+            .get(&DataKey::NextIndex)
+            .expect("NextIndex set after insert")
     });
     assert_eq!(next_index, 1, "Leaf should be inserted without admin auth");
 }
@@ -433,7 +463,10 @@ fn test_permissionless_insert_multiple_leaves() {
     }
 
     let next_index: u64 = env.as_contract(&contract_id, || {
-        env.storage().persistent().get(&DataKey::NextIndex).unwrap()
+        env.storage()
+            .persistent()
+            .get(&DataKey::NextIndex)
+            .expect("NextIndex set after inserts")
     });
     assert_eq!(
         next_index, 5,
@@ -509,7 +542,9 @@ fn test_hash_pair_consistency_1() {
     for (i, item) in bytes_offchain.iter().enumerate().take(32) {
         assert_eq!(
             *item,
-            bytes_on_chain.get(i as u32).unwrap(),
+            bytes_on_chain
+                .get(u32::try_from(i).expect("index fits in u32"))
+                .expect("byte exists at index"),
             "hash_pair compression on-chain should match poseidon2_compression off-chain"
         );
     }
@@ -548,7 +583,9 @@ fn test_hash_pair_consistency_2() {
     for (i, item) in bytes_offchain.iter().enumerate().take(32) {
         assert_eq!(
             *item,
-            bytes_on_chain.get(i as u32).unwrap(),
+            bytes_on_chain
+                .get(u32::try_from(i).expect("index fits in u32"))
+                .expect("byte exists at index"),
             "hash_pair compression on-chain should match poseidon2_compression off-chain"
         );
     }
@@ -625,11 +662,19 @@ fn test_merkle_consistency() {
 
     // Get the on-chain root
     let on_chain_root: U256 = env.as_contract(&contract_id, || {
-        env.storage().persistent().get(&DataKey::Root).unwrap()
+        env.storage()
+            .persistent()
+            .get(&DataKey::Root)
+            .expect("Root set in constructor")
     });
 
     // Empty roots should match
-    assert_eq!(on_chain_root, off_chain_roots.get(0).unwrap());
+    assert_eq!(
+        on_chain_root,
+        off_chain_roots
+            .get(0)
+            .expect("off_chain_roots has element 0")
+    );
 
     // Insert all leaves on-chain
     for i in 0..num_leaves {
@@ -638,10 +683,18 @@ fn test_merkle_consistency() {
 
         // Get the on-chain root
         let on_chain_root: U256 = env.as_contract(&contract_id, || {
-            env.storage().persistent().get(&DataKey::Root).unwrap()
+            env.storage()
+                .persistent()
+                .get(&DataKey::Root)
+                .expect("Root updated after insert")
         });
 
         // Enforce roots match after inserting a leaf
-        assert_eq!(on_chain_root, off_chain_roots.get(i + 1).unwrap());
+        assert_eq!(
+            on_chain_root,
+            off_chain_roots
+                .get(i + 1)
+                .expect("off_chain_roots has element")
+        );
     }
 }

--- a/contracts/asp-non-membership/Cargo.toml
+++ b/contracts/asp-non-membership/Cargo.toml
@@ -16,3 +16,6 @@ soroban-utils = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[lints]
+workspace = true

--- a/contracts/asp-non-membership/src/lib.rs
+++ b/contracts/asp-non-membership/src/lib.rs
@@ -65,6 +65,7 @@ pub enum Error {
     KeyAlreadyExists = 3,
     InvalidProof = 4,
     NotInitialized = 5,
+    Overflow = 6,
 }
 
 // Events
@@ -279,10 +280,24 @@ impl ASPNonMembership {
             let level_idx = level;
             let mut result = if !key_bits.get(level_idx).ok_or(Error::KeyNotFound)? {
                 // Go left
-                Self::find_key_internal(env, store, key, key_bits, &left, level.wrapping_add(1))?
+                Self::find_key_internal(
+                    env,
+                    store,
+                    key,
+                    key_bits,
+                    &left,
+                    level.checked_add(1).ok_or(Error::Overflow)?,
+                )?
             } else {
                 // Go right
-                Self::find_key_internal(env, store, key, key_bits, &right, level.wrapping_add(1))?
+                Self::find_key_internal(
+                    env,
+                    store,
+                    key,
+                    key_bits,
+                    &right,
+                    level.checked_add(1).ok_or(Error::Overflow)?,
+                )?
             };
 
             // Add sibling to path
@@ -387,7 +402,7 @@ impl ASPNonMembership {
                     == key_bits.get(i).ok_or(Error::KeyNotFound)?
             {
                 siblings.push_back(zero.clone());
-                i = i.wrapping_add(1);
+                i = i.checked_add(1).ok_or(Error::Overflow)?;
             }
             rt_old = Self::hash_leaf(
                 &env,

--- a/contracts/asp-non-membership/src/lib.rs
+++ b/contracts/asp-non-membership/src/lib.rs
@@ -245,9 +245,11 @@ impl ASPNonMembership {
         let node_data: Vec<U256> = store.get(&node_key).ok_or(Error::KeyNotFound)?;
 
         // Check if it's a leaf node (3 elements: [1, key, value])
-        if node_data.len() == 3 && node_data.get(0).unwrap() == U256::from_u32(env, 1u32) {
-            let stored_key = node_data.get(1).unwrap();
-            let stored_value = node_data.get(2).unwrap();
+        if node_data.len() == 3
+            && node_data.get(0).ok_or(Error::KeyNotFound)? == U256::from_u32(env, 1u32)
+        {
+            let stored_key = node_data.get(1).ok_or(Error::KeyNotFound)?;
+            let stored_value = node_data.get(2).ok_or(Error::KeyNotFound)?;
             if stored_key == *key {
                 // Key found
                 return Ok(FindResult {
@@ -271,20 +273,20 @@ impl ASPNonMembership {
             }
         } else if node_data.len() == 2 {
             // Internal node (2 elements: [left, right])
-            let left = node_data.get(0).unwrap();
-            let right = node_data.get(1).unwrap();
+            let left = node_data.get(0).ok_or(Error::KeyNotFound)?;
+            let right = node_data.get(1).ok_or(Error::KeyNotFound)?;
 
             let level_idx = level;
-            let mut result = if !key_bits.get(level_idx).unwrap() {
+            let mut result = if !key_bits.get(level_idx).ok_or(Error::KeyNotFound)? {
                 // Go left
-                Self::find_key_internal(env, store, key, key_bits, &left, level + 1)?
+                Self::find_key_internal(env, store, key, key_bits, &left, level.wrapping_add(1))?
             } else {
                 // Go right
-                Self::find_key_internal(env, store, key, key_bits, &right, level + 1)?
+                Self::find_key_internal(env, store, key, key_bits, &right, level.wrapping_add(1))?
             };
 
             // Add sibling to path
-            let sibling = if !key_bits.get(level_idx).unwrap() {
+            let sibling = if !key_bits.get(level_idx).ok_or(Error::KeyNotFound)? {
                 right.clone()
             } else {
                 left.clone()
@@ -348,9 +350,10 @@ impl ASPNonMembership {
     ///
     /// * `Error::KeyAlreadyExists` - Key already exists in the tree
     /// * `Error::KeyNotFound` - Database operations failed
+    #[allow(clippy::cast_possible_truncation)]
     pub fn insert_leaf(env: Env, key: U256, value: U256) -> Result<(), Error> {
         let store = env.storage().persistent();
-        let admin: Address = store.get(&DataKey::Admin).unwrap();
+        let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
         admin.require_auth();
 
         let root: U256 = store
@@ -380,10 +383,11 @@ impl ASPNonMembership {
             // Extend siblings with zeros for common prefix bits
             while i < old_key_bits.len()
                 && i < key_bits.len()
-                && old_key_bits.get(i).unwrap() == key_bits.get(i).unwrap()
+                && old_key_bits.get(i).ok_or(Error::KeyNotFound)?
+                    == key_bits.get(i).ok_or(Error::KeyNotFound)?
             {
                 siblings.push_back(zero.clone());
-                i += 1;
+                i = i.wrapping_add(1);
             }
             rt_old = Self::hash_leaf(
                 &env,
@@ -410,7 +414,7 @@ impl ASPNonMembership {
             // Check if we need to delete old nodes (mixed case)
             // Skip the last index if added_one=true (it's the old leaf, not an internal
             // node)
-            let is_last_added_leaf = added_one && (i == (siblings_len - 1) as usize);
+            let is_last_added_leaf = added_one && (i == siblings_len.saturating_sub(1) as usize);
             if !is_last_added_leaf
                 && (i as u32) < siblings_len.saturating_sub(1)
                 && sibling.clone() != zero
@@ -420,11 +424,15 @@ impl ASPNonMembership {
 
             if mixed && !is_last_added_leaf {
                 let old_sibling = if (i as u32) < find_result.siblings.len() {
-                    find_result.siblings.get(i as u32).unwrap().clone()
+                    find_result
+                        .siblings
+                        .get(i as u32)
+                        .ok_or(Error::KeyNotFound)?
+                        .clone()
                 } else {
                     zero.clone()
                 };
-                let bit = key_bits.get(i as u32).unwrap();
+                let bit = key_bits.get(i as u32).ok_or(Error::KeyNotFound)?;
                 rt_old = if bit {
                     Self::hash_internal(&env, old_sibling.clone(), rt_old.clone())
                 } else {
@@ -434,7 +442,7 @@ impl ASPNonMembership {
             }
 
             // Build a new internal node
-            let bit = key_bits.get(i as u32).unwrap();
+            let bit = key_bits.get(i as u32).ok_or(Error::KeyNotFound)?;
             let (left_hash, right_hash) = if bit {
                 (sibling.clone(), rt.clone())
             } else {
@@ -454,8 +462,8 @@ impl ASPNonMembership {
         }
         // Remove trailing zeros from siblings
         while !siblings.is_empty() {
-            let last_idx = siblings.len() - 1;
-            if siblings.get(last_idx).unwrap() == zero {
+            let last_idx = siblings.len().saturating_sub(1);
+            if siblings.get(last_idx).ok_or(Error::KeyNotFound)? == zero {
                 siblings.pop_back();
             } else {
                 break;
@@ -500,9 +508,9 @@ impl ASPNonMembership {
     ///   operations failed
     pub fn delete_leaf(env: Env, key: U256) -> Result<(), Error> {
         let store = env.storage().persistent();
-        let admin: Address = store.get(&DataKey::Admin).unwrap();
+        let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
         admin.require_auth();
-        let root: U256 = store.get(&DataKey::Root).unwrap();
+        let root: U256 = store.get(&DataKey::Root).ok_or(Error::NotInitialized)?;
 
         // Compute key bits once for both find and delete operations
         let key_bits = Self::split_bits(&env, &key);
@@ -529,7 +537,7 @@ impl ASPNonMembership {
             let node_key = DataKey::Node(last_sibling.clone());
             if let Some(node_data) = store.get::<DataKey, Vec<U256>>(&node_key) {
                 // Check if it's a leaf node (3 elements: [1, key, value])
-                if node_data.len() == 3 && node_data.get(0).unwrap() == one {
+                if node_data.len() == 3 && node_data.get(0).ok_or(Error::KeyNotFound)? == one {
                     // Last sibling is a leaf - promote it
                     rt_new = last_sibling.clone();
                     // Remove the last sibling from the list since we're promoting it
@@ -553,14 +561,14 @@ impl ASPNonMembership {
         let siblings_len = siblings_to_use.len();
 
         for level_idx in 0..siblings_len {
-            let level = siblings_len - 1 - level_idx; // Process from leaf to root
-            let sibling = siblings_to_use.get(level).unwrap();
+            let level = siblings_len.saturating_sub(1).saturating_sub(level_idx); // Process from leaf to root
+            let sibling = siblings_to_use.get(level).ok_or(Error::KeyNotFound)?;
 
             // Use actual sibling value
             let new_sibling = sibling.clone();
 
             // Delete old internal node along the old path
-            let bit = key_bits.get(level).unwrap();
+            let bit = key_bits.get(level).ok_or(Error::KeyNotFound)?;
             rt_old = if bit {
                 Self::hash_internal(&env, sibling.clone(), rt_old)
             } else {
@@ -624,7 +632,7 @@ impl ASPNonMembership {
     ///   operations failed
     pub fn update_leaf(env: Env, key: U256, new_value: U256) -> Result<(), Error> {
         let store = env.storage().persistent();
-        let admin: Address = store.get(&DataKey::Admin).unwrap();
+        let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
         admin.require_auth();
         let root: U256 = store
             .get(&DataKey::Root)
@@ -660,9 +668,9 @@ impl ASPNonMembership {
 
         let siblings_len = find_result.siblings.len();
         for level_idx in 0..siblings_len {
-            let level = siblings_len - 1 - level_idx; // Reverse: process from leaf to root
-            let sibling = find_result.siblings.get(level).unwrap();
-            let bit = key_bits.get(level).unwrap();
+            let level = siblings_len.saturating_sub(1).saturating_sub(level_idx); // Reverse: process from leaf to root
+            let sibling = find_result.siblings.get(level).ok_or(Error::KeyNotFound)?;
+            let bit = key_bits.get(level).ok_or(Error::KeyNotFound)?;
 
             let (left_hash, right_hash) = if bit {
                 (sibling.clone(), current_hash)
@@ -723,6 +731,7 @@ impl ASPNonMembership {
     ///
     /// Returns `Ok(true)` if non-membership is verified, `Ok(false)` if the key
     /// actually exists in the tree.
+    #[allow(clippy::cast_possible_truncation)]
     pub fn verify_non_membership(
         env: Env,
         key: U256,
@@ -751,7 +760,10 @@ impl ASPNonMembership {
         }
 
         for (i, sibling) in siblings.iter().enumerate() {
-            let expected = find_result.siblings.get(i as u32).unwrap();
+            let expected = find_result
+                .siblings
+                .get(i as u32)
+                .ok_or(Error::InvalidProof)?;
             if sibling != expected {
                 return Err(Error::InvalidProof);
             }
@@ -773,9 +785,9 @@ impl ASPNonMembership {
 
         let siblings_len = siblings.len();
         for level_idx in 0..siblings_len {
-            let level = siblings_len - 1 - level_idx; // Reverse: process from leaf to root
-            let sibling = siblings.get(level).unwrap();
-            let bit = key_bits.get(level).unwrap();
+            let level = siblings_len.saturating_sub(1).saturating_sub(level_idx); // Reverse: process from leaf to root
+            let sibling = siblings.get(level).ok_or(Error::InvalidProof)?;
+            let bit = key_bits.get(level).ok_or(Error::InvalidProof)?;
 
             computed_root = if bit {
                 Self::hash_internal(&env, sibling.clone(), computed_root)

--- a/contracts/circom-groth16-verifier/Cargo.toml
+++ b/contracts/circom-groth16-verifier/Cargo.toml
@@ -23,3 +23,6 @@ ark-relations = { workspace = true }
 ark-std = { workspace = true }
 soroban-sdk = { workspace = true, features = ["testutils"] }
 soroban-utils = { workspace = true }
+
+[lints]
+workspace = true

--- a/contracts/circom-groth16-verifier/src/lib.rs
+++ b/contracts/circom-groth16-verifier/src/lib.rs
@@ -80,21 +80,30 @@ impl CircomGroth16Verifier {
     ) -> Result<bool, Groth16Error> {
         let bn = env.crypto().bn254();
 
-        if pub_inputs.len() + 1 != vk.ic.len() {
+        if pub_inputs.len().checked_add(1) != Some(vk.ic.len()) {
             return Err(Groth16Error::MalformedPublicInputs);
         }
 
         let mut vk_x = vk.ic.get(0).ok_or(Groth16Error::MalformedPublicInputs)?;
 
         for i in 0..pub_inputs.len() {
-            let s = pub_inputs.get(i).unwrap();
-            let v = vk.ic.get(i + 1).unwrap();
+            let s = pub_inputs
+                .get(i)
+                .ok_or(Groth16Error::MalformedPublicInputs)?;
+            let ic_idx = i
+                .checked_add(1)
+                .ok_or(Groth16Error::MalformedPublicInputs)?;
+            let v = vk
+                .ic
+                .get(ic_idx)
+                .ok_or(Groth16Error::MalformedPublicInputs)?;
             let prod = bn.g1_mul(&v, &s);
             vk_x = bn.g1_add(&vk_x, &prod);
         }
 
         // Compute the pairing check:
         // e(-A, B) * e(alpha, beta) * e(vk_x, gamma) * e(C, delta) == 1
+        #[allow(clippy::arithmetic_side_effects)]
         let neg_a = -proof.a;
 
         let g1_points = vec![env, neg_a, vk.alpha.clone(), vk_x, proof.c];

--- a/contracts/circom-groth16-verifier/src/test.rs
+++ b/contracts/circom-groth16-verifier/src/test.rs
@@ -2,10 +2,7 @@ use super::*;
 use ark_bn254::{Bn254, Fr as ArkFr};
 use ark_ff::{BigInteger, Field, PrimeField};
 use ark_groth16::{Groth16, Proof};
-use ark_relations::{
-    gr1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError, Variable},
-    lc,
-};
+use ark_relations::gr1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError, Variable};
 use ark_std::rand::{SeedableRng, rngs::StdRng};
 use contract_types::PROOF_SIZE;
 use soroban_sdk::{Bytes, BytesN, Env, Vec};
@@ -31,11 +28,10 @@ impl<F: Field> ConstraintSynthesizer<F> for ElevenInputCircuit<F> {
 
         // Constrain a witness to equal the first public input: w * 1 = input_0
         let witness = cs.new_witness_variable(|| Ok(self.inputs[0]))?;
-        cs.enforce_r1cs_constraint(
-            || lc!() + witness,
-            || lc!() + Variable::One,
-            || lc!() + input_vars[0],
-        )?;
+        let a_lc = witness.into();
+        let b_lc = Variable::One.into();
+        let c_lc = input_vars[0].into();
+        cs.enforce_r1cs_constraint(|| a_lc, || b_lc, || c_lc)?;
         Ok(())
     }
 }

--- a/contracts/pool/Cargo.toml
+++ b/contracts/pool/Cargo.toml
@@ -21,3 +21,6 @@ asp-membership = { workspace = true }
 asp-non-membership = { workspace = true }
 circom-groth16-verifier = { workspace = true }
 soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[lints]
+workspace = true

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-
 pub mod merkle_with_history;
 pub mod pool;
 

--- a/contracts/pool/src/merkle_with_history.rs
+++ b/contracts/pool/src/merkle_with_history.rs
@@ -25,6 +25,7 @@ pub enum Error {
     MerkleTreeFull,
     NextIndexNotEven,
     NotInitialized,
+    Overflow,
 }
 
 /// Storage keys for Merkle tree persistent data
@@ -137,7 +138,7 @@ impl MerkleTreeWithHistory {
             return Err(Error::NextIndexNotEven);
         }
 
-        if next_index.wrapping_add(2) > max_leaves {
+        if next_index.checked_add(2).ok_or(Error::Overflow)? > max_leaves {
             return Err(Error::MerkleTreeFull);
         }
 
@@ -170,18 +171,22 @@ impl MerkleTreeWithHistory {
         }
 
         // Update the root history index
-        root_index = root_index.wrapping_add(1) % ROOT_HISTORY_SIZE;
+        root_index = root_index.checked_add(1).ok_or(Error::Overflow)? % ROOT_HISTORY_SIZE;
         // Update the root with the computed hash
         storage.set(&MerkleDataKey::Root(root_index), &current_hash);
         storage.set(&MerkleDataKey::CurrentRootIndex, &root_index);
 
         // Update NextIndex
-        storage.set(&MerkleDataKey::NextIndex, &(next_index.wrapping_add(2)));
+        storage.set(
+            &MerkleDataKey::NextIndex,
+            &(next_index.checked_add(2).ok_or(Error::Overflow)?),
+        );
 
         // Return the index of the left leaf
         Ok((
             u32::try_from(next_index).map_err(|_| Error::MerkleTreeFull)?,
-            u32::try_from(next_index.wrapping_add(1)).map_err(|_| Error::MerkleTreeFull)?,
+            u32::try_from(next_index.checked_add(1).ok_or(Error::Overflow)?)
+                .map_err(|_| Error::MerkleTreeFull)?,
         ))
     }
 
@@ -221,7 +226,7 @@ impl MerkleTreeWithHistory {
             {
                 return Ok(true);
             }
-            i = i.wrapping_add(1) % ROOT_HISTORY_SIZE;
+            i = i.checked_add(1).ok_or(Error::Overflow)? % ROOT_HISTORY_SIZE;
             if i == current_root_index {
                 // Break after seeing all roots
                 break;

--- a/contracts/pool/src/merkle_with_history.rs
+++ b/contracts/pool/src/merkle_with_history.rs
@@ -82,7 +82,7 @@ impl MerkleTreeWithHistory {
         let zeros: Vec<U256> = get_zeroes(env);
 
         // Initialize filledSubtrees[i] = zeros(i) for each level
-        for i in 0..levels + 1 {
+        for i in 0..=levels {
             let z: U256 = zeros.get(i).ok_or(Error::NotInitialized)?;
             storage.set(&MerkleDataKey::FilledSubtree(i), &z);
             storage.set(&MerkleDataKey::Zeroes(i), &z);
@@ -137,7 +137,7 @@ impl MerkleTreeWithHistory {
             return Err(Error::NextIndexNotEven);
         }
 
-        if (next_index + 2) > max_leaves {
+        if next_index.wrapping_add(2) > max_leaves {
             return Err(Error::MerkleTreeFull);
         }
 
@@ -170,16 +170,19 @@ impl MerkleTreeWithHistory {
         }
 
         // Update the root history index
-        root_index = (root_index + 1) % ROOT_HISTORY_SIZE;
+        root_index = root_index.wrapping_add(1) % ROOT_HISTORY_SIZE;
         // Update the root with the computed hash
         storage.set(&MerkleDataKey::Root(root_index), &current_hash);
         storage.set(&MerkleDataKey::CurrentRootIndex, &root_index);
 
         // Update NextIndex
-        storage.set(&MerkleDataKey::NextIndex, &(next_index + 2));
+        storage.set(&MerkleDataKey::NextIndex, &(next_index.wrapping_add(2)));
 
         // Return the index of the left leaf
-        Ok((next_index as u32, (next_index + 1) as u32))
+        Ok((
+            u32::try_from(next_index).map_err(|_| Error::MerkleTreeFull)?,
+            u32::try_from(next_index.wrapping_add(1)).map_err(|_| Error::MerkleTreeFull)?,
+        ))
     }
 
     /// Check if a root exists in the recent history
@@ -218,7 +221,7 @@ impl MerkleTreeWithHistory {
             {
                 return Ok(true);
             }
-            i = (i + 1) % ROOT_HISTORY_SIZE;
+            i = i.wrapping_add(1) % ROOT_HISTORY_SIZE;
             if i == current_root_index {
                 // Break after seeing all roots
                 break;

--- a/contracts/pool/src/pool.rs
+++ b/contracts/pool/src/pool.rs
@@ -48,6 +48,8 @@ pub enum Error {
     WrongExtHash = 10,
     /// Contract is not initialized
     NotInitialized = 11,
+    /// Arithmetic overflow occurred
+    Overflow = 12,
 }
 
 /// Conversion from MerkleTreeWithHistory errors to pool contract errors
@@ -60,6 +62,7 @@ impl From<MerkleError> for Error {
             MerkleError::WrongLevels => Error::WrongLevels,
             MerkleError::NextIndexNotEven => Error::NextIndexNotEven,
             MerkleError::NotInitialized => Error::NotInitialized,
+            MerkleError::Overflow => Error::Overflow,
         }
     }
 }

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -172,13 +172,13 @@ fn pool_constructor_sets_state() {
         env.storage()
             .persistent()
             .get(&crate::pool::DataKey::Admin)
-            .unwrap()
+            .unwrap_or_else(|| panic!("expected admin to be stored"))
     });
     let stored_max: U256 = env.as_contract(&pool_id, || {
         env.storage()
             .persistent()
             .get(&crate::pool::DataKey::MaximumDepositAmount)
-            .unwrap()
+            .unwrap_or_else(|| panic!("expected maximum deposit amount to be stored"))
     });
     let has_merkle_root = env.as_contract(&pool_id, || {
         env.storage()
@@ -245,20 +245,25 @@ fn merkle_insert_updates_root_and_index() {
         let leaf1 = U256::from_u32(&env, 0x01);
         let leaf2 = U256::from_u32(&env, 0x02);
 
-        let (idx_0, idx_1) = MerkleTreeWithHistory::insert_two_leaves(&env, leaf1, leaf2).unwrap();
+        let (idx_0, idx_1) = MerkleTreeWithHistory::insert_two_leaves(&env, leaf1, leaf2)
+            .unwrap_or_else(|err| panic!("expected leaf insertion to succeed: {err:?}"));
         assert_eq!(idx_0, 0);
         assert_eq!(idx_1, 1);
 
         // last root must be known
-        let root = MerkleTreeWithHistory::get_last_root(&env).unwrap();
-        assert!(MerkleTreeWithHistory::is_known_root(&env, &root).unwrap());
+        let root = MerkleTreeWithHistory::get_last_root(&env)
+            .unwrap_or_else(|err| panic!("expected last root to exist: {err:?}"));
+        assert!(
+            MerkleTreeWithHistory::is_known_root(&env, &root)
+                .unwrap_or_else(|err| panic!("expected root lookup to succeed: {err:?}"))
+        );
 
         // nextIndex should now be 2 (stored in persistent storage)
         let next: u64 = env
             .storage()
             .persistent()
             .get(&MerkleDataKey::NextIndex)
-            .unwrap();
+            .unwrap_or_else(|| panic!("expected next index to be stored"));
         assert_eq!(next, 2);
     });
 }

--- a/contracts/soroban-utils/Cargo.toml
+++ b/contracts/soroban-utils/Cargo.toml
@@ -17,3 +17,6 @@ ark-ff = { workspace = true }
 ark-groth16 = { workspace = true }
 contract-types = { workspace = true }
 soroban-sdk = { workspace = true }
+
+[lints]
+workspace = true

--- a/contracts/soroban-utils/src/lib.rs
+++ b/contracts/soroban-utils/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-
 //! Shared utilities for Soroban contracts
 //!
 //! This crate provides common functions and constants that can be reused

--- a/contracts/soroban-utils/src/poseidon2.rs
+++ b/contracts/soroban-utils/src/poseidon2.rs
@@ -16,8 +16,12 @@ use soroban_sdk::{Bytes, Env, U256, Vec, symbol_short, vec};
 /// # Returns
 /// The compressed hash result as U256
 ///
+///
 /// # Panics
 /// Panics if either input is >= BN256 modulus
+// SAFETY: The Soroban SDK's poseidon2_permutation function is guaranteed to return exactly 't' elements.
+// Therefore, out.get(0) is statically guaranteed to succeed.
+#[allow(clippy::unwrap_used)]
 pub fn poseidon2_compress(env: &Env, left: U256, right: U256) -> U256 {
     // Check inputs are within field range
     let bn256_mod = bn256_modulus(env);
@@ -65,8 +69,12 @@ pub fn poseidon2_compress(env: &Env, left: U256, right: U256) -> U256 {
 /// # Returns
 /// The hash result as U256
 ///
+///
 /// # Panics
 /// Panics if either input is >= BN256 modulus
+// SAFETY: The Soroban SDK's poseidon2_permutation function is guaranteed to return exactly 't' elements.
+// Therefore, out.get(0) is statically guaranteed to succeed.
+#[allow(clippy::unwrap_used)]
 pub fn poseidon2_hash2(env: &Env, a: U256, b: U256, sep: Option<U256>) -> U256 {
     // Check inputs are within field range
     let bn256_mod = bn256_modulus(env);

--- a/contracts/soroban-utils/src/poseidon2.rs
+++ b/contracts/soroban-utils/src/poseidon2.rs
@@ -19,8 +19,8 @@ use soroban_sdk::{Bytes, Env, U256, Vec, symbol_short, vec};
 ///
 /// # Panics
 /// Panics if either input is >= BN256 modulus
-// SAFETY: The Soroban SDK's poseidon2_permutation function is guaranteed to return exactly 't' elements.
-// Therefore, out.get(0) is statically guaranteed to succeed.
+// SAFETY: The Soroban SDK's poseidon2_permutation function is guaranteed to return exactly 't'
+// elements. Therefore, out.get(0) is statically guaranteed to succeed.
 #[allow(clippy::unwrap_used)]
 pub fn poseidon2_compress(env: &Env, left: U256, right: U256) -> U256 {
     // Check inputs are within field range
@@ -72,8 +72,8 @@ pub fn poseidon2_compress(env: &Env, left: U256, right: U256) -> U256 {
 ///
 /// # Panics
 /// Panics if either input is >= BN256 modulus
-// SAFETY: The Soroban SDK's poseidon2_permutation function is guaranteed to return exactly 't' elements.
-// Therefore, out.get(0) is statically guaranteed to succeed.
+// SAFETY: The Soroban SDK's poseidon2_permutation function is guaranteed to return exactly 't'
+// elements. Therefore, out.get(0) is statically guaranteed to succeed.
 #[allow(clippy::unwrap_used)]
 pub fn poseidon2_hash2(env: &Env, a: U256, b: U256, sep: Option<U256>) -> U256 {
     // Check inputs are within field range

--- a/contracts/soroban-utils/src/utils.rs
+++ b/contracts/soroban-utils/src/utils.rs
@@ -20,7 +20,7 @@ where
     K: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
 {
     let store = env.storage().persistent();
-    let admin: Address = store.get(admin_key).unwrap();
+    let admin: Address = store.get(admin_key).expect("admin not initialized");
     admin.require_auth();
 
     // Update admin address
@@ -50,8 +50,16 @@ impl MockToken {
 
 pub fn g1_bytes_from_ark(p: ArkG1Affine) -> [u8; 64] {
     let mut out = [0u8; 64];
-    let x_bytes: [u8; 32] = p.x.into_bigint().to_bytes_be().try_into().unwrap();
-    let y_bytes: [u8; 32] = p.y.into_bigint().to_bytes_be().try_into().unwrap();
+    let x_bytes: [u8; 32] =
+        p.x.into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .expect("length mismatch");
+    let y_bytes: [u8; 32] =
+        p.y.into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .expect("length mismatch");
     out[..32].copy_from_slice(&x_bytes);
     out[32..].copy_from_slice(&y_bytes);
     out
@@ -59,10 +67,30 @@ pub fn g1_bytes_from_ark(p: ArkG1Affine) -> [u8; 64] {
 
 pub fn g2_bytes_from_ark(p: ArkG2Affine) -> [u8; 128] {
     let mut out = [0u8; 128];
-    let x0: [u8; 32] = p.x.c0.into_bigint().to_bytes_be().try_into().unwrap();
-    let x1: [u8; 32] = p.x.c1.into_bigint().to_bytes_be().try_into().unwrap();
-    let y0: [u8; 32] = p.y.c0.into_bigint().to_bytes_be().try_into().unwrap();
-    let y1: [u8; 32] = p.y.c1.into_bigint().to_bytes_be().try_into().unwrap();
+    let x0: [u8; 32] =
+        p.x.c0
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .expect("length mismatch");
+    let x1: [u8; 32] =
+        p.x.c1
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .expect("length mismatch");
+    let y0: [u8; 32] =
+        p.y.c0
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .expect("length mismatch");
+    let y1: [u8; 32] =
+        p.y.c1
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .expect("length mismatch");
 
     // Imaginary component first, real component second
     // According to Soroban G2Affine documentation

--- a/contracts/types/Cargo.toml
+++ b/contracts/types/Cargo.toml
@@ -12,3 +12,6 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true, features = ["alloc"] }
+
+[lints]
+workspace = true

--- a/contracts/types/src/lib.rs
+++ b/contracts/types/src/lib.rs
@@ -25,10 +25,15 @@ pub enum Groth16Error {
 #[contracttype]
 #[derive(Clone)]
 pub struct VerificationKeyBytes {
+    /// Alpha G1 point
     pub alpha: BytesN<64>,
+    /// Beta G2 point
     pub beta: BytesN<128>,
+    /// Gamma G2 point
     pub gamma: BytesN<128>,
+    /// Delta G2 point
     pub delta: BytesN<128>,
+    /// IC (public input commitments)
     pub ic: Vec<BytesN<64>>,
 }
 
@@ -37,8 +42,11 @@ pub struct VerificationKeyBytes {
 #[derive(Clone)]
 #[contracttype]
 pub struct Groth16Proof {
+    /// Point A
     pub a: Bn254G1Affine,
+    /// Point B
     pub b: Bn254G2Affine,
+    /// Point C
     pub c: Bn254G1Affine,
 }
 


### PR DESCRIPTION
This PR addresses to issue #104 and enables workspace lints across all crates. 
