### PR TITLE
refactor: unify usage of types::Field in the prover crate

### DIFF
--- a/app/crates/core/prover/src/flows.rs
+++ b/app/crates/core/prover/src/flows.rs
@@ -33,11 +33,11 @@ pub struct TransactInputNote {
     pub amount_stroops: NoteAmount,
     /// Note blinding factor as a BN254 scalar field element.
     pub blinding: Field,
-    /// Merkle proof sibling hashes as BN254 scalars (little-endian field
-    /// bytes), one element per tree level.
-    pub merkle_path_elements: Vec<[u8; 32]>,
-    /// Merkle path indices packed into a scalar (little-endian field bytes).
-    pub merkle_path_indices: [u8; 32],
+    /// Merkle proof sibling hashes as BN254 field elements, one element per
+    /// tree level.
+    pub merkle_path_elements: Vec<Field>,
+    /// Merkle path indices packed into a BN254 field element.
+    pub merkle_path_indices: Field,
 }
 
 /// Output note specification for a pool transaction.
@@ -77,21 +77,19 @@ pub struct PreparedTx {
     ///
     /// For witness/public-input encoding, use `pool_root.to_le_bytes()`.
     pub pool_root: Field,
-    /// Computed nullifiers for both input slots (little-endian field bytes).
-    pub input_nullifiers: [[u8; 32]; N_INPUTS],
-    /// Computed commitments for both output slots (little-endian field bytes).
-    pub output_commitments: [[u8; 32]; N_OUTPUTS],
-    /// Field element representation of ext_amount (LE bytes).
-    pub public_amount_field: [u8; 32],
+    /// Computed nullifiers for both input slots.
+    pub input_nullifiers: [Field; N_INPUTS],
+    /// Computed commitments for both output slots.
+    pub output_commitments: [Field; N_OUTPUTS],
+    /// Field element representation of ext_amount.
+    pub public_amount_field: Field,
     /// Hash of extData used by both circuit and contract checks (32-byte
     /// big-endian).
     pub ext_data_hash_be: [u8; 32],
-    /// ASP membership root used for the circuit public inputs (little-endian
-    /// field bytes).
-    pub asp_membership_root: [u8; 32],
-    /// ASP non-membership root used for the circuit public inputs
-    /// (little-endian field bytes).
-    pub asp_non_membership_root: [u8; 32],
+    /// ASP membership root used for the circuit public inputs.
+    pub asp_membership_root: Field,
+    /// ASP non-membership root used for the circuit public inputs.
+    pub asp_non_membership_root: Field,
 }
 
 /// Full output of `transact()` and the wrapper flows.
@@ -557,7 +555,7 @@ where
 
     // Public inputs.
     circuit.set_single("root", &field_to_circuit_hex(pool_root)?);
-    let public_amount_field_le = Field::try_from(ext_amount)?.to_le_bytes();
+    let public_amount_field = Field::try_from(ext_amount)?;
     circuit.set_single("publicAmount", &ext_amount_to_circuit_hex(ext_amount)?);
 
     // Input notes: compute commitments/signatures/nullifiers.
@@ -573,31 +571,31 @@ where
         .ok_or_else(|| anyhow!("path elements capacity overflow"))?;
     let mut in_path_elements_hex: Vec<String> = Vec::with_capacity(in_path_elements_capacity);
 
-    let mut input_nullifiers_bytes: [[u8; 32]; N_INPUTS] = [[0u8; 32]; N_INPUTS];
+    let mut input_nullifiers_fields: [Field; N_INPUTS] = [Field::ZERO; N_INPUTS];
 
     for (idx, inp) in input_slots.iter().enumerate() {
         let amount_field = note_amount_to_field(inp.amount_stroops);
         let amount_field_le = amount_field.to_le_bytes();
         let inp_blinding_le = inp.blinding.to_le_bytes();
+        let merkle_path_indices = inp.merkle_path_indices.to_le_bytes();
         let commitment =
             crypto::compute_commitment(&amount_field_le, &sender_note_pubkey, &inp_blinding_le)?;
-        let signature =
-            crypto::compute_signature(&priv_key.0, &commitment, &inp.merkle_path_indices)?;
-        let nullifier =
-            crypto::compute_nullifier(&commitment, &inp.merkle_path_indices, &signature)?;
+        let signature = crypto::compute_signature(&priv_key.0, &commitment, &merkle_path_indices)?;
+        let nullifier = crypto::compute_nullifier(&commitment, &merkle_path_indices, &signature)?;
 
         let nullifier_arr: [u8; 32] = nullifier
             .try_into()
             .map_err(|v: Vec<u8>| anyhow!("nullifier: expected 32 bytes, got {}", v.len()))?;
-        input_nullifiers_bytes[idx] = nullifier_arr;
+        let nullifier_field = Field::try_from_le_bytes(nullifier_arr)?;
+        input_nullifiers_fields[idx] = nullifier_field;
 
-        input_nullifiers_hex.push(field_bytes_to_hex(&nullifier_arr)?);
+        input_nullifiers_hex.push(field_to_circuit_hex(nullifier_field)?);
         in_amount_hex.push(field_to_circuit_hex(amount_field)?);
         in_priv_hex.push(priv_key_hex.clone());
         in_blinding_hex.push(field_bytes_to_hex(&inp_blinding_le)?);
-        in_path_indices_hex.push(field_bytes_to_hex(&inp.merkle_path_indices)?);
+        in_path_indices_hex.push(field_to_circuit_hex(inp.merkle_path_indices)?);
         for pe in &inp.merkle_path_elements {
-            in_path_elements_hex.push(field_bytes_to_hex(pe)?);
+            in_path_elements_hex.push(field_to_circuit_hex(*pe)?);
         }
     }
 
@@ -607,7 +605,7 @@ where
     let mut out_blinding_hex: Vec<String> = Vec::with_capacity(N_OUTPUTS);
     let mut output_commitments_hex: Vec<String> = Vec::with_capacity(N_OUTPUTS);
 
-    let mut output_commitments_bytes: [[u8; 32]; N_OUTPUTS] = [[0u8; 32]; N_OUTPUTS];
+    let mut output_commitments_fields: [Field; N_OUTPUTS] = [Field::ZERO; N_OUTPUTS];
     let mut encrypted_outputs: [Vec<u8>; N_OUTPUTS] = [Vec::new(), Vec::new()];
 
     for (idx, out) in output_slots.iter().enumerate() {
@@ -629,7 +627,8 @@ where
         let commitment_arr: [u8; 32] = commitment
             .try_into()
             .map_err(|v: Vec<u8>| anyhow!("commitment: expected 32 bytes, got {}", v.len()))?;
-        output_commitments_bytes[idx] = commitment_arr;
+        let commitment_field = Field::try_from_le_bytes(commitment_arr)?;
+        output_commitments_fields[idx] = commitment_field;
 
         let enc = encryption::encrypt_output_note(
             &recipient_enc_pubkey,
@@ -641,7 +640,7 @@ where
         out_amount_hex.push(field_to_circuit_hex(amount_field)?);
         out_pubkey_hex.push(field_bytes_to_hex(&recipient_note_pubkey)?);
         out_blinding_hex.push(field_bytes_to_hex(&out_blinding_le)?);
-        output_commitments_hex.push(field_bytes_to_hex(&commitment_arr)?);
+        output_commitments_hex.push(field_to_circuit_hex(commitment_field)?);
     }
 
     // Wire public arrays.
@@ -755,12 +754,12 @@ where
         ext_data,
         prepared: PreparedTx {
             pool_root,
-            input_nullifiers: input_nullifiers_bytes,
-            output_commitments: output_commitments_bytes,
-            public_amount_field: public_amount_field_le,
+            input_nullifiers: input_nullifiers_fields,
+            output_commitments: output_commitments_fields,
+            public_amount_field,
             ext_data_hash_be,
-            asp_membership_root: membership_proof.root.to_le_bytes(),
-            asp_non_membership_root: non_membership_proof.root.to_le_bytes(),
+            asp_membership_root: membership_proof.root,
+            asp_non_membership_root: non_membership_proof.root,
         },
     })
 }
@@ -770,8 +769,8 @@ fn dummy_input(tree_depth: usize) -> Result<TransactInputNote> {
     Ok(TransactInputNote {
         amount_stroops: NoteAmount::ZERO,
         blinding,
-        merkle_path_elements: vec![[0u8; 32]; tree_depth],
-        merkle_path_indices: [0u8; 32],
+        merkle_path_elements: vec![Field::ZERO; tree_depth],
+        merkle_path_indices: Field::ZERO,
     })
 }
 
@@ -917,8 +916,8 @@ mod tests {
         let input = TransactInputNote {
             amount_stroops: NoteAmount::from(10),
             blinding: Field::try_from_le_bytes([4u8; 32]).expect("field"),
-            merkle_path_elements: vec![[0u8; 32]; tree_depth_usize],
-            merkle_path_indices: [0u8; 32],
+            merkle_path_elements: vec![Field::ZERO; tree_depth_usize],
+            merkle_path_indices: Field::ZERO,
         };
 
         let artifacts = withdraw(
@@ -964,8 +963,8 @@ mod tests {
         let input = TransactInputNote {
             amount_stroops: NoteAmount::from(10),
             blinding: Field::try_from_le_bytes([4u8; 32]).expect("field"),
-            merkle_path_elements: vec![[0u8; 32]; tree_depth_usize],
-            merkle_path_indices: [0u8; 32],
+            merkle_path_elements: vec![Field::ZERO; tree_depth_usize],
+            merkle_path_indices: Field::ZERO,
         };
         let out = TransactOutput {
             amount_stroops: NoteAmount::from(9), // unbalanced
@@ -1006,14 +1005,14 @@ mod tests {
         let input0 = TransactInputNote {
             amount_stroops: NoteAmount::MAX,
             blinding: Field::try_from_le_bytes([4u8; 32]).expect("field"),
-            merkle_path_elements: vec![[0u8; 32]; tree_depth_usize],
-            merkle_path_indices: [0u8; 32],
+            merkle_path_elements: vec![Field::ZERO; tree_depth_usize],
+            merkle_path_indices: Field::ZERO,
         };
         let input1 = TransactInputNote {
             amount_stroops: NoteAmount::MAX,
             blinding: Field::try_from_le_bytes([5u8; 32]).expect("field"),
-            merkle_path_elements: vec![[0u8; 32]; tree_depth_usize],
-            merkle_path_indices: [0u8; 32],
+            merkle_path_elements: vec![Field::ZERO; tree_depth_usize],
+            merkle_path_indices: Field::ZERO,
         };
 
         // Withdraw a small amount so `change` is > NoteAmount::MAX.

--- a/app/crates/core/prover/src/flows.rs
+++ b/app/crates/core/prover/src/flows.rs
@@ -556,12 +556,9 @@ where
     let mut circuit = CircuitInputs::new();
 
     // Public inputs.
-    circuit.set_single("root", &field_bytes_to_hex(&pool_root.to_le_bytes())?);
+    circuit.set_single("root", &field_to_circuit_hex(pool_root)?);
     let public_amount_field_le = Field::try_from(ext_amount)?.to_le_bytes();
-    circuit.set_single(
-        "publicAmount",
-        &field_bytes_to_hex(&public_amount_field_le)?,
-    );
+    circuit.set_single("publicAmount", &ext_amount_to_circuit_hex(ext_amount)?);
 
     // Input notes: compute commitments/signatures/nullifiers.
     let priv_key_hex = field_bytes_to_hex(&priv_key.0)?;
@@ -579,10 +576,11 @@ where
     let mut input_nullifiers_bytes: [[u8; 32]; N_INPUTS] = [[0u8; 32]; N_INPUTS];
 
     for (idx, inp) in input_slots.iter().enumerate() {
-        let amount_field = note_amount_to_field_le(inp.amount_stroops);
+        let amount_field = note_amount_to_field(inp.amount_stroops);
+        let amount_field_le = amount_field.to_le_bytes();
         let inp_blinding_le = inp.blinding.to_le_bytes();
         let commitment =
-            crypto::compute_commitment(&amount_field, &sender_note_pubkey, &inp_blinding_le)?;
+            crypto::compute_commitment(&amount_field_le, &sender_note_pubkey, &inp_blinding_le)?;
         let signature =
             crypto::compute_signature(&priv_key.0, &commitment, &inp.merkle_path_indices)?;
         let nullifier =
@@ -594,7 +592,7 @@ where
         input_nullifiers_bytes[idx] = nullifier_arr;
 
         input_nullifiers_hex.push(field_bytes_to_hex(&nullifier_arr)?);
-        in_amount_hex.push(field_bytes_to_hex(&amount_field)?);
+        in_amount_hex.push(field_to_circuit_hex(amount_field)?);
         in_priv_hex.push(priv_key_hex.clone());
         in_blinding_hex.push(field_bytes_to_hex(&inp_blinding_le)?);
         in_path_indices_hex.push(field_bytes_to_hex(&inp.merkle_path_indices)?);
@@ -623,10 +621,11 @@ where
             .clone()
             .unwrap_or_else(|| encryption_pubkey.clone());
 
-        let amount_field = note_amount_to_field_le(out.amount_stroops);
+        let amount_field = note_amount_to_field(out.amount_stroops);
+        let amount_field_le = amount_field.to_le_bytes();
         let out_blinding_le = out.blinding.to_le_bytes();
         let commitment =
-            crypto::compute_commitment(&amount_field, &recipient_note_pubkey, &out_blinding_le)?;
+            crypto::compute_commitment(&amount_field_le, &recipient_note_pubkey, &out_blinding_le)?;
         let commitment_arr: [u8; 32] = commitment
             .try_into()
             .map_err(|v: Vec<u8>| anyhow!("commitment: expected 32 bytes, got {}", v.len()))?;
@@ -639,7 +638,7 @@ where
         )?;
         encrypted_outputs[idx] = enc;
 
-        out_amount_hex.push(field_bytes_to_hex(&amount_field)?);
+        out_amount_hex.push(field_to_circuit_hex(amount_field)?);
         out_pubkey_hex.push(field_bytes_to_hex(&recipient_note_pubkey)?);
         out_blinding_hex.push(field_bytes_to_hex(&out_blinding_le)?);
         output_commitments_hex.push(field_bytes_to_hex(&commitment_arr)?);
@@ -662,8 +661,8 @@ where
     circuit.set_array("outBlinding", out_blinding_hex);
 
     // ASP roots arrays (flattened).
-    let membership_root_hex = field_bytes_to_hex(&membership_proof.root.to_le_bytes())?;
-    let non_membership_root_hex = field_bytes_to_hex(&non_membership_proof.root.to_le_bytes())?;
+    let membership_root_hex = field_to_circuit_hex(membership_proof.root)?;
+    let non_membership_root_hex = field_to_circuit_hex(non_membership_proof.root)?;
     circuit.set_array(
         "membershipRoots",
         vec![membership_root_hex.clone(), membership_root_hex.clone()],
@@ -682,48 +681,48 @@ where
         let prefix_m = format!("membershipProofs[{}][0].", slot);
         circuit.set_single(
             &format!("{prefix_m}leaf"),
-            &field_bytes_to_hex(&membership_proof.leaf.to_le_bytes())?,
+            &field_to_circuit_hex(membership_proof.leaf)?,
         );
         circuit.set_single(
             &format!("{prefix_m}blinding"),
-            &field_bytes_to_hex(&membership_proof.blinding.to_le_bytes())?,
+            &field_to_circuit_hex(membership_proof.blinding)?,
         );
         circuit.set_single(
             &format!("{prefix_m}pathIndices"),
-            &field_bytes_to_hex(&membership_proof.path_indices.to_le_bytes())?,
+            &field_to_circuit_hex(membership_proof.path_indices)?,
         );
         circuit.set_array(
             &format!("{prefix_m}pathElements"),
             membership_proof
                 .path_elements
                 .iter()
-                .map(|e| field_bytes_to_hex(&e.to_le_bytes()))
+                .map(|e| field_to_circuit_hex(*e))
                 .collect::<Result<Vec<_>>>()?,
         );
         circuit.set_single(
             &format!("{prefix_m}root"),
-            &field_bytes_to_hex(&membership_proof.root.to_le_bytes())?,
+            &field_to_circuit_hex(membership_proof.root)?,
         );
 
         let prefix_n = format!("nonMembershipProofs[{}][0].", slot);
         circuit.set_single(
             &format!("{prefix_n}key"),
-            &field_bytes_to_hex(&non_membership_proof.key.to_le_bytes())?,
+            &field_to_circuit_hex(non_membership_proof.key)?,
         );
         circuit.set_single(
             &format!("{prefix_n}oldKey"),
-            &field_bytes_to_hex(&non_membership_proof.old_key.to_le_bytes())?,
+            &field_to_circuit_hex(non_membership_proof.old_key)?,
         );
         circuit.set_single(
             &format!("{prefix_n}oldValue"),
-            &field_bytes_to_hex(&non_membership_proof.old_value.to_le_bytes())?,
+            &field_to_circuit_hex(non_membership_proof.old_value)?,
         );
         circuit.set_single(
             &format!("{prefix_n}isOld0"),
-            &field_bytes_to_hex(&if non_membership_proof.is_old0 {
-                Field::from(NoteAmount::ONE).to_le_bytes()
+            &field_to_circuit_hex(if non_membership_proof.is_old0 {
+                Field::from(NoteAmount::ONE)
             } else {
-                Field::ZERO.to_le_bytes()
+                Field::ZERO
             })?,
         );
         circuit.set_array(
@@ -731,12 +730,12 @@ where
             non_membership_proof
                 .siblings
                 .iter()
-                .map(|s| field_bytes_to_hex(&s.to_le_bytes()))
+                .map(|s| field_to_circuit_hex(*s))
                 .collect::<Result<Vec<_>>>()?,
         );
         circuit.set_single(
             &format!("{prefix_n}root"),
-            &field_bytes_to_hex(&non_membership_proof.root.to_le_bytes())?,
+            &field_to_circuit_hex(non_membership_proof.root)?,
         );
     }
 
@@ -776,8 +775,17 @@ fn dummy_input(tree_depth: usize) -> Result<TransactInputNote> {
     })
 }
 
-fn note_amount_to_field_le(amount: NoteAmount) -> [u8; 32] {
-    Field::from(amount).to_le_bytes()
+fn note_amount_to_field(amount: NoteAmount) -> Field {
+    Field::from(amount)
+}
+
+fn field_to_circuit_hex(field: Field) -> Result<String> {
+    field_bytes_to_hex(&field.to_le_bytes())
+}
+
+fn ext_amount_to_circuit_hex(amount: ExtAmount) -> Result<String> {
+    let field = Field::try_from(amount)?;
+    field_to_circuit_hex(field)
 }
 
 // Note: `ExtAmount -> Field` conversion happens via

--- a/app/crates/core/prover/src/merkle.rs
+++ b/app/crates/core/prover/src/merkle.rs
@@ -6,44 +6,58 @@
 use alloc::vec::Vec;
 
 use anyhow::{Result, anyhow};
-use zkhash::fields::bn256::FpBN256 as Scalar;
+use zkhash::{ark_ff::PrimeField, fields::bn256::FpBN256 as Scalar};
 
-use crate::{
-    crypto,
-    serialization::{bytes_to_scalar, scalar_to_bytes},
-};
-use types::Field as AppField;
+use crate::{crypto, serialization::scalar_to_bytes};
+use types::Field;
 
 // Re-export core merkle functions from circuits
 pub use circuits::core::merkle::{
     merkle_proof as merkle_proof_internal, merkle_root, poseidon2_compression,
 };
 
+fn field_to_scalar(field: Field) -> Scalar {
+    Scalar::from_le_bytes_mod_order(&field.to_le_bytes())
+}
+
+fn scalar_to_field(scalar: Scalar) -> Field {
+    let le = scalar_to_bytes(&scalar);
+    let le: [u8; 32] = le.try_into().expect("scalar bytes length");
+    Field::try_from_le_bytes(le).expect("scalar to field conversion")
+}
+
+fn hash_pair(left: Field, right: Field) -> Field {
+    let left_s = field_to_scalar(left);
+    let right_s = field_to_scalar(right);
+    let hashed = poseidon2_compression(left_s, right_s);
+    scalar_to_field(hashed)
+}
+
 /// Merkle proof data
 pub struct MerkleProof {
     /// Path elements
-    pub path_elements: Vec<AppField>,
+    pub path_elements: Vec<Field>,
     /// Path indices as a single scalar
-    pub path_indices: AppField,
+    pub path_indices: Field,
     /// Computed root
-    pub root: AppField,
+    pub root: Field,
     /// Number of levels
     pub levels: usize,
 }
 
 impl MerkleProof {
     /// Get path elements, one field element per level.
-    pub fn path_elements(&self) -> Vec<AppField> {
+    pub fn path_elements(&self) -> Vec<Field> {
         self.path_elements.clone()
     }
 
     /// Get path indices packed into a field element.
-    pub fn path_indices(&self) -> AppField {
+    pub fn path_indices(&self) -> Field {
         self.path_indices
     }
 
     /// Get computed root as a field element.
-    pub fn root(&self) -> AppField {
+    pub fn root(&self) -> Field {
         self.root
     }
 
@@ -62,11 +76,11 @@ impl MerkleProof {
 /// - Merkle proofs for any existing leaf index `< leaves.len()`.
 pub struct MerklePrefixTree {
     depth: usize,
-    leaves: Vec<Scalar>,
+    leaves: Vec<Field>,
     /// `empty[level]` is the node value of a completely-empty subtree at
     /// `level`, where level 0 is the leaf level and level `depth` is the
     /// root.
-    empty: Vec<Scalar>,
+    empty: Vec<Field>,
 }
 
 /// Built/cached prefix Merkle tree for efficiently computing multiple proofs.
@@ -76,11 +90,11 @@ pub struct MerklePrefixTree {
 pub struct MerklePrefixTreeBuilt {
     depth: usize,
     /// See [`MerklePrefixTree::empty`].
-    empty: Vec<Scalar>,
+    empty: Vec<Field>,
     /// `levels[level]` contains the computed nodes for that level for the
     /// provided prefix. `levels[0]` are the leaves; `levels[depth][0]` is the
     /// root (after padding with `empty` as needed).
-    levels: Vec<Vec<Scalar>>,
+    levels: Vec<Vec<Field>>,
 }
 
 impl MerklePrefixTree {
@@ -93,7 +107,7 @@ impl MerklePrefixTree {
     /// Missing leaves (i.e., indices `>= leaves.len()`) are treated as the
     /// contract's `zero_leaf` value, and the computed root/proofs match the
     /// circuit's Poseidon2 merkle implementation.
-    pub fn new(depth: u32, leaves: &[AppField]) -> Result<Self> {
+    pub fn new(depth: u32, leaves: &[Field]) -> Result<Self> {
         let depth = usize::try_from(depth).map_err(|_| anyhow!("tree depth too large"))?;
         if depth == 0 || depth > 32 {
             return Err(anyhow!("Depth must be between 1 and 32"));
@@ -102,7 +116,10 @@ impl MerklePrefixTree {
         // Build the empty-subtree chain using the same zero leaf as the contract.
         let mut zero_leaf_be = crypto::zero_leaf();
         zero_leaf_be.reverse();
-        let zero = bytes_to_scalar(&zero_leaf_be)?;
+        let zero_leaf_le: [u8; 32] = zero_leaf_be
+            .try_into()
+            .map_err(|_| anyhow!("zero leaf: expected 32 bytes"))?;
+        let zero = Field::try_from_le_bytes(zero_leaf_le)?;
 
         let empty_cap = depth
             .checked_add(1)
@@ -110,13 +127,10 @@ impl MerklePrefixTree {
         let mut empty = Vec::with_capacity(empty_cap);
         empty.push(zero);
         for i in 0..depth {
-            empty.push(poseidon2_compression(empty[i], empty[i]));
+            empty.push(hash_pair(empty[i], empty[i]));
         }
 
-        let mut scalar_leaves = Vec::with_capacity(leaves.len());
-        for leaf in leaves {
-            scalar_leaves.push(bytes_to_scalar(&leaf.to_le_bytes())?);
-        }
+        let scalar_leaves = leaves.to_vec();
 
         Ok(Self {
             depth,
@@ -146,8 +160,8 @@ impl MerklePrefixTree {
 
     fn build_from_parts(
         depth: usize,
-        leaves: Vec<Scalar>,
-        empty: Vec<Scalar>,
+        leaves: Vec<Field>,
+        empty: Vec<Field>,
     ) -> MerklePrefixTreeBuilt {
         let levels_cap = depth.checked_add(1).expect("depth overflow");
         let mut levels = Vec::with_capacity(levels_cap);
@@ -169,7 +183,7 @@ impl MerklePrefixTree {
                     .get(right_idx)
                     .copied()
                     .unwrap_or(empty[level]);
-                next.push(poseidon2_compression(left, right));
+                next.push(hash_pair(left, right));
             }
             levels.push(next);
         }
@@ -185,7 +199,7 @@ impl MerklePrefixTree {
     ///
     /// This hashes up to `depth` levels, using `zero_leaf`-derived empty
     /// subtree nodes for all missing leaves.
-    pub fn root(&self) -> Result<AppField> {
+    pub fn root(&self) -> Result<Field> {
         let mut nodes = self.leaves.clone();
 
         for level in 0..self.depth {
@@ -201,17 +215,12 @@ impl MerklePrefixTree {
                 let right_idx = left_idx.checked_add(1).expect("index overflow");
                 let left = nodes.get(left_idx).copied().unwrap_or(self.empty[level]);
                 let right = nodes.get(right_idx).copied().unwrap_or(self.empty[level]);
-                next.push(poseidon2_compression(left, right));
+                next.push(hash_pair(left, right));
             }
             nodes = next;
         }
 
-        let root = nodes.first().copied().unwrap_or(self.empty[self.depth]);
-        let root_le = scalar_to_bytes(&root);
-        let root_le: [u8; 32] = root_le
-            .try_into()
-            .map_err(|_| anyhow!("Merkle root: expected 32 bytes"))?;
-        AppField::try_from_le_bytes(root_le)
+        Ok(nodes.first().copied().unwrap_or(self.empty[self.depth]))
     }
 
     /// Compute a Merkle proof for `index`, returning:
@@ -251,11 +260,7 @@ impl MerklePrefixTree {
                 .get(sib_index)
                 .copied()
                 .unwrap_or(self.empty[level]);
-            let sib_le = scalar_to_bytes(&sib);
-            let sib_le: [u8; 32] = sib_le
-                .try_into()
-                .map_err(|_| anyhow!("path element: expected 32 bytes"))?;
-            path_elements.push(sib_le);
+            path_elements.push(sib.to_le_bytes());
             path_indices_bits_lsb.push((index & 1) as u64);
 
             if level_nodes.is_empty() {
@@ -275,7 +280,7 @@ impl MerklePrefixTree {
                     .get(right_idx)
                     .copied()
                     .unwrap_or(self.empty[level]);
-                next.push(poseidon2_compression(left, right));
+                next.push(hash_pair(left, right));
             }
             level_nodes = next;
             index /= 2;
@@ -286,11 +291,8 @@ impl MerklePrefixTree {
             path_indices |= b << i;
         }
 
-        let idx_scalar = Scalar::from(path_indices);
-        let idx_le = scalar_to_bytes(&idx_scalar);
-        let idx_le: [u8; 32] = idx_le
-            .try_into()
-            .map_err(|_| anyhow!("path indices: expected 32 bytes"))?;
+        let mut idx_le = [0u8; 32];
+        idx_le[..8].copy_from_slice(&path_indices.to_le_bytes());
 
         Ok((path_elements, idx_le))
     }
@@ -303,18 +305,14 @@ impl MerklePrefixTreeBuilt {
     }
 
     /// Compute the full-depth Merkle root for this built prefix.
-    pub fn root(&self) -> Result<AppField> {
+    pub fn root(&self) -> Result<Field> {
         let root = self
             .levels
             .get(self.depth)
             .and_then(|v| v.first())
             .copied()
             .unwrap_or(self.empty[self.depth]);
-        let root_le = scalar_to_bytes(&root);
-        let root_le: [u8; 32] = root_le
-            .try_into()
-            .map_err(|_| anyhow!("Merkle root: expected 32 bytes"))?;
-        AppField::try_from_le_bytes(root_le)
+        Ok(root)
     }
 
     /// Compute a Merkle proof for `index` for the provided prefix.
@@ -330,7 +328,7 @@ impl MerklePrefixTreeBuilt {
             ));
         }
 
-        let mut path_elements: Vec<AppField> = Vec::with_capacity(self.depth);
+        let mut path_elements: Vec<Field> = Vec::with_capacity(self.depth);
         let mut path_indices_bits: u64 = 0;
         let mut current_index = idx_usize;
 
@@ -341,11 +339,7 @@ impl MerklePrefixTreeBuilt {
                 .copied()
                 .unwrap_or(self.empty[level]);
 
-            let sib_le = scalar_to_bytes(&sib);
-            let sib_le: [u8; 32] = sib_le
-                .try_into()
-                .map_err(|_| anyhow!("path element: expected 32 bytes"))?;
-            path_elements.push(AppField::try_from_le_bytes(sib_le)?);
+            path_elements.push(sib);
 
             if !current_index.is_multiple_of(2) {
                 path_indices_bits |= 1u64 << level;
@@ -355,7 +349,7 @@ impl MerklePrefixTreeBuilt {
 
         let mut path_indices_le = [0u8; 32];
         path_indices_le[..8].copy_from_slice(&path_indices_bits.to_le_bytes());
-        let path_indices = AppField::try_from_le_bytes(path_indices_le)?;
+        let path_indices = Field::try_from_le_bytes(path_indices_le)?;
 
         let root = self.root()?;
 
@@ -391,9 +385,9 @@ mod tests {
     fn prefix_built_root_matches_prefix_root() {
         let depth = 8u32;
         let leaves = [
-            AppField::try_from_le_bytes([7u8; 32]).expect("field"),
-            AppField::try_from_le_bytes([9u8; 32]).expect("field"),
-            AppField::try_from_le_bytes([11u8; 32]).expect("field"),
+            Field::try_from_le_bytes([7u8; 32]).expect("field"),
+            Field::try_from_le_bytes([9u8; 32]).expect("field"),
+            Field::try_from_le_bytes([11u8; 32]).expect("field"),
         ];
 
         let tree = MerklePrefixTree::new(depth, &leaves).expect("new");
@@ -405,8 +399,8 @@ mod tests {
     #[test]
     fn prefix_built_proof_bytes_matches_prefix_proof_bytes() {
         let depth = 6u32;
-        let leaves: Vec<AppField> = (0u8..15u8)
-            .map(|v| AppField::try_from_le_bytes([v; 32]).expect("field"))
+        let leaves: Vec<Field> = (0u8..15u8)
+            .map(|v| Field::try_from_le_bytes([v; 32]).expect("field"))
             .collect();
 
         let tree = MerklePrefixTree::new(depth, &leaves).expect("new");
@@ -424,9 +418,9 @@ mod tests {
     fn prefix_built_proof_matches_circuits_full_tree() {
         let depth = 4u32;
         let leaves = [
-            AppField::try_from_le_bytes([1u8; 32]).expect("field"),
-            AppField::try_from_le_bytes([2u8; 32]).expect("field"),
-            AppField::try_from_le_bytes([3u8; 32]).expect("field"),
+            Field::try_from_le_bytes([1u8; 32]).expect("field"),
+            Field::try_from_le_bytes([2u8; 32]).expect("field"),
+            Field::try_from_le_bytes([3u8; 32]).expect("field"),
         ];
 
         let tree = MerklePrefixTree::new(depth, &leaves)
@@ -435,19 +429,20 @@ mod tests {
 
         let mut zero_leaf_be = crypto::zero_leaf();
         zero_leaf_be.reverse();
-        let zero = bytes_to_scalar(&zero_leaf_be).expect("zero");
+        let zero_leaf_le: [u8; 32] = zero_leaf_be.try_into().expect("zero");
+        let zero = Field::try_from_le_bytes(zero_leaf_le).expect("zero");
 
         let depth_usize = usize::try_from(depth).expect("depth");
         let expected_leaves = 1usize << depth_usize;
-        let mut full: Vec<Scalar> = vec![zero; expected_leaves];
+        let mut full: Vec<Scalar> = vec![field_to_scalar(zero); expected_leaves];
         for (i, leaf) in leaves.iter().enumerate() {
-            full[i] = bytes_to_scalar(&leaf.to_le_bytes()).expect("leaf scalar");
+            full[i] = field_to_scalar(*leaf);
         }
 
         let root_scalar = circuits::core::merkle::merkle_root(full.clone());
         let root_le = scalar_to_bytes(&root_scalar);
         let root_le: [u8; 32] = root_le.try_into().expect("32");
-        let root_field = AppField::try_from_le_bytes(root_le).expect("field");
+        let root_field = Field::try_from_le_bytes(root_le).expect("field");
         assert_eq!(tree.root().expect("root"), root_field);
 
         for idx in 0..leaves.len() {
@@ -465,14 +460,7 @@ mod tests {
             let proof_indices = u64::from_le_bytes(proof_indices);
             assert_eq!(proof_indices, indices, "indices mismatch at idx={idx}");
 
-            let expected_path: Vec<AppField> = path
-                .into_iter()
-                .map(|s| {
-                    let le = scalar_to_bytes(&s);
-                    let le: [u8; 32] = le.try_into().expect("32");
-                    AppField::try_from_le_bytes(le).expect("field")
-                })
-                .collect();
+            let expected_path: Vec<Field> = path.into_iter().map(scalar_to_field).collect();
             assert_eq!(
                 proof.path_elements, expected_path,
                 "path mismatch at idx={idx}"

--- a/app/crates/core/prover/src/merkle.rs
+++ b/app/crates/core/prover/src/merkle.rs
@@ -223,79 +223,6 @@ impl MerklePrefixTree {
         Ok(nodes.first().copied().unwrap_or(self.empty[self.depth]))
     }
 
-    /// Compute a Merkle proof for `index`, returning:
-    /// - `path_elements`: sibling node values as 32-byte little-endian field
-    ///   bytes
-    /// - `path_indices`: packed path bits as a 32-byte little-endian scalar
-    ///
-    /// `index` must be `< leaf_count()`.
-    pub fn proof_bytes(&self, index: u32) -> Result<(Vec<[u8; 32]>, [u8; 32])> {
-        let idx_usize = usize::try_from(index).map_err(|_| anyhow!("index too large"))?;
-        if idx_usize >= self.leaves.len() {
-            return Err(anyhow!(
-                "leaf index out of range: index={}, leaves={}",
-                idx_usize,
-                self.leaves.len()
-            ));
-        }
-
-        let mut level_nodes = self.leaves.clone();
-        let mut index = idx_usize;
-
-        let mut path_elements = Vec::with_capacity(self.depth);
-        let mut path_indices_bits_lsb = Vec::with_capacity(self.depth);
-
-        for level in 0..self.depth {
-            let sib_index = if index.is_multiple_of(2) {
-                index
-                    .checked_add(1)
-                    .ok_or_else(|| anyhow!("sibling index overflow"))?
-            } else {
-                index
-                    .checked_sub(1)
-                    .ok_or_else(|| anyhow!("sibling index underflow"))?
-            };
-
-            let sib = level_nodes
-                .get(sib_index)
-                .copied()
-                .unwrap_or(self.empty[level]);
-            path_elements.push(sib.to_le_bytes());
-            path_indices_bits_lsb.push((index & 1) as u64);
-
-            if level_nodes.is_empty() {
-                level_nodes.push(self.empty[level]);
-            }
-            let level_len = level_nodes.len();
-            let next_len = level_len.div_ceil(2);
-            let mut next = Vec::with_capacity(next_len);
-            for i in 0..next_len {
-                let left_idx = i.checked_mul(2).expect("index overflow");
-                let right_idx = left_idx.checked_add(1).expect("index overflow");
-                let left = level_nodes
-                    .get(left_idx)
-                    .copied()
-                    .unwrap_or(self.empty[level]);
-                let right = level_nodes
-                    .get(right_idx)
-                    .copied()
-                    .unwrap_or(self.empty[level]);
-                next.push(hash_pair(left, right));
-            }
-            level_nodes = next;
-            index /= 2;
-        }
-
-        let mut path_indices: u64 = 0;
-        for (i, b) in path_indices_bits_lsb.into_iter().enumerate() {
-            path_indices |= b << i;
-        }
-
-        let mut idx_le = [0u8; 32];
-        idx_le[..8].copy_from_slice(&path_indices.to_le_bytes());
-
-        Ok((path_elements, idx_le))
-    }
 }
 
 impl MerklePrefixTreeBuilt {
@@ -361,19 +288,7 @@ impl MerklePrefixTreeBuilt {
         })
     }
 
-    /// Compute a pool-witness compatible Merkle proof for `index`.
-    ///
-    /// `index` must be `< leaf_count()`.
-    pub fn proof_bytes(&self, index: u32) -> Result<(Vec<[u8; 32]>, [u8; 32])> {
-        let proof = self.proof(index)?;
 
-        let mut out_elems = Vec::with_capacity(proof.path_elements.len());
-        for elem in proof.path_elements {
-            out_elems.push(elem.to_le_bytes());
-        }
-
-        Ok((out_elems, proof.path_indices.to_le_bytes()))
-    }
 }
 
 #[cfg(test)]
@@ -397,23 +312,7 @@ mod tests {
         assert_eq!(tree.root().expect("root"), built.root().expect("root"));
     }
 
-    #[test]
-    fn prefix_built_proof_bytes_matches_prefix_proof_bytes() {
-        let depth = 6u32;
-        let leaves: Vec<Field> = (0u8..15u8)
-            .map(|v| Field::try_from_le_bytes([v; 32]).expect("field"))
-            .collect();
 
-        let tree = MerklePrefixTree::new(depth, &leaves).expect("new");
-        let built = tree.build();
-
-        for idx in [0u32, 1u32, 2u32, 7u32, 14u32] {
-            let (a_elems, a_idx) = tree.proof_bytes(idx).expect("proof");
-            let (b_elems, b_idx) = built.proof_bytes(idx).expect("proof");
-            assert_eq!(a_elems, b_elems, "path elems mismatch at idx={idx}");
-            assert_eq!(a_idx, b_idx, "path idx mismatch at idx={idx}");
-        }
-    }
 
     #[test]
     fn prefix_built_proof_matches_circuits_full_tree() {

--- a/app/crates/core/prover/src/merkle.rs
+++ b/app/crates/core/prover/src/merkle.rs
@@ -380,6 +380,7 @@ impl MerklePrefixTreeBuilt {
 mod tests {
     use super::*;
     use alloc::vec;
+    use zkhash::ark_ff::{BigInteger, Zero};
 
     #[test]
     fn prefix_built_root_matches_prefix_root() {
@@ -466,5 +467,50 @@ mod tests {
                 "path mismatch at idx={idx}"
             );
         }
+    }
+
+    #[test]
+    fn field_to_scalar_roundtrip_zero_and_one() {
+        let zero = Field::ZERO;
+        let one = Field::ONE;
+
+        assert_eq!(field_to_scalar(zero), Scalar::from(0u64));
+        assert_eq!(field_to_scalar(one), Scalar::from(1u64));
+    }
+
+    #[test]
+    fn field_to_scalar_roundtrip_modulus_minus_one() {
+        let mut modulus_le = Scalar::MODULUS.to_bytes_le();
+        let mut borrow = 1u8;
+        for byte in &mut modulus_le {
+            if *byte >= borrow {
+                *byte -= borrow;
+                borrow = 0;
+                break;
+            } else {
+                *byte = 0xFF;
+                borrow = 1;
+            }
+        }
+        assert_eq!(borrow, 0, "modulus should be > 0");
+
+        let scalar = Scalar::from_le_bytes_mod_order(&modulus_le);
+        let field = scalar_to_field(scalar);
+
+        assert_eq!(field_to_scalar(field), scalar);
+    }
+
+    #[test]
+    fn field_to_scalar_modulus_reduces_to_zero() {
+        let modulus_le = Scalar::MODULUS.to_bytes_le();
+        let modulus_le: [u8; 32] = modulus_le
+            .try_into()
+            .expect("modulus bytes should be 32 bytes");
+        let reduced = Scalar::from_le_bytes_mod_order(&modulus_le);
+
+        assert!(reduced.is_zero());
+
+        let field = scalar_to_field(reduced);
+        assert_eq!(field_to_scalar(field), Scalar::from(0u64));
     }
 }

--- a/app/crates/core/prover/src/sparse_merkle.rs
+++ b/app/crates/core/prover/src/sparse_merkle.rs
@@ -418,7 +418,7 @@ impl WasmSparseMerkleTree {
     }
 
     /// Get a proof for a key, padded to max_levels
-    pub fn get_proof(&self, key_bytes: &[u8], max_levels: usize) -> Result<WasmSMTProof> {
+    pub fn get_proof(&self, key_bytes: &[u8], max_levels: usize) -> Result<SMTProof> {
         let key = bytes_to_field(key_bytes)?;
 
         let find_result = self.inner.find(&key).map_err(|e| anyhow!(e))?;
@@ -429,7 +429,7 @@ impl WasmSparseMerkleTree {
             siblings.push(Field::ZERO);
         }
 
-        Ok(WasmSMTProof {
+        Ok(SMTProof {
             found: find_result.found,
             siblings: siblings.iter().flat_map(|s| s.to_le_bytes()).collect(),
             found_value: find_result.found_value.to_le_bytes().to_vec(),
@@ -606,7 +606,7 @@ fn bytes_to_field(bytes: &[u8]) -> Result<Field> {
 }
 
 /// SMT Proof for circuit inputs
-pub struct WasmSMTProof {
+pub struct SMTProof {
     found: bool,
     siblings: Vec<u8>,
     found_value: Vec<u8>,
@@ -617,7 +617,7 @@ pub struct WasmSMTProof {
     num_siblings: usize,
 }
 
-impl WasmSMTProof {
+impl SMTProof {
     /// Whether the key was found
     pub fn found(&self) -> bool {
         self.found

--- a/app/crates/core/prover/src/sparse_merkle.rs
+++ b/app/crates/core/prover/src/sparse_merkle.rs
@@ -14,7 +14,7 @@ use zkhash::{ark_ff::PrimeField, fields::bn256::FpBN256 as Scalar};
 
 use crate::{
     crypto::{poseidon2_compression, poseidon2_hash2_internal},
-    serialization::{scalar_to_bytes},
+    serialization::scalar_to_bytes,
 };
 use types::Field;
 

--- a/app/crates/core/prover/src/sparse_merkle.rs
+++ b/app/crates/core/prover/src/sparse_merkle.rs
@@ -14,16 +14,35 @@ use zkhash::{ark_ff::PrimeField, fields::bn256::FpBN256 as Scalar};
 
 use crate::{
     crypto::{poseidon2_compression, poseidon2_hash2_internal},
-    serialization::{bytes_to_scalar, scalar_to_bytes},
+    serialization::{scalar_to_bytes},
 };
+use types::Field;
 
 /// Poseidon2 hash for leaf nodes: Poseidon2(key, value, domain=1)
-fn poseidon2_hash_leaf(key: Scalar, value: Scalar) -> Scalar {
-    poseidon2_hash2_internal(key, value, Some(Scalar::from(1u64)))
+fn poseidon2_hash_leaf(key: Field, value: Field) -> Field {
+    let key_s = field_to_scalar(key);
+    let value_s = field_to_scalar(value);
+    let hashed = poseidon2_hash2_internal(key_s, value_s, Some(Scalar::from(1u64)));
+    scalar_to_field(hashed)
 }
 
-/// Split a scalar into 256 bits (LSB first)
-fn scalar_to_bits(scalar: &Scalar) -> Vec<bool> {
+fn field_to_scalar(field: Field) -> Scalar {
+    Scalar::from_le_bytes_mod_order(&field.to_le_bytes())
+}
+
+fn scalar_to_field(scalar: Scalar) -> Field {
+    let le = scalar_to_bytes(&scalar);
+    let le: [u8; 32] = le.try_into().expect("scalar bytes length");
+    Field::try_from_le_bytes(le).expect("scalar to field conversion")
+}
+
+fn field_to_key(field: &Field) -> [u8; 32] {
+    field.to_le_bytes()
+}
+
+/// Split a field element into 256 bits (LSB first)
+fn field_to_bits(field: &Field) -> Vec<bool> {
+    let scalar = field_to_scalar(*field);
     let bigint = scalar.into_bigint();
     let mut bits = Vec::with_capacity(256);
 
@@ -43,9 +62,9 @@ enum Node {
     /// Empty node (represents zero)
     Empty,
     /// Leaf node containing (key, value)
-    Leaf { key: Scalar, value: Scalar },
+    Leaf { key: Field, value: Field },
     /// Internal node containing (left_child_hash, right_child_hash)
-    Internal { left: Scalar, right: Scalar },
+    Internal { left: Field, right: Field },
 }
 
 /// Result of SMT find operation
@@ -54,13 +73,13 @@ pub struct FindResult {
     /// Whether the key was found
     pub found: bool,
     /// Sibling hashes along the path
-    pub siblings: Vec<Scalar>,
+    pub siblings: Vec<Field>,
     /// The found value (if found)
-    pub found_value: Scalar,
+    pub found_value: Field,
     /// The key that was not found (for collision detection)
-    pub not_found_key: Scalar,
+    pub not_found_key: Field,
     /// The value at collision (if not found)
-    pub not_found_value: Scalar,
+    pub not_found_value: Field,
     /// Whether the path ended at zero
     pub is_old0: bool,
 }
@@ -69,19 +88,19 @@ pub struct FindResult {
 #[derive(Clone, Debug)]
 pub struct SMTResult {
     /// The old root before the operation
-    pub old_root: Scalar,
+    pub old_root: Field,
     /// The new root after the operation
-    pub new_root: Scalar,
+    pub new_root: Field,
     /// Sibling hashes along the path
-    pub siblings: Vec<Scalar>,
+    pub siblings: Vec<Field>,
     /// The old key
-    pub old_key: Scalar,
+    pub old_key: Field,
     /// The old value
-    pub old_value: Scalar,
+    pub old_value: Field,
     /// The new key
-    pub new_key: Scalar,
+    pub new_key: Field,
     /// The new value
-    pub new_value: Scalar,
+    pub new_value: Field,
     /// Whether the old value was zero
     pub is_old0: bool,
 }
@@ -91,7 +110,7 @@ pub struct SparseMerkleTree {
     /// Database storing nodes by their hash
     db: BTreeMap<[u8; 32], Node>,
     /// Current root hash
-    root: Scalar,
+    root: Field,
 }
 
 impl Default for SparseMerkleTree {
@@ -105,41 +124,38 @@ impl SparseMerkleTree {
     pub fn new() -> Self {
         SparseMerkleTree {
             db: BTreeMap::new(),
-            root: Scalar::from(0u64),
+            root: Field::ZERO,
         }
     }
 
     /// Get the current root
-    pub fn root(&self) -> Scalar {
+    pub fn root(&self) -> Field {
         self.root
     }
 
-    /// Convert scalar to bytes for use as BTreeMap key
-    fn scalar_to_key(s: &Scalar) -> [u8; 32] {
-        let mut key = [0u8; 32];
-        let bytes = scalar_to_bytes(s);
-        key.copy_from_slice(&bytes);
-        key
+    /// Convert field to bytes for use as BTreeMap key
+    fn field_to_key(s: &Field) -> [u8; 32] {
+        field_to_key(s)
     }
 
     /// Get a node from the database
-    fn get_node(&self, hash: &Scalar) -> Option<&Node> {
-        if *hash == Scalar::from(0u64) {
+    fn get_node(&self, hash: &Field) -> Option<&Node> {
+        if *hash == Field::ZERO {
             return Some(&Node::Empty);
         }
-        self.db.get(&Self::scalar_to_key(hash))
+        self.db.get(&Self::field_to_key(hash))
     }
 
     /// Store a node in the database
-    fn put_node(&mut self, hash: Scalar, node: Node) {
-        if hash != Scalar::from(0u64) {
-            self.db.insert(Self::scalar_to_key(&hash), node);
+    fn put_node(&mut self, hash: Field, node: Node) {
+        if hash != Field::ZERO {
+            self.db.insert(Self::field_to_key(&hash), node);
         }
     }
 
     /// Find a key in the tree
-    pub fn find(&self, key: &Scalar) -> Result<FindResult, &'static str> {
-        let key_bits = scalar_to_bits(key);
+    pub fn find(&self, key: &Field) -> Result<FindResult, &'static str> {
+        let key_bits = field_to_bits(key);
         let mut result = self.find_internal(key, &key_bits, &self.root, 0)?;
         result.siblings.reverse();
         Ok(result)
@@ -147,22 +163,22 @@ impl SparseMerkleTree {
 
     fn find_internal(
         &self,
-        key: &Scalar,
+        key: &Field,
         key_bits: &[bool],
-        current_hash: &Scalar,
+        current_hash: &Field,
         level: usize,
     ) -> Result<FindResult, &'static str> {
         if level >= 256 {
             return Err("Maximum tree depth exceeded");
         }
 
-        if *current_hash == Scalar::from(0u64) {
+        if *current_hash == Field::ZERO {
             return Ok(FindResult {
                 found: false,
                 siblings: Vec::new(),
-                found_value: Scalar::from(0u64),
+                found_value: Field::ZERO,
                 not_found_key: *key,
-                not_found_value: Scalar::from(0u64),
+                not_found_value: Field::ZERO,
                 is_old0: true,
             });
         }
@@ -177,15 +193,15 @@ impl SparseMerkleTree {
                         found: true,
                         siblings: Vec::new(),
                         found_value: *leaf_value,
-                        not_found_key: Scalar::from(0u64),
-                        not_found_value: Scalar::from(0u64),
+                        not_found_key: Field::ZERO,
+                        not_found_value: Field::ZERO,
                         is_old0: false,
                     })
                 } else {
                     Ok(FindResult {
                         found: false,
                         siblings: Vec::new(),
-                        found_value: Scalar::from(0u64),
+                        found_value: Field::ZERO,
                         not_found_key: *leaf_key,
                         not_found_value: *leaf_value,
                         is_old0: false,
@@ -209,9 +225,9 @@ impl SparseMerkleTree {
             Some(Node::Empty) => Ok(FindResult {
                 found: false,
                 siblings: Vec::new(),
-                found_value: Scalar::from(0u64),
+                found_value: Field::ZERO,
                 not_found_key: *key,
-                not_found_value: Scalar::from(0u64),
+                not_found_value: Field::ZERO,
                 is_old0: true,
             }),
             None => Err("Node not found in database"),
@@ -219,7 +235,7 @@ impl SparseMerkleTree {
     }
 
     /// Insert a key-value pair
-    pub fn insert(&mut self, key: &Scalar, value: &Scalar) -> Result<SMTResult, &'static str> {
+    pub fn insert(&mut self, key: &Field, value: &Field) -> Result<SMTResult, &'static str> {
         let find_result = self.find(key)?;
 
         if find_result.found {
@@ -227,7 +243,7 @@ impl SparseMerkleTree {
         }
 
         let old_root = self.root;
-        let key_bits = scalar_to_bits(key);
+        let key_bits = field_to_bits(key);
 
         // Create the new leaf
         let new_leaf_hash = poseidon2_hash_leaf(*key, *value);
@@ -246,12 +262,12 @@ impl SparseMerkleTree {
         // If there's a collision (not_found_key != 0 and is_old0 == false), we need to
         // extend the path
         if !find_result.is_old0 {
-            let old_key_bits = scalar_to_bits(&find_result.not_found_key);
+            let old_key_bits = field_to_bits(&find_result.not_found_key);
 
             // Find where the paths diverge
             let mut diverge_level = siblings.len();
             while diverge_level < 256 && old_key_bits[diverge_level] == key_bits[diverge_level] {
-                siblings.push(Scalar::from(0u64));
+                siblings.push(Field::ZERO);
                 diverge_level = diverge_level.saturating_add(1);
             }
 
@@ -269,7 +285,7 @@ impl SparseMerkleTree {
                 (current_hash, *sibling)
             };
 
-            current_hash = poseidon2_compression(left, right);
+            current_hash = smt_hash_pair_field(left, right);
             self.put_node(current_hash, Node::Internal { left, right });
         }
 
@@ -277,7 +293,7 @@ impl SparseMerkleTree {
 
         // Trim trailing zeros from siblings for the result
         let mut result_siblings = siblings;
-        while result_siblings.last() == Some(&Scalar::from(0u64)) {
+        while result_siblings.last() == Some(&Field::ZERO) {
             result_siblings.pop();
         }
         // Remove the collision leaf if we added one
@@ -298,7 +314,7 @@ impl SparseMerkleTree {
     }
 
     /// Update a key's value
-    pub fn update(&mut self, key: &Scalar, new_value: &Scalar) -> Result<SMTResult, &'static str> {
+    pub fn update(&mut self, key: &Field, new_value: &Field) -> Result<SMTResult, &'static str> {
         let find_result = self.find(key)?;
 
         if !find_result.found {
@@ -307,7 +323,7 @@ impl SparseMerkleTree {
 
         let old_root = self.root;
         let old_value = find_result.found_value;
-        let key_bits = scalar_to_bits(key);
+        let key_bits = field_to_bits(key);
 
         // Create the new leaf
         let new_leaf_hash = poseidon2_hash_leaf(*key, *new_value);
@@ -328,7 +344,7 @@ impl SparseMerkleTree {
                 (current_hash, *sibling)
             };
 
-            current_hash = poseidon2_compression(left, right);
+            current_hash = smt_hash_pair_field(left, right);
             self.put_node(current_hash, Node::Internal { left, right });
         }
 
@@ -362,7 +378,7 @@ impl WasmSparseMerkleTree {
 
     /// Get the current root as bytes (32 bytes, Little-Endian)
     pub fn root(&self) -> Vec<u8> {
-        scalar_to_bytes(&self.inner.root())
+        self.inner.root().to_le_bytes().to_vec()
     }
 
     /// Insert a key-value pair into the tree
@@ -371,8 +387,8 @@ impl WasmSparseMerkleTree {
     /// * `key_bytes` - Key as 32 bytes (Little-Endian)
     /// * `value_bytes` - Value as 32 bytes (Little-Endian)
     pub fn insert(&mut self, key_bytes: &[u8], value_bytes: &[u8]) -> Result<WasmSMTResult> {
-        let key = bytes_to_scalar(key_bytes)?;
-        let value = bytes_to_scalar(value_bytes)?;
+        let key = bytes_to_field(key_bytes)?;
+        let value = bytes_to_field(value_bytes)?;
 
         let result = self.inner.insert(&key, &value).map_err(|e| anyhow!(e))?;
 
@@ -381,8 +397,8 @@ impl WasmSparseMerkleTree {
 
     /// Update a key's value in the tree
     pub fn update(&mut self, key_bytes: &[u8], new_value_bytes: &[u8]) -> Result<WasmSMTResult> {
-        let key = bytes_to_scalar(key_bytes)?;
-        let new_value = bytes_to_scalar(new_value_bytes)?;
+        let key = bytes_to_field(key_bytes)?;
+        let new_value = bytes_to_field(new_value_bytes)?;
 
         let result = self
             .inner
@@ -394,7 +410,7 @@ impl WasmSparseMerkleTree {
 
     /// Find a key in the tree and get a membership/non-membership proof
     pub fn find(&self, key_bytes: &[u8]) -> Result<WasmFindResult> {
-        let key = bytes_to_scalar(key_bytes)?;
+        let key = bytes_to_field(key_bytes)?;
 
         let result = self.inner.find(&key).map_err(|e| anyhow!(e))?;
 
@@ -403,24 +419,24 @@ impl WasmSparseMerkleTree {
 
     /// Get a proof for a key, padded to max_levels
     pub fn get_proof(&self, key_bytes: &[u8], max_levels: usize) -> Result<WasmSMTProof> {
-        let key = bytes_to_scalar(key_bytes)?;
+        let key = bytes_to_field(key_bytes)?;
 
         let find_result = self.inner.find(&key).map_err(|e| anyhow!(e))?;
 
         // Pad siblings to max_levels
         let mut siblings = find_result.siblings.clone();
         while siblings.len() < max_levels {
-            siblings.push(Scalar::from(0u64));
+            siblings.push(Field::ZERO);
         }
 
         Ok(WasmSMTProof {
             found: find_result.found,
-            siblings: siblings.iter().flat_map(scalar_to_bytes).collect(),
-            found_value: scalar_to_bytes(&find_result.found_value),
-            not_found_key: scalar_to_bytes(&find_result.not_found_key),
-            not_found_value: scalar_to_bytes(&find_result.not_found_value),
+            siblings: siblings.iter().flat_map(|s| s.to_le_bytes()).collect(),
+            found_value: find_result.found_value.to_le_bytes().to_vec(),
+            not_found_key: find_result.not_found_key.to_le_bytes().to_vec(),
+            not_found_value: find_result.not_found_value.to_le_bytes().to_vec(),
             is_old0: find_result.is_old0,
-            root: scalar_to_bytes(&self.inner.root()),
+            root: self.inner.root().to_le_bytes().to_vec(),
             num_siblings: siblings.len(),
         })
     }
@@ -495,13 +511,13 @@ impl WasmSMTResult {
 impl WasmSMTResult {
     fn from_result(r: &SMTResult) -> Self {
         WasmSMTResult {
-            old_root: scalar_to_bytes(&r.old_root),
-            new_root: scalar_to_bytes(&r.new_root),
-            siblings: r.siblings.iter().flat_map(scalar_to_bytes).collect(),
-            old_key: scalar_to_bytes(&r.old_key),
-            old_value: scalar_to_bytes(&r.old_value),
-            new_key: scalar_to_bytes(&r.new_key),
-            new_value: scalar_to_bytes(&r.new_value),
+            old_root: r.old_root.to_le_bytes().to_vec(),
+            new_root: r.new_root.to_le_bytes().to_vec(),
+            siblings: r.siblings.iter().flat_map(|s| s.to_le_bytes()).collect(),
+            old_key: r.old_key.to_le_bytes().to_vec(),
+            old_value: r.old_value.to_le_bytes().to_vec(),
+            new_key: r.new_key.to_le_bytes().to_vec(),
+            new_value: r.new_value.to_le_bytes().to_vec(),
             is_old0: r.is_old0,
             num_siblings: r.siblings.len(),
         }
@@ -563,18 +579,30 @@ impl WasmFindResult {
 }
 
 impl WasmFindResult {
-    fn from_result(r: &FindResult, root: &Scalar) -> Self {
+    fn from_result(r: &FindResult, root: &Field) -> Self {
         WasmFindResult {
             found: r.found,
-            siblings: r.siblings.iter().flat_map(scalar_to_bytes).collect(),
-            found_value: scalar_to_bytes(&r.found_value),
-            not_found_key: scalar_to_bytes(&r.not_found_key),
-            not_found_value: scalar_to_bytes(&r.not_found_value),
+            siblings: r.siblings.iter().flat_map(|s| s.to_le_bytes()).collect(),
+            found_value: r.found_value.to_le_bytes().to_vec(),
+            not_found_key: r.not_found_key.to_le_bytes().to_vec(),
+            not_found_value: r.not_found_value.to_le_bytes().to_vec(),
             is_old0: r.is_old0,
-            root: scalar_to_bytes(root),
+            root: root.to_le_bytes().to_vec(),
             num_siblings: r.siblings.len(),
         }
     }
+}
+
+fn smt_hash_pair_field(left: Field, right: Field) -> Field {
+    let left_s = field_to_scalar(left);
+    let right_s = field_to_scalar(right);
+    let hashed = poseidon2_compression(left_s, right_s);
+    scalar_to_field(hashed)
+}
+
+fn bytes_to_field(bytes: &[u8]) -> Result<Field> {
+    let arr: [u8; 32] = bytes.try_into().map_err(|_| anyhow!("expected 32 bytes"))?;
+    Field::try_from_le_bytes(arr)
 }
 
 /// SMT Proof for circuit inputs
@@ -633,16 +661,16 @@ impl WasmSMTProof {
 
 /// Compute Poseidon2 compression hash of two field elements
 pub fn smt_hash_pair(left: &[u8], right: &[u8]) -> Result<Vec<u8>> {
-    let l = bytes_to_scalar(left)?;
-    let r = bytes_to_scalar(right)?;
-    let result = poseidon2_compression(l, r);
-    Ok(scalar_to_bytes(&result))
+    let l = bytes_to_field(left)?;
+    let r = bytes_to_field(right)?;
+    let result = smt_hash_pair_field(l, r);
+    Ok(result.to_le_bytes().to_vec())
 }
 
 /// Compute Poseidon2 hash for leaf nodes: hash(key, value, 1)
 pub fn smt_hash_leaf(key: &[u8], value: &[u8]) -> Result<Vec<u8>> {
-    let k = bytes_to_scalar(key)?;
-    let v = bytes_to_scalar(value)?;
+    let k = bytes_to_field(key)?;
+    let v = bytes_to_field(value)?;
     let result = poseidon2_hash_leaf(k, v);
-    Ok(scalar_to_bytes(&result))
+    Ok(result.to_le_bytes().to_vec())
 }

--- a/app/crates/platforms/web/src/workers/prover.rs
+++ b/app/crates/platforms/web/src/workers/prover.rs
@@ -178,17 +178,11 @@ fn prove_from_artifacts(transact_artifacts: TransactArtifacts) -> Result<Prepare
         }
 
         let p = transact_artifacts.prepared.clone();
-        let input_nullifiers = [
-            types::Field::try_from_le_bytes(p.input_nullifiers[0])?,
-            types::Field::try_from_le_bytes(p.input_nullifiers[1])?,
-        ];
-        let output_commitments = [
-            types::Field::try_from_le_bytes(p.output_commitments[0])?,
-            types::Field::try_from_le_bytes(p.output_commitments[1])?,
-        ];
-        let public_amount = types::Field::try_from_le_bytes(p.public_amount_field)?;
-        let asp_membership_root = types::Field::try_from_le_bytes(p.asp_membership_root)?;
-        let asp_non_membership_root = types::Field::try_from_le_bytes(p.asp_non_membership_root)?;
+        let input_nullifiers = p.input_nullifiers;
+        let output_commitments = p.output_commitments;
+        let public_amount = p.public_amount_field;
+        let asp_membership_root = p.asp_membership_root;
+        let asp_non_membership_root = p.asp_non_membership_root;
 
         let prepared_public = PreparedTxPublic {
             pool_root: p.pool_root,

--- a/app/crates/platforms/web/src/workers/prover.rs
+++ b/app/crates/platforms/web/src/workers/prover.rs
@@ -144,6 +144,7 @@ pub(crate) async fn router(req: ProverWorkerRequest) -> Result<ProverWorkerRespo
 
 fn prove_from_artifacts(transact_artifacts: TransactArtifacts) -> Result<PreparedProverTx> {
     let circuit_inputs_json = serde_json::to_string(&transact_artifacts.circuit_inputs)?;
+    let ext_data = transact_artifacts.ext_data.clone();
     log::debug!("[{WORKER_NAME}] compute witness");
     let witness_bytes = WITNESS_CALC.with(|cell| {
         let mut borrow = cell.borrow_mut();
@@ -177,21 +178,15 @@ fn prove_from_artifacts(transact_artifacts: TransactArtifacts) -> Result<Prepare
             ));
         }
 
-        let p = transact_artifacts.prepared.clone();
-        let input_nullifiers = p.input_nullifiers;
-        let output_commitments = p.output_commitments;
-        let public_amount = p.public_amount_field;
-        let asp_membership_root = p.asp_membership_root;
-        let asp_non_membership_root = p.asp_non_membership_root;
-
+        let p = transact_artifacts.prepared;
         let prepared_public = PreparedTxPublic {
             pool_root: p.pool_root,
-            input_nullifiers,
-            output_commitments,
-            public_amount,
+            input_nullifiers: p.input_nullifiers,
+            output_commitments: p.output_commitments,
+            public_amount: p.public_amount_field,
             ext_data_hash_be: p.ext_data_hash_be,
-            asp_membership_root,
-            asp_non_membership_root,
+            asp_membership_root: p.asp_membership_root,
+            asp_non_membership_root: p.asp_non_membership_root,
         };
 
         Ok::<_, anyhow::Error>((proof_uncompressed, prepared_public))
@@ -199,7 +194,7 @@ fn prove_from_artifacts(transact_artifacts: TransactArtifacts) -> Result<Prepare
 
     Ok(PreparedProverTx {
         proof_uncompressed,
-        ext_data: transact_artifacts.ext_data,
+        ext_data,
         prepared: prepared_public,
     })
 }

--- a/app/crates/platforms/web/src/workers/storage.rs
+++ b/app/crates/platforms/web/src/workers/storage.rs
@@ -636,6 +636,11 @@ fn build_pool_inputs(
             })?;
 
         let (path_elements, path_indices) = tree.proof_bytes(leaf_index)?;
+        let path_elements = path_elements
+            .into_iter()
+            .map(types::Field::try_from_le_bytes)
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let path_indices = types::Field::try_from_le_bytes(path_indices)?;
 
         out.push(TransactInputNote {
             amount_stroops: amount,

--- a/app/crates/platforms/web/src/workers/storage.rs
+++ b/app/crates/platforms/web/src/workers/storage.rs
@@ -635,12 +635,11 @@ fn build_pool_inputs(
                 anyhow::anyhow!("unspent note not found for commitment {}", commitment)
             })?;
 
-        let (path_elements, path_indices) = tree.proof_bytes(leaf_index)?;
-        let path_elements = path_elements
-            .into_iter()
-            .map(types::Field::try_from_le_bytes)
-            .collect::<anyhow::Result<Vec<_>>>()?;
-        let path_indices = types::Field::try_from_le_bytes(path_indices)?;
+        let MerkleProof {
+            path_elements,
+            path_indices,
+            ..
+        } = tree.proof(leaf_index)?;
 
         out.push(TransactInputNote {
             amount_stroops: amount,


### PR DESCRIPTION
Implements the changes described in issue https://github.com/NethermindEth/stellar-private-payments/issues/170

Summary of changes:
Structures now use `types::Field`  and use arkworks `Scalar` type only when needed for hashing. Also updated the Merkle Tree structures as well to use Field instead of Scalar.
Used standard circuit input encoding using `Field::to_le_bytes()`

- cargo test -p prover --tests  (all passed)
- cargo clippy passed
- cargo fmt applied

continued from pr https://github.com/NethermindEth/stellar-private-payments/pull/148