### PR TITLE
Fix rustdoc warnings

### DIFF
--- a/app/crates/core/prover/src/r1cs.rs
+++ b/app/crates/core/prover/src/r1cs.rs
@@ -9,7 +9,7 @@
 //! - Sections for header info, constraints, and wire mappings
 //!
 //! # Reference
-//! https://github.com/iden3/r1csfile/blob/master/doc/r1cs_bin_format.md
+//! <https://github.com/iden3/r1csfile/blob/master/doc/r1cs_bin_format.md>
 
 use alloc::vec::Vec;
 

--- a/app/crates/core/stellar/src/conversions.rs
+++ b/app/crates/core/stellar/src/conversions.rs
@@ -31,7 +31,7 @@ pub fn scval_to_address_string(val: &xdr::ScVal) -> Result<String, Error> {
     }
 }
 
-/// Helper to convert ScVal Bytes to a Vec<u8>
+/// Helper to convert ScVal Bytes to a `Vec<u8>`
 pub fn scval_to_bytes(val: &xdr::ScVal) -> Result<Vec<u8>, Error> {
     if let xdr::ScVal::Bytes(sc_bytes) = val {
         Ok(sc_bytes.0.to_vec())

--- a/circuits/src/test/utils/circom_tester.rs
+++ b/circuits/src/test/utils/circom_tester.rs
@@ -112,7 +112,7 @@ impl Inputs {
         self.inner.insert(key.into(), value.into());
     }
 
-    /// Set using a SignalKey path (e.g., membershipProofs[0][0].leaf).
+    /// Set using a SignalKey path (e.g., membershipProofs\[0\]\[0\].leaf).
     pub fn set_key<V>(&mut self, key: &SignalKey, value: V)
     where
         V: Into<InputValue>,

--- a/circuits/src/test/utils/general.rs
+++ b/circuits/src/test/utils/general.rs
@@ -33,7 +33,7 @@ pub fn poseidon2_compression(left: Scalar, right: Scalar) -> Scalar {
 /// Poseidon2 hash of 2 field elements (t = 3, r=2, c=1)
 ///
 /// Performs a Poseidon2 permutation on two field elements with an optional
-/// domain separator, returning the first element (state[0]).
+/// domain separator, returning the first element (state\[0\]).
 ///
 /// # Arguments
 ///
@@ -43,7 +43,7 @@ pub fn poseidon2_compression(left: Scalar, right: Scalar) -> Scalar {
 ///
 /// # Returns
 ///
-/// Returns the first lane (state[0]) of the permutation result.
+/// Returns the first lane (state\[0\]) of the permutation result.
 pub fn poseidon2_hash2(a: Scalar, b: Scalar, dom_sep: Option<Scalar>) -> Scalar {
     let h = Poseidon2::new(&POSEIDON2_BN256_PARAMS_3);
     let perm: Vec<Scalar>;
@@ -58,7 +58,7 @@ pub fn poseidon2_hash2(a: Scalar, b: Scalar, dom_sep: Option<Scalar>) -> Scalar 
 /// Poseidon2 hash of 3 field elements (t = 4, r=3, c=1)
 ///
 /// Performs a Poseidon2 permutation on three field elements with an optional
-/// domain separator, returning the first element (state[0]).
+/// domain separator, returning the first element (state\[0\]).
 ///
 /// # Arguments
 ///
@@ -69,7 +69,7 @@ pub fn poseidon2_hash2(a: Scalar, b: Scalar, dom_sep: Option<Scalar>) -> Scalar 
 ///
 /// # Returns
 ///
-/// Returns the first element (state[0]) of the permutation result.
+/// Returns the first element (state\[0\]) of the permutation result.
 pub fn poseidon2_hash3(a: Scalar, b: Scalar, c: Scalar, dom_sep: Option<Scalar>) -> Scalar {
     let h = Poseidon2::new(&POSEIDON2_BN256_PARAMS_4);
     let perm: Vec<Scalar>;

--- a/circuits/src/test/utils/sparse_merkle_tree.rs
+++ b/circuits/src/test/utils/sparse_merkle_tree.rs
@@ -1,7 +1,7 @@
 //! Sparse Merkle Tree implementation compatible with circomlibjs/smt.js
 //!
 //! This is a Rust port of the Sparse Merkle Tree implementation from:
-//! - JavaScript: https://github.com/iden3/circomlibjs/blob/main/src/smt.js
+//! - JavaScript: <https://github.com/iden3/circomlibjs/blob/main/src/smt.js>
 //!
 //! This implementation uses Poseidon2 hash function for compatibility with
 //! circomlib circuits.

--- a/contracts/soroban-utils/src/utils.rs
+++ b/contracts/soroban-utils/src/utils.rs
@@ -105,7 +105,7 @@ pub fn g2_bytes_from_ark(p: ArkG2Affine) -> [u8; 128] {
 ///
 /// # Arguments
 /// * `env` - The Soroban environment
-/// * `vk` - The ark-groth16 VerifyingKey<Bn254>
+/// * `vk` - The ark-groth16 `VerifyingKey<Bn254>`
 ///
 /// # Returns
 /// A VerificationKeyBytes struct suitable for use with the


### PR DESCRIPTION
Fixes #199

## Changes
- Wrap generic types (`Vec<u8>`, `VerifyingKey<Bn254>`) in backticks in doc comments
- Escape bracket notation (`[0]` → `\[0\]`) to prevent unresolved link warnings
- Convert bare URLs to `<url>` format

## Verification
`cargo doc --no-deps --workspace --release` now produces zero rustdoc warnings.