### PR TITLE
(chore) fix when user doesnt accept terms

### DIFF
--- a/app/js/ui/navigation.js
+++ b/app/js/ui/navigation.js
@@ -8,7 +8,7 @@ import { getHandle, initializeWasm } from '../wasm-facade.js';
 import { submitPublicKeyRegistration } from '../stellar.js';
 import { App, Utils, Toast } from './core.js';
 import { setTabsRef } from './templates.js';
-import { runOnboardingWizard } from './onboarding-wizard.js';
+import { isOnboardingCancelledError, runOnboardingWizard } from './onboarding-wizard.js';
 
 /**
  * Updates the disabled state of all submit buttons and disclaimers based on wallet connection.
@@ -72,7 +72,9 @@ export const Wallet = {
                 e.stopPropagation();
                 this.toggleDropdown();
             } else {
-                this.connect({ auto: false });
+                this.connect({ auto: false }).catch((err) => {
+                    if (!isOnboardingCancelledError(err)) console.error(err);
+                });
             }
         });
 
@@ -207,6 +209,10 @@ export const Wallet = {
             try {
                 await run();
             } catch (e) {
+                if (isOnboardingCancelledError(e)) {
+                    this.disconnect();
+                    return;
+                }
                 if (!auto) Toast.show(e?.message || 'Failed to connect wallet', 'error');
                 this.disconnect();
                 throw e;
@@ -317,7 +323,9 @@ export const Wallet = {
                     if (btn) btn.disabled = false;
                 }
             } catch (e) {
-                Toast.show(e?.message || 'Wallet changed; failed to re-onboard', 'error', 8000);
+                if (!isOnboardingCancelledError(e)) {
+                    Toast.show(e?.message || 'Wallet changed; failed to re-onboard', 'error', 8000);
+                }
                 this.disconnect();
             } finally {
                 const btn = document.getElementById('wallet-btn');

--- a/app/js/ui/onboarding-wizard.js
+++ b/app/js/ui/onboarding-wizard.js
@@ -3,6 +3,24 @@ import { deriveKeysFromWallet } from '../wallet.js';
 
 const STORAGE_PERSIST_FLAG = 'poolstellar_storage_persist_prompted';
 
+class OnboardingCancelledError extends Error {
+    constructor(message = 'Onboarding cancelled') {
+        super(message);
+        this.name = 'OnboardingCancelledError';
+    }
+}
+
+class TermsDeclinedError extends Error {
+    constructor(message = 'Terms & Conditions must be accepted to use this service.') {
+        super(message);
+        this.name = 'TermsDeclinedError';
+    }
+}
+
+export function isOnboardingCancelledError(e) {
+    return !!e && (e.name === 'OnboardingCancelledError' || e instanceof OnboardingCancelledError);
+}
+
 function hasStorageManager() {
     return (
         typeof navigator !== 'undefined' &&
@@ -293,15 +311,17 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
         renderStepContent(wrap);
 
         await new Promise((resolve, reject) => {
-            const onAbort = () => reject(new Error('Onboarding cancelled'));
+            const onAbort = () => reject(new OnboardingCancelledError());
             abort.signal.addEventListener('abort', onAbort, { once: true });
 
             const decline = makeButton({
                 text: 'Decline',
                 variant: 'danger',
                 onClick: () => {
-                    onClose();
-                    reject(new Error('Terms & Conditions must be accepted to use this service.'));
+                    abort.signal.removeEventListener('abort', onAbort);
+                    cancelled = true;
+                    hideModal();
+                    reject(new TermsDeclinedError());
                 },
             });
             const accept = makeButton({
@@ -327,7 +347,7 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
             renderActions([decline, accept]);
         });
 
-        if (cancelled) throw new Error('Onboarding cancelled');
+        if (cancelled) throw new OnboardingCancelledError();
         setStepState('disclaimer', 'done');
     }
 
@@ -393,7 +413,7 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
             renderActions([notNow, enable]);
         });
 
-        if (cancelled) throw new Error('Onboarding cancelled');
+        if (cancelled) throw new OnboardingCancelledError();
         setStepState('storage', 'done');
     }
 
@@ -434,7 +454,7 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
         renderStepContent(wrap);
 
         await new Promise((resolve, reject) => {
-            const onAbort = () => reject(new Error('Onboarding cancelled'));
+            const onAbort = () => reject(new OnboardingCancelledError());
             abort.signal.addEventListener('abort', onAbort, { once: true });
 
             const deriveBtn = makeButton({
@@ -470,7 +490,7 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
             renderActions([deriveBtn]);
         });
 
-        if (cancelled) throw new Error('Onboarding cancelled');
+        if (cancelled) throw new OnboardingCancelledError();
         if (!keys) throw new Error('Privacy keys not ready yet. Please try again.');
         setStepState('keys', 'done');
     }


### PR DESCRIPTION
Current behaviour: If a user doesn't accept disclaimer terms on the onboading, then clicks connect wallet, then again decline - we see the error in console. It doesn't prevent a user from onboarding again, just we don't need to have an error in console.