### PR TITLE
Feature/selective disclosure circuit

### DIFF
--- a/circuits/build.rs
+++ b/circuits/build.rs
@@ -11,8 +11,8 @@
 //!
 //! To Build the test circuits use `BUILD_TESTS=1 cargo build`
 //!
-//! The script also generates Groth16 proving and verification
-//! keys for the main circuit (policy_tx_2_2) and outputs them to
+//! The script also generates Groth16 proving and verification keys for selected
+//! entry-point circuits (see `GROTH16_KEY_CIRCUITS` below) and outputs them to
 //! `testdata/`.
 //!
 //! The output directory is exposed as en environment variable
@@ -41,6 +41,19 @@ use std::{
 use type_analysis::check_types::check_types;
 
 const CURVE_ID: &str = "bn128";
+
+/// Circom stems whose Groth16 artifacts live under `testdata/`
+/// (`{stem}_proving_key.bin`, etc.). Append here when wiring a new entry-point
+/// through the same key-generation path.
+const GROTH16_KEY_CIRCUITS: &[&str] = &["policy_tx_2_2", "selectiveDisclosure_1"];
+
+/// `testdata/` filenames (`{stem}{suffix}`) that invalidate the build when
+/// changed.
+const GROTH16_TESTDATA_SUFFIXES: &[&str] = &["_proving_key.bin", "_vk.json", "_vk_soroban.bin"];
+
+fn circuit_needs_groth16_keys(name: &str) -> bool {
+    GROTH16_KEY_CIRCUITS.contains(&name)
+}
 
 fn publish_dir_path(crate_dir: &Path) -> Result<PathBuf> {
     let workspace_root = crate_dir.parent().unwrap_or(crate_dir);
@@ -113,18 +126,14 @@ fn main() -> Result<()> {
 
     // Rerun if testdata key files are missing or changed
     let testdata_dir = crate_dir.join("../testdata");
-    println!(
-        "cargo:rerun-if-changed={}",
-        testdata_dir.join("policy_tx_2_2_proving_key.bin").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        testdata_dir.join("policy_tx_2_2_vk.json").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        testdata_dir.join("policy_tx_2_2_vk_soroban.bin").display()
-    );
+    for stem in GROTH16_KEY_CIRCUITS {
+        for suffix in GROTH16_TESTDATA_SUFFIXES {
+            println!(
+                "cargo:rerun-if-changed={}",
+                testdata_dir.join(format!("{stem}{suffix}")).display()
+            );
+        }
+    }
 
     // === CIRCOMLIB DEPENDENCY ===
     // Import circomlib library (only if not already present) and pin it to the
@@ -253,8 +262,9 @@ fn main() -> Result<()> {
                     );
                 }
 
-                // Still check if we need to generate keys for policy_tx_2_2
-                if circuit_name == "policy_tx_2_2" && wasm_path.exists() {
+                // Still check if we need to generate keys for circuits that ship PK/VK under
+                // testdata/
+                if circuit_needs_groth16_keys(circuit_name.as_str()) && wasm_path.exists() {
                     match generate_keys_if_needed(&crate_dir, &out_dir, &circuit_name, &r1cs_file) {
                         Ok(_) => {}
                         Err(e) => {
@@ -339,8 +349,8 @@ fn main() -> Result<()> {
         }
 
         // === GROTH16 Proving/Verifying key generation ===
-        // For now we only generate keys for the policy_tx_2_2 circuit.
-        if circuit_name == "policy_tx_2_2" {
+        // policy_tx_2_2 and selectiveDisclosure_1 (must match `*.circom` file stem).
+        if circuit_needs_groth16_keys(circuit_name.as_str()) {
             if !wasm_success {
                 bail!(
                     "Skipping key generation for {} - WASM compilation failed",
@@ -1052,7 +1062,8 @@ fn check_keys_need_generation(
 ///
 /// * `crate_dir` - The circuits crate directory
 /// * `out_dir` - The output directory containing WASM files
-/// * `circuit_name` - Name of the circuit (e.g., "policy_tx_2_2")
+/// * `circuit_name` - Name of the circuit (e.g., `policy_tx_2_2`,
+///   `selectiveDisclosure_1`)
 /// * `r1cs_file` - Path to the R1CS file for freshness comparison
 ///
 /// # Returns

--- a/circuits/src/selectiveDisclosure.circom
+++ b/circuits/src/selectiveDisclosure.circom
@@ -1,0 +1,63 @@
+pragma circom 2.2.2;
+
+// Selective Disclosure Circuit
+include "./merkleProof.circom";
+include "./poseidon2/poseidon2_hash.circom";
+include "./keypair.circom";
+
+// Allows a user to demonstrate ownership of a note commitment without revealing its secrets
+// * levels: Number of levels in the Merkle tree that holds the note commitments
+// * nNotes: Number of notes to prove ownership of.
+// Right now we allow proving ownership of multiple notes on different roots BUT for the same external context:
+// - Purpose
+// - Authority 
+// - Pool address
+// So that you can prove multiple notes 
+template SelectiveDisclosure(levels, nNotes) {
+    /** PUBLIC INPUTS **/
+    signal input roots[nNotes];
+    signal input noteCommitments[nNotes];
+    signal input extContextHash;
+ 
+    
+    /** PRIVATE INPUTS **/
+    signal input inAmount[nNotes];
+    signal input inPrivateKey[nNotes];
+    signal input inBlinding[nNotes];
+    signal input inPathIndices[nNotes];
+    signal input inPathElements[nNotes][levels];
+    
+    // Components
+    component inKeypair[nNotes];
+    component inCommitmentHasher[nNotes];
+    component inTree[nNotes];
+    
+    for (var ni = 0; ni < nNotes; ni++) {
+        // Verify that the sender actually owns the inputs
+        // He knows the secret keys and the blinding factors.
+        inKeypair[ni] = Keypair();
+        inKeypair[ni].privateKey <== inPrivateKey[ni];
+        
+        // Computes the leaf commitment as hash(amount, publicKey, blinding)
+        inCommitmentHasher[ni] = Poseidon2(3);
+        inCommitmentHasher[ni].inputs[0] <== inAmount[ni];
+        inCommitmentHasher[ni].inputs[1] <== inKeypair[ni].publicKey;
+        inCommitmentHasher[ni].inputs[2] <== inBlinding[ni];
+        inCommitmentHasher[ni].domainSeparation <== 0x01; // Leaf commitment
+        
+        // Ensures it matches the claimed note
+        noteCommitments[ni] === inCommitmentHasher[ni].out;
+        
+        // Verifies the merkle proofs
+        inTree[ni] = MerkleProof(levels);
+        inTree[ni].leaf <== inCommitmentHasher[ni].out;
+        inTree[ni].pathIndices <== inPathIndices[ni];
+        for (var i = 0; i < levels; i++) {
+            inTree[ni].pathElements[i] <== inPathElements[ni][i];
+        }
+        // Ensure root matches the expected value
+        roots[ni] === inTree[ni].root;
+    }
+    // Safety constraint to bind external context 
+    signal extContextSquare <== extContextHash * extContextHash;   
+}

--- a/circuits/src/selectiveDisclosure_1.circom
+++ b/circuits/src/selectiveDisclosure_1.circom
@@ -1,0 +1,8 @@
+pragma circom 2.2.2;
+// Selective disclosure for a single note commitment.
+include "./selectiveDisclosure.circom";
+
+// SelectiveDisclosure(
+//   levels, nNotes
+// )
+component main {public [roots, noteCommitments, extContextHash]} = SelectiveDisclosure(10, 1);

--- a/circuits/src/test/mod.rs
+++ b/circuits/src/test/mod.rs
@@ -11,5 +11,6 @@ mod prove_sparse;
 
 mod prove_keypair;
 mod prove_policy;
+mod prove_selective_disclosure;
 mod prove_transaction;
 pub mod utils;

--- a/circuits/src/test/prove_selective_disclosure.rs
+++ b/circuits/src/test/prove_selective_disclosure.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::test::utils::{
-        circom_tester::{Inputs, generate_keys, prove_and_verify_with_keys},
+        circom_tester::{CircuitKeys, Inputs, generate_keys, prove_and_verify_with_keys},
         general::{load_artifacts, scalar_to_bigint},
         keypair::derive_public_key,
         merkle_tree::{merkle_proof, merkle_root},
@@ -9,7 +9,30 @@ mod tests {
     };
     use anyhow::{Context, Result};
     use num_bigint::BigInt;
+    use std::{
+        panic::{self, AssertUnwindSafe},
+        path::Path,
+    };
     use zkhash::fields::bn256::FpBN256 as Scalar;
+
+    /// Returns `true` when the prover produced a verifying proof for the given
+    /// inputs. Any other outcome (a returned `Err`, a `verified == false`
+    /// result, or a panic from the WASM witness calculator) counts as a
+    /// rejection and yields `false`, so negative tests can assert on this
+    /// uniformly regardless of which layer trips first.
+    /// This is needed because `arkworks` and `wasmer` might panic or return
+    /// depending on in which layer the error is found.
+    fn proof_verifies(
+        wasm: impl AsRef<Path>,
+        r1cs: impl AsRef<Path>,
+        inputs: &Inputs,
+        keys: &CircuitKeys,
+    ) -> bool {
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| {
+            prove_and_verify_with_keys(wasm.as_ref(), r1cs.as_ref(), inputs, keys)
+        }));
+        matches!(outcome, Ok(Ok(ref res)) if res.verified)
+    }
 
     const LEVELS: usize = 10;
     const EXT_CONTEXT_HASH: u64 = 0xC0FFEE_u64;
@@ -35,7 +58,10 @@ mod tests {
 
         let root = merkle_root(frozen.clone());
         let (siblings, path_idx_u64, depth) = merkle_proof(&frozen, note.leaf_index);
-        assert_eq!(depth, LEVELS, "unexpected Merkle depth: expected {LEVELS}, got {depth}");
+        assert_eq!(
+            depth, LEVELS,
+            "unexpected Merkle depth: expected {LEVELS}, got {depth}"
+        );
 
         let path_elements: Vec<BigInt> = siblings.into_iter().map(scalar_to_bigint).collect();
 
@@ -67,8 +93,8 @@ mod tests {
     #[test]
     #[ignore]
     fn test_selective_disclosure_valid_note() -> Result<()> {
-        let (wasm, r1cs) =
-            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let (wasm, r1cs) = load_artifacts("selectiveDisclosure_1")
+            .expect("Cannot find selectiveDisclosure_1 artifacts");
         let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
 
         let note = sample_note(7);
@@ -82,10 +108,9 @@ mod tests {
 
     #[test]
     #[ignore]
-    #[should_panic]
     fn test_selective_disclosure_wrong_private_key_fails() {
-        let (wasm, r1cs) =
-            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let (wasm, r1cs) = load_artifacts("selectiveDisclosure_1")
+            .expect("Cannot find selectiveDisclosure_1 artifacts");
         let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
 
         let note = sample_note(14);
@@ -94,15 +119,17 @@ mod tests {
             build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
         inputs.set("inPrivateKey", vec![Scalar::from(9999u64)]);
 
-        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+        assert!(
+            !proof_verifies(&wasm, &r1cs, &inputs, &keys),
+            "Wrong private key case unexpectedly verified; expected rejection"
+        );
     }
 
     #[test]
     #[ignore]
-    #[should_panic]
     fn test_selective_disclosure_wrong_amount_fails() {
-        let (wasm, r1cs) =
-            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let (wasm, r1cs) = load_artifacts("selectiveDisclosure_1")
+            .expect("Cannot find selectiveDisclosure_1 artifacts");
         let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
 
         let note = sample_note(18);
@@ -111,15 +138,17 @@ mod tests {
             build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
         inputs.set("inAmount", vec![Scalar::from(9999u64)]);
 
-        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+        assert!(
+            !proof_verifies(&wasm, &r1cs, &inputs, &keys),
+            "Wrong amount case unexpectedly verified; expected rejection"
+        );
     }
 
     #[test]
     #[ignore]
-    #[should_panic]
     fn test_selective_disclosure_wrong_blinding_fails() {
-        let (wasm, r1cs) =
-            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let (wasm, r1cs) = load_artifacts("selectiveDisclosure_1")
+            .expect("Cannot find selectiveDisclosure_1 artifacts");
         let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
 
         let note = sample_note(25);
@@ -128,15 +157,17 @@ mod tests {
             build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
         inputs.set("inBlinding", vec![Scalar::from(8888u64)]);
 
-        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+        assert!(
+            !proof_verifies(&wasm, &r1cs, &inputs, &keys),
+            "Wrong blinding case unexpectedly verified; expected rejection"
+        );
     }
 
     #[test]
     #[ignore]
-    #[should_panic]
     fn test_selective_disclosure_wrong_path_fails() {
-        let (wasm, r1cs) =
-            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let (wasm, r1cs) = load_artifacts("selectiveDisclosure_1")
+            .expect("Cannot find selectiveDisclosure_1 artifacts");
         let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
 
         let note = sample_note(21);
@@ -146,15 +177,17 @@ mod tests {
         let zeros: Vec<BigInt> = (0..LEVELS).map(|_| BigInt::from(0u32)).collect();
         inputs.set("inPathElements", zeros);
 
-        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+        assert!(
+            !proof_verifies(&wasm, &r1cs, &inputs, &keys),
+            "Wrong Merkle path case unexpectedly verified; expected rejection"
+        );
     }
 
     #[test]
     #[ignore]
-    #[should_panic]
     fn test_selective_disclosure_wrong_root_fails() {
-        let (wasm, r1cs) =
-            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let (wasm, r1cs) = load_artifacts("selectiveDisclosure_1")
+            .expect("Cannot find selectiveDisclosure_1 artifacts");
         let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
 
         let note = sample_note(28);
@@ -163,15 +196,17 @@ mod tests {
             build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
         inputs.set("roots", vec![scalar_to_bigint(Scalar::from(12345u64))]);
 
-        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+        assert!(
+            !proof_verifies(&wasm, &r1cs, &inputs, &keys),
+            "Wrong root case unexpectedly verified; expected rejection"
+        );
     }
 
     #[test]
     #[ignore]
-    #[should_panic]
     fn test_selective_disclosure_wrong_note_commitment_fails() {
-        let (wasm, r1cs) =
-            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let (wasm, r1cs) = load_artifacts("selectiveDisclosure_1")
+            .expect("Cannot find selectiveDisclosure_1 artifacts");
         let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
 
         let note = sample_note(35);
@@ -183,7 +218,9 @@ mod tests {
             vec![scalar_to_bigint(Scalar::from(99999u64))],
         );
 
-        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+        assert!(
+            !proof_verifies(&wasm, &r1cs, &inputs, &keys),
+            "Wrong note commitment case unexpectedly verified; expected rejection"
+        );
     }
-
 }

--- a/circuits/src/test/prove_selective_disclosure.rs
+++ b/circuits/src/test/prove_selective_disclosure.rs
@@ -1,0 +1,189 @@
+#[cfg(test)]
+mod tests {
+    use crate::test::utils::{
+        circom_tester::{Inputs, generate_keys, prove_and_verify_with_keys},
+        general::{load_artifacts, scalar_to_bigint},
+        keypair::derive_public_key,
+        merkle_tree::{merkle_proof, merkle_root},
+        transaction::{commitment, prepopulated_leaves},
+    };
+    use anyhow::{Context, Result};
+    use num_bigint::BigInt;
+    use zkhash::fields::bn256::FpBN256 as Scalar;
+
+    const LEVELS: usize = 10;
+    const EXT_CONTEXT_HASH: u64 = 0xC0FFEE_u64;
+
+    /// Note material for a single selective-disclosure proof.
+    struct DisclosureNote {
+        leaf_index: usize,
+        priv_key: Scalar,
+        blinding: Scalar,
+        amount: Scalar,
+    }
+
+    fn build_inputs(
+        note: &DisclosureNote,
+        leaves: &[Scalar],
+        ext_context_hash: Scalar,
+    ) -> Result<Inputs> {
+        let pub_key = derive_public_key(note.priv_key);
+        let note_commitment = commitment(note.amount, pub_key, note.blinding);
+
+        let mut frozen = leaves.to_vec();
+        frozen[note.leaf_index] = note_commitment;
+
+        let root = merkle_root(frozen.clone());
+        let (siblings, path_idx_u64, depth) = merkle_proof(&frozen, note.leaf_index);
+        assert_eq!(depth, LEVELS, "unexpected Merkle depth: expected {LEVELS}, got {depth}");
+
+        let path_elements: Vec<BigInt> = siblings.into_iter().map(scalar_to_bigint).collect();
+
+        let mut inputs = Inputs::new();
+        inputs.set("roots", vec![scalar_to_bigint(root)]);
+        inputs.set("noteCommitments", vec![scalar_to_bigint(note_commitment)]);
+        inputs.set("extContextHash", ext_context_hash);
+        inputs.set("inAmount", vec![note.amount]);
+        inputs.set("inPrivateKey", vec![note.priv_key]);
+        inputs.set("inBlinding", vec![note.blinding]);
+        inputs.set("inPathIndices", vec![Scalar::from(path_idx_u64)]);
+        inputs.set("inPathElements", path_elements);
+        Ok(inputs)
+    }
+
+    fn sample_note(leaf_index: usize) -> DisclosureNote {
+        DisclosureNote {
+            leaf_index,
+            priv_key: Scalar::from(4242u64),
+            blinding: Scalar::from(5151u64),
+            amount: Scalar::from(17u64),
+        }
+    }
+
+    fn sample_leaves(note: &DisclosureNote) -> Vec<Scalar> {
+        prepopulated_leaves(LEVELS, 0xD15C_105E_u64, &[note.leaf_index], 24)
+    }
+
+    #[test]
+    #[ignore]
+    fn test_selective_disclosure_valid_note() -> Result<()> {
+        let (wasm, r1cs) =
+            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
+
+        let note = sample_note(7);
+        let leaves = sample_leaves(&note);
+        let inputs = build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH))?;
+        let res = prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys)
+            .context("prove_and_verify failed")?;
+        assert!(res.verified, "selective disclosure proof did not verify");
+        Ok(())
+    }
+
+    #[test]
+    #[ignore]
+    #[should_panic]
+    fn test_selective_disclosure_wrong_private_key_fails() {
+        let (wasm, r1cs) =
+            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
+
+        let note = sample_note(14);
+        let leaves = sample_leaves(&note);
+        let mut inputs =
+            build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
+        inputs.set("inPrivateKey", vec![Scalar::from(9999u64)]);
+
+        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+    }
+
+    #[test]
+    #[ignore]
+    #[should_panic]
+    fn test_selective_disclosure_wrong_amount_fails() {
+        let (wasm, r1cs) =
+            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
+
+        let note = sample_note(18);
+        let leaves = sample_leaves(&note);
+        let mut inputs =
+            build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
+        inputs.set("inAmount", vec![Scalar::from(9999u64)]);
+
+        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+    }
+
+    #[test]
+    #[ignore]
+    #[should_panic]
+    fn test_selective_disclosure_wrong_blinding_fails() {
+        let (wasm, r1cs) =
+            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
+
+        let note = sample_note(25);
+        let leaves = sample_leaves(&note);
+        let mut inputs =
+            build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
+        inputs.set("inBlinding", vec![Scalar::from(8888u64)]);
+
+        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+    }
+
+    #[test]
+    #[ignore]
+    #[should_panic]
+    fn test_selective_disclosure_wrong_path_fails() {
+        let (wasm, r1cs) =
+            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
+
+        let note = sample_note(21);
+        let leaves = sample_leaves(&note);
+        let mut inputs =
+            build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
+        let zeros: Vec<BigInt> = (0..LEVELS).map(|_| BigInt::from(0u32)).collect();
+        inputs.set("inPathElements", zeros);
+
+        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+    }
+
+    #[test]
+    #[ignore]
+    #[should_panic]
+    fn test_selective_disclosure_wrong_root_fails() {
+        let (wasm, r1cs) =
+            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
+
+        let note = sample_note(28);
+        let leaves = sample_leaves(&note);
+        let mut inputs =
+            build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
+        inputs.set("roots", vec![scalar_to_bigint(Scalar::from(12345u64))]);
+
+        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+    }
+
+    #[test]
+    #[ignore]
+    #[should_panic]
+    fn test_selective_disclosure_wrong_note_commitment_fails() {
+        let (wasm, r1cs) =
+            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
+
+        let note = sample_note(35);
+        let leaves = sample_leaves(&note);
+        let mut inputs =
+            build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
+        inputs.set(
+            "noteCommitments",
+            vec![scalar_to_bigint(Scalar::from(99999u64))],
+        );
+
+        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+    }
+
+}


### PR DESCRIPTION
It adds circuit support for selective disclosure:

- Adds new selective disclosure circuit.
- Updates build.rs to include additional circuits.
- Adds circom tests for the new circuit

---
Selective disclosure is a feature that allows a user to generate a zk-proof for claiming ownership of a note privately. Basically, claiming they know the private key, amount, and blinding factor behind the note, without spending the note or revealing those secrets. The proof will be tied to a context: pool address, merkle root and authority id to avoid proof replaying.

The selective disclosure allows batched proving for multiple notes, on different merkle roots, but for the SAME context.
