### PR TITLE
Selective disclosure crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,6 +1774,7 @@ name = "disclosure"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "prover",
  "serde_json",
  "types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,6 +1770,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "disclosure"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde_json",
+ "types",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,8 +1774,10 @@ name = "disclosure"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "hex",
  "prover",
  "serde_json",
+ "sha2 0.11.0",
  "types",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "app/crates/core/prover",
+    "app/crates/core/disclosure",
     "app/crates/core/state",
     "app/crates/core/stellar",
     "app/crates/core/types",
@@ -54,6 +55,7 @@ num-integer = { version = "0.1.46", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 pool = { path = "contracts/pool" }
 prover = { path = "app/crates/core/prover" }
+disclosure = { path = "app/crates/core/disclosure" }
 rusqlite = { version = "0.39.0", default-features = false, features = ["buildtime_bindgen"] }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 serde-wasm-bindgen = { version = "0.6", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = [
-    "app/crates/core/prover",
     "app/crates/core/disclosure",
+    "app/crates/core/prover",
     "app/crates/core/state",
     "app/crates/core/stellar",
     "app/crates/core/types",
@@ -45,6 +45,7 @@ circuit-keys = { path = "circuit-keys" }
 circuits = { path = "circuits", default-features = false }
 console_error_panic_hook = { version = "0.1.7", default-features = false }
 contract-types = { path = "contracts/types" }
+disclosure = { path = "app/crates/core/disclosure" }
 futures = { version = "0.3.32", default-features = false, features = ["async-await"] }
 getrandom = { version = "0.2", default-features = false }
 gloo-timers = { version = "0.4", default-features = false, features = ["futures"] }
@@ -55,7 +56,6 @@ num-integer = { version = "0.1.46", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 pool = { path = "contracts/pool" }
 prover = { path = "app/crates/core/prover" }
-disclosure = { path = "app/crates/core/disclosure" }
 rusqlite = { version = "0.39.0", default-features = false, features = ["buildtime_bindgen"] }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 serde-wasm-bindgen = { version = "0.6", default-features = false }

--- a/app/crates/core/disclosure/Cargo.toml
+++ b/app/crates/core/disclosure/Cargo.toml
@@ -9,7 +9,9 @@ description = "Selective disclosure receipt validation and circuit metadata"
 
 [dependencies]
 anyhow = { workspace = true }
+hex = { workspace = true }
 prover = { workspace = true }
+sha2 = { workspace = true }
 types = { workspace = true }
 
 [dev-dependencies]

--- a/app/crates/core/disclosure/Cargo.toml
+++ b/app/crates/core/disclosure/Cargo.toml
@@ -9,6 +9,7 @@ description = "Selective disclosure receipt validation and circuit metadata"
 
 [dependencies]
 anyhow = { workspace = true }
+prover = { workspace = true }
 types = { workspace = true }
 
 [dev-dependencies]

--- a/app/crates/core/disclosure/Cargo.toml
+++ b/app/crates/core/disclosure/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "disclosure"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "Selective disclosure receipt validation and circuit metadata"
+
+[dependencies]
+anyhow = { workspace = true }
+types = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true, features = ["alloc"] }
+
+[lints]
+workspace = true

--- a/app/crates/core/disclosure/src/lib.rs
+++ b/app/crates/core/disclosure/src/lib.rs
@@ -1,8 +1,4 @@
 //! Selective-disclosure circuit metadata and receipt validation.
-//!
-//! This crate intentionally does not perform proving or Groth16 verification
-//! yet. It owns the circuit-specific receipt checks that sit above the generic
-//! `prover` crate and below the platforms entry points.
 
 use anyhow::{Result, anyhow};
 use prover::prover::{Prover, verify_proof};

--- a/app/crates/core/disclosure/src/lib.rs
+++ b/app/crates/core/disclosure/src/lib.rs
@@ -140,6 +140,26 @@ pub fn validate_registered_receipt(
     Ok(circuit)
 }
 
+/// Mock-checks every root named by a disclosure receipt.
+///
+/// # Arguments
+/// * `receipt` - Receipt containing the roots to check.
+/// * `expected_vk_hash` - Verifying-key hash expected by the caller.
+///
+/// # Returns
+/// Returns `true` after receipt metadata validation.
+///
+/// # Errors
+/// Returns an error if receipt metadata is invalid.
+/// TODO: REMOVE THIS AFTER MODIFYING THE SMART CONTRACT.
+pub fn mock_receipt_roots_are_known(
+    receipt: &DisclosureReceipt,
+    expected_vk_hash: &str,
+) -> Result<bool> {
+    validate_registered_receipt(receipt, expected_vk_hash)?;
+    Ok(true)
+}
+
 /// Proof bytes and public inputs produced for a disclosure receipt.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ProvedReceiptProof {

--- a/app/crates/core/disclosure/src/lib.rs
+++ b/app/crates/core/disclosure/src/lib.rs
@@ -1,0 +1,219 @@
+//! Selective-disclosure circuit metadata and receipt validation.
+//!
+//! This crate intentionally does not perform proving or Groth16 verification
+//! yet. It owns the circuit-specific receipt checks that sit above the generic
+//! `prover` crate and below the platforms entry points.
+
+use anyhow::{Result, anyhow};
+use types::{DisclosureCircuitMetadata, DisclosureReceipt, SELECTIVE_DISCLOSURE_1_CIRCUIT};
+
+/// Public input order declared by `selectiveDisclosure_1.circom`.
+pub const SELECTIVE_DISCLOSURE_1_PUBLIC_INPUTS_ORDER: &[&str] =
+    &["roots", "noteCommitments", "extContextHash"];
+
+/// Artifact file names for a registered disclosure circuit.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct CircuitArtifacts {
+    /// Circuit WASM file name.
+    pub wasm: &'static str,
+    /// Circuit R1CS file name.
+    pub r1cs: &'static str,
+    /// Groth16 proving-key file name.
+    pub proving_key: &'static str,
+    /// Groth16 verifying-key JSON file name.
+    pub verifying_key_json: &'static str,
+}
+
+/// Static metadata for a registered disclosure circuit.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct RegisteredCircuit {
+    /// Circuit entry-point name.
+    pub name: &'static str,
+    /// Merkle tree depth expected by the circuit.
+    pub levels: u32,
+    /// Number of note disclosures represented by the circuit.
+    pub n_notes: u32,
+    /// Public input order used by the witness and verifier.
+    pub public_inputs_order: &'static [&'static str],
+    /// Artifact file names used by build, web, and CLI callers.
+    pub artifacts: CircuitArtifacts,
+}
+
+impl RegisteredCircuit {
+    /// Builds the receipt metadata expected for this circuit and verifying key.
+    ///
+    /// # Arguments
+    /// * `vk_hash` - Hash of the verifying key encoded as `0x`-prefixed
+    ///   lowercase hex.
+    ///
+    /// # Returns
+    /// Returns circuit metadata suitable for a disclosure receipt.
+    pub fn receipt_metadata(&self, vk_hash: &str) -> DisclosureCircuitMetadata {
+        DisclosureCircuitMetadata {
+            name: self.name.to_string(),
+            levels: self.levels,
+            n_notes: self.n_notes,
+            vk_hash: vk_hash.to_string(),
+        }
+    }
+
+    /// Validates a receipt against this registered circuit.
+    ///
+    /// # Arguments
+    /// * `receipt` - Receipt to validate.
+    /// * `expected_vk_hash` - Verifying-key hash expected by the caller.
+    ///
+    /// # Returns
+    /// Returns `Ok(())` when the receipt schema, circuit metadata, and public
+    /// input shape match this circuit.
+    ///
+    /// # Errors
+    /// Returns an error if the receipt schema is invalid, the circuit metadata
+    /// does not match this circuit, or the verifying-key hash differs from
+    /// `expected_vk_hash`.
+    pub fn validate_receipt(
+        &self,
+        receipt: &DisclosureReceipt,
+        expected_vk_hash: &str,
+    ) -> Result<()> {
+        receipt.validate()?;
+
+        let expected = self.receipt_metadata(expected_vk_hash);
+        expected.validate()?;
+
+        if receipt.circuit != expected {
+            return Err(anyhow!("Disclosure receipt circuit metadata mismatch"));
+        }
+
+        Ok(())
+    }
+}
+
+/// Circuit metadata for `selectiveDisclosure_1`.
+pub const SELECTIVE_DISCLOSURE_1: RegisteredCircuit = RegisteredCircuit {
+    name: SELECTIVE_DISCLOSURE_1_CIRCUIT,
+    levels: 10,
+    n_notes: 1,
+    public_inputs_order: SELECTIVE_DISCLOSURE_1_PUBLIC_INPUTS_ORDER,
+    artifacts: CircuitArtifacts {
+        wasm: "selectiveDisclosure_1.wasm",
+        r1cs: "selectiveDisclosure_1.r1cs",
+        proving_key: "selectiveDisclosure_1_proving_key.bin",
+        verifying_key_json: "selectiveDisclosure_1_vk.json",
+    },
+};
+
+/// Finds a registered disclosure circuit by entry-point name.
+///
+/// # Arguments
+/// * `name` - Circuit entry-point name from a receipt.
+///
+/// # Returns
+/// Returns the registered circuit when `name` is known.
+pub fn find_circuit(name: &str) -> Option<&'static RegisteredCircuit> {
+    match name {
+        SELECTIVE_DISCLOSURE_1_CIRCUIT => Some(&SELECTIVE_DISCLOSURE_1),
+        _ => None,
+    }
+}
+
+/// Validates a receipt against the registered circuit named in the receipt.
+///
+/// # Arguments
+/// * `receipt` - Receipt to validate.
+/// * `expected_vk_hash` - Verifying-key hash expected by the caller.
+///
+/// # Returns
+/// Returns the registered circuit when the receipt validates successfully.
+///
+/// # Errors
+/// Returns an error if the receipt names an unknown circuit, fails schema
+/// validation, or does not match the expected circuit metadata.
+pub fn validate_registered_receipt(
+    receipt: &DisclosureReceipt,
+    expected_vk_hash: &str,
+) -> Result<&'static RegisteredCircuit> {
+    let circuit = find_circuit(&receipt.circuit.name)
+        .ok_or_else(|| anyhow!("Unknown disclosure circuit: {}", receipt.circuit.name))?;
+    circuit.validate_receipt(receipt, expected_vk_hash)?;
+    Ok(circuit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use types::{
+        DISCLOSURE_RECEIPT_VERSION, DisclosureContext, DisclosurePublicInputs, Field, U256,
+    };
+
+    const VK_HASH: &str = "0x1111111111111111111111111111111111111111111111111111111111111111";
+
+    fn field(value: u64) -> Field {
+        Field(U256::from(value))
+    }
+
+    fn valid_receipt() -> DisclosureReceipt {
+        DisclosureReceipt {
+            version: DISCLOSURE_RECEIPT_VERSION,
+            circuit: SELECTIVE_DISCLOSURE_1.receipt_metadata(VK_HASH),
+            context: DisclosureContext {
+                network: "testnet".to_string(),
+                pool_address: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                    .to_string(),
+                authority_label: "Authority XYZ".to_string(),
+                authority_identity_payload_hex: "0x617574686f72697479".to_string(),
+                purpose: "kyc-review".to_string(),
+                context_nonce: field(7),
+            },
+            public_inputs: DisclosurePublicInputs {
+                roots: vec![field(1)],
+                note_commitments: vec![field(2)],
+                ext_context_hash: field(3),
+            },
+            proof_uncompressed_hex: format!("0x{}", "aa".repeat(256)),
+            issued_at: "2026-05-19T14:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn registry_finds_selective_disclosure_1() {
+        let circuit = find_circuit(SELECTIVE_DISCLOSURE_1_CIRCUIT)
+            .expect("selectiveDisclosure_1 should be registered");
+
+        assert_eq!(circuit, &SELECTIVE_DISCLOSURE_1);
+        assert_eq!(
+            circuit.public_inputs_order,
+            ["roots", "noteCommitments", "extContextHash"]
+        );
+    }
+
+    #[test]
+    fn registry_rejects_unknown_circuit() {
+        assert!(find_circuit("unknown").is_none());
+    }
+
+    #[test]
+    fn validates_registered_receipt() -> Result<()> {
+        let receipt = valid_receipt();
+        let circuit = validate_registered_receipt(&receipt, VK_HASH)?;
+
+        assert_eq!(circuit.name, SELECTIVE_DISCLOSURE_1_CIRCUIT);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_wrong_vk_hash() {
+        let receipt = valid_receipt();
+        let wrong_hash = "0x2222222222222222222222222222222222222222222222222222222222222222";
+
+        assert!(validate_registered_receipt(&receipt, wrong_hash).is_err());
+    }
+
+    #[test]
+    fn rejects_wrong_circuit_levels() {
+        let mut receipt = valid_receipt();
+        receipt.circuit.levels = 11;
+
+        assert!(validate_registered_receipt(&receipt, VK_HASH).is_err());
+    }
+}

--- a/app/crates/core/disclosure/src/lib.rs
+++ b/app/crates/core/disclosure/src/lib.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{Result, anyhow};
 use prover::prover::{Prover, verify_proof};
+use sha2::{Digest, Sha256};
 use types::{DisclosureCircuitMetadata, DisclosureReceipt, SELECTIVE_DISCLOSURE_1_CIRCUIT};
 
 /// Public input order declared by `selectiveDisclosure_1.circom`.
@@ -84,6 +85,95 @@ impl RegisteredCircuit {
 
         Ok(())
     }
+
+    /// Serializes receipt public inputs in `public_inputs_order`.
+    ///
+    /// The caller must already have validated `receipt` against this circuit
+    /// (via [`validate_registered_receipt`] or
+    /// [`RegisteredCircuit::validate_receipt`]).
+    ///
+    /// # Arguments
+    /// * `receipt` - Receipt whose public inputs are serialized.
+    ///
+    /// # Returns
+    /// Returns public inputs as 32-byte little-endian field elements, suitable
+    /// for the generic Groth16 verifier.
+    ///
+    /// # Errors
+    /// Returns an error if `public_inputs_order` contains an unknown name or if
+    /// the output buffer capacity overflows.
+    pub fn public_inputs_bytes(&self, receipt: &DisclosureReceipt) -> Result<Vec<u8>> {
+        let n_notes =
+            usize::try_from(self.n_notes).map_err(|_| anyhow!("Circuit n_notes out of range"))?;
+        let capacity = n_notes
+            .checked_mul(2)
+            .and_then(|n| n.checked_add(1))
+            .and_then(|n| n.checked_mul(32))
+            .ok_or_else(|| anyhow!("Public input byte capacity overflow"))?;
+        let mut out = Vec::with_capacity(capacity);
+
+        for &name in self.public_inputs_order {
+            match name {
+                "roots" => {
+                    for root in &receipt.public_inputs.roots {
+                        out.extend_from_slice(&root.to_le_bytes());
+                    }
+                }
+                "noteCommitments" => {
+                    for note_commitment in &receipt.public_inputs.note_commitments {
+                        out.extend_from_slice(&note_commitment.to_le_bytes());
+                    }
+                }
+                "extContextHash" => {
+                    out.extend_from_slice(&receipt.public_inputs.ext_context_hash.to_le_bytes());
+                }
+                other => {
+                    return Err(anyhow!(
+                        "Unknown public input `{other}` in circuit `{}` order",
+                        self.name
+                    ));
+                }
+            }
+        }
+
+        Ok(out)
+    }
+}
+
+/// Hashes serialized verifying-key bytes using the receipt VK hash format.
+///
+/// # Arguments
+/// * `vk_bytes` - Serialized compressed arkworks verifying key.
+///
+/// # Returns
+/// Returns the `0x`-prefixed lowercase SHA-256 hash used in disclosure
+/// receipts.
+pub fn verifying_key_hash(vk_bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(vk_bytes);
+    format!("0x{}", hex::encode(hasher.finalize()))
+}
+
+/// Validates that serialized verifying-key bytes match an expected VK hash.
+///
+/// # Arguments
+/// * `vk_bytes` - Serialized compressed arkworks verifying key.
+/// * `expected_vk_hash` - Expected `0x`-prefixed lowercase SHA-256 hash.
+///
+/// # Returns
+/// Returns `Ok(())` when `vk_bytes` hash to `expected_vk_hash`.
+///
+/// # Errors
+/// Returns an error when the actual verifying-key hash differs from
+/// `expected_vk_hash`.
+fn validate_verifying_key_hash(vk_bytes: &[u8], expected_vk_hash: &str) -> Result<bool> {
+    let actual_vk_hash = verifying_key_hash(vk_bytes);
+
+    if actual_vk_hash != expected_vk_hash {
+        return Err(anyhow!("Verifying key hash mismatch"));
+    }
+
+    Ok(true)
 }
 
 /// Circuit metadata for `selectiveDisclosure_1`.
@@ -199,7 +289,16 @@ pub fn prove_receipt_proof(
     })
 }
 
-/// Serializes receipt public inputs in the circuit's declared order.
+/// Validates a receipt, then serializes its public inputs for Groth16
+/// verification.
+///
+/// This is a convenience wrapper for callers that have not already validated
+/// the receipt. It checks the receipt against the registered circuit and
+/// `expected_vk_hash` before serializing public inputs.
+///
+/// Prefer [`validate_registered_receipt`] plus
+/// [`RegisteredCircuit::public_inputs_bytes`] when the receipt is already
+/// validated in the same call path.
 ///
 /// # Arguments
 /// * `receipt` - Receipt containing named public inputs.
@@ -210,31 +309,14 @@ pub fn prove_receipt_proof(
 /// the generic Groth16 verifier.
 ///
 /// # Errors
-/// Returns an error if the receipt does not match a registered circuit or if
-/// its public-input shape is invalid.
-pub fn receipt_public_inputs_bytes(
+/// Returns an error if receipt validation fails, the receipt does not match a
+/// registered circuit, or public-input serialization fails.
+pub fn validate_and_serialize_receipt_public_inputs(
     receipt: &DisclosureReceipt,
     expected_vk_hash: &str,
 ) -> Result<Vec<u8>> {
     let circuit = validate_registered_receipt(receipt, expected_vk_hash)?;
-    let n_notes =
-        usize::try_from(circuit.n_notes).map_err(|_| anyhow!("Circuit n_notes out of range"))?;
-    let capacity = n_notes
-        .checked_mul(2)
-        .and_then(|n| n.checked_add(1))
-        .and_then(|n| n.checked_mul(32))
-        .ok_or_else(|| anyhow!("Public input byte capacity overflow"))?;
-    let mut out = Vec::with_capacity(capacity);
-
-    for root in &receipt.public_inputs.roots {
-        out.extend_from_slice(&root.to_le_bytes());
-    }
-    for note_commitment in &receipt.public_inputs.note_commitments {
-        out.extend_from_slice(&note_commitment.to_le_bytes());
-    }
-    out.extend_from_slice(&receipt.public_inputs.ext_context_hash.to_le_bytes());
-
-    Ok(out)
+    circuit.public_inputs_bytes(receipt)
 }
 
 /// Verifies the Groth16 proof carried by a disclosure receipt.
@@ -249,15 +331,19 @@ pub fn receipt_public_inputs_bytes(
 /// receipt public inputs.
 ///
 /// # Errors
-/// Returns an error if the receipt is malformed, targets an unsupported
-/// circuit, has unexpected metadata, or contains malformed proof bytes.
+/// Returns an error if `vk_bytes` do not match `expected_vk_hash`, the receipt
+/// is malformed, targets an unsupported circuit, has unexpected metadata, or
+/// contains malformed proof bytes.
 pub fn verify_receipt_proof(
     receipt: &DisclosureReceipt,
     vk_bytes: &[u8],
     expected_vk_hash: &str,
 ) -> Result<bool> {
+    validate_verifying_key_hash(vk_bytes, expected_vk_hash)?;
+
+    let circuit = validate_registered_receipt(receipt, expected_vk_hash)?;
     let proof_bytes = receipt.proof_compressed_bytes()?;
-    let public_inputs = receipt_public_inputs_bytes(receipt, expected_vk_hash)?;
+    let public_inputs = circuit.public_inputs_bytes(receipt)?;
     verify_proof(vk_bytes, &proof_bytes, &public_inputs)
 }
 
@@ -332,6 +418,25 @@ mod tests {
     }
 
     #[test]
+    fn hashes_verifying_key_bytes() {
+        let vk_bytes = b"verifying key bytes";
+
+        assert_eq!(
+            verifying_key_hash(vk_bytes),
+            "0x7330601fe3493c2be3f5ebbca5fc7879af6d7b102016e37d81f12ad40d316fd0"
+        );
+    }
+
+    #[test]
+    fn rejects_verifying_key_hash_mismatch() {
+        let expected_vk_hash = verifying_key_hash(b"trusted verifying key bytes");
+
+        assert!(
+            validate_verifying_key_hash(b"other verifying key bytes", &expected_vk_hash).is_err()
+        );
+    }
+
+    #[test]
     fn rejects_wrong_circuit_levels() {
         let mut receipt = valid_receipt();
         receipt.circuit.levels = 11;
@@ -342,7 +447,8 @@ mod tests {
     #[test]
     fn serializes_public_inputs_in_circuit_order() -> Result<()> {
         let receipt = valid_receipt();
-        let bytes = receipt_public_inputs_bytes(&receipt, VK_HASH)?;
+        let circuit = validate_registered_receipt(&receipt, VK_HASH)?;
+        let bytes = circuit.public_inputs_bytes(&receipt)?;
 
         assert_eq!(bytes.len(), 96);
         assert_eq!(&bytes[..32], &field(1).to_le_bytes());
@@ -352,10 +458,21 @@ mod tests {
     }
 
     #[test]
+    fn validate_and_serialize_matches_circuit_serialization() -> Result<()> {
+        let receipt = valid_receipt();
+        let circuit = validate_registered_receipt(&receipt, VK_HASH)?;
+        let direct = circuit.public_inputs_bytes(&receipt)?;
+        let wrapped = validate_and_serialize_receipt_public_inputs(&receipt, VK_HASH)?;
+
+        assert_eq!(direct, wrapped);
+        Ok(())
+    }
+
+    #[test]
     fn public_input_serialization_rejects_wrong_vk_hash() {
         let receipt = valid_receipt();
         let wrong_hash = "0x2222222222222222222222222222222222222222222222222222222222222222";
 
-        assert!(receipt_public_inputs_bytes(&receipt, wrong_hash).is_err());
+        assert!(validate_and_serialize_receipt_public_inputs(&receipt, wrong_hash).is_err());
     }
 }

--- a/app/crates/core/disclosure/src/lib.rs
+++ b/app/crates/core/disclosure/src/lib.rs
@@ -5,6 +5,7 @@
 //! `prover` crate and below the platforms entry points.
 
 use anyhow::{Result, anyhow};
+use prover::prover::{Prover, verify_proof};
 use types::{DisclosureCircuitMetadata, DisclosureReceipt, SELECTIVE_DISCLOSURE_1_CIRCUIT};
 
 /// Public input order declared by `selectiveDisclosure_1.circom`.
@@ -139,6 +140,111 @@ pub fn validate_registered_receipt(
     Ok(circuit)
 }
 
+/// Proof bytes and public inputs produced for a disclosure receipt.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ProvedReceiptProof {
+    /// Compressed arkworks proof bytes.
+    pub proof_compressed: Vec<u8>,
+    /// Public inputs extracted from the witness in circuit order.
+    pub public_inputs: Vec<u8>,
+}
+
+/// Proves a disclosure witness using the real Groth16 prover.
+///
+/// # Arguments
+/// * `proving_key_bytes` - Serialized compressed Groth16 proving key.
+/// * `r1cs_bytes` - R1CS bytes for the disclosure circuit.
+/// * `witness_bytes` - Witness bytes produced by the circuit witness
+///   calculator.
+///
+/// # Returns
+/// Returns the compressed proof bytes and extracted public inputs.
+///
+/// # Errors
+/// Returns an error if the proving key or R1CS cannot be loaded, proving
+/// fails, public input extraction fails, or the generated proof does not verify
+/// locally.
+pub fn prove_receipt_proof(
+    proving_key_bytes: &[u8],
+    r1cs_bytes: &[u8],
+    witness_bytes: &[u8],
+) -> Result<ProvedReceiptProof> {
+    let prover = Prover::new(proving_key_bytes, r1cs_bytes)?;
+    let proof_compressed = prover.prove_bytes(witness_bytes)?;
+    let public_inputs = prover.extract_public_inputs(witness_bytes)?;
+
+    if !prover.verify(&proof_compressed, &public_inputs)? {
+        return Err(anyhow!("Generated disclosure proof did not verify"));
+    }
+
+    Ok(ProvedReceiptProof {
+        proof_compressed,
+        public_inputs,
+    })
+}
+
+/// Serializes receipt public inputs in the circuit's declared order.
+///
+/// # Arguments
+/// * `receipt` - Receipt containing named public inputs.
+/// * `expected_vk_hash` - Verifying-key hash expected by the caller.
+///
+/// # Returns
+/// Returns public inputs as 32-byte little-endian field elements, suitable for
+/// the generic Groth16 verifier.
+///
+/// # Errors
+/// Returns an error if the receipt does not match a registered circuit or if
+/// its public-input shape is invalid.
+pub fn receipt_public_inputs_bytes(
+    receipt: &DisclosureReceipt,
+    expected_vk_hash: &str,
+) -> Result<Vec<u8>> {
+    let circuit = validate_registered_receipt(receipt, expected_vk_hash)?;
+    let n_notes =
+        usize::try_from(circuit.n_notes).map_err(|_| anyhow!("Circuit n_notes out of range"))?;
+    let capacity = n_notes
+        .checked_mul(2)
+        .and_then(|n| n.checked_add(1))
+        .and_then(|n| n.checked_mul(32))
+        .ok_or_else(|| anyhow!("Public input byte capacity overflow"))?;
+    let mut out = Vec::with_capacity(capacity);
+
+    for root in &receipt.public_inputs.roots {
+        out.extend_from_slice(&root.to_le_bytes());
+    }
+    for note_commitment in &receipt.public_inputs.note_commitments {
+        out.extend_from_slice(&note_commitment.to_le_bytes());
+    }
+    out.extend_from_slice(&receipt.public_inputs.ext_context_hash.to_le_bytes());
+
+    Ok(out)
+}
+
+/// Verifies the Groth16 proof carried by a disclosure receipt.
+///
+/// # Arguments
+/// * `receipt` - Receipt containing proof bytes and named public inputs.
+/// * `vk_bytes` - Serialized compressed arkworks verifying key.
+/// * `expected_vk_hash` - Verifying-key hash expected by the caller.
+///
+/// # Returns
+/// Returns `true` when the receipt proof verifies against `vk_bytes` and the
+/// receipt public inputs.
+///
+/// # Errors
+/// Returns an error if the receipt is malformed, targets an unsupported
+/// circuit, has unexpected metadata, or contains malformed proof bytes.
+pub fn verify_receipt_proof(
+    receipt: &DisclosureReceipt,
+    vk_bytes: &[u8],
+    expected_vk_hash: &str,
+) -> Result<bool> {
+    let proof_bytes = receipt.proof_compressed_bytes()?;
+    let public_inputs = receipt_public_inputs_bytes(receipt, expected_vk_hash)?;
+    verify_proof(vk_bytes, &proof_bytes, &public_inputs)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -170,7 +276,7 @@ mod tests {
                 note_commitments: vec![field(2)],
                 ext_context_hash: field(3),
             },
-            proof_uncompressed_hex: format!("0x{}", "aa".repeat(256)),
+            proof_compressed_hex: format!("0x{}", "aa".repeat(128)),
             issued_at: "2026-05-19T14:00:00Z".to_string(),
         }
     }
@@ -215,5 +321,25 @@ mod tests {
         receipt.circuit.levels = 11;
 
         assert!(validate_registered_receipt(&receipt, VK_HASH).is_err());
+    }
+
+    #[test]
+    fn serializes_public_inputs_in_circuit_order() -> Result<()> {
+        let receipt = valid_receipt();
+        let bytes = receipt_public_inputs_bytes(&receipt, VK_HASH)?;
+
+        assert_eq!(bytes.len(), 96);
+        assert_eq!(&bytes[..32], &field(1).to_le_bytes());
+        assert_eq!(&bytes[32..64], &field(2).to_le_bytes());
+        assert_eq!(&bytes[64..], &field(3).to_le_bytes());
+        Ok(())
+    }
+
+    #[test]
+    fn public_input_serialization_rejects_wrong_vk_hash() {
+        let receipt = valid_receipt();
+        let wrong_hash = "0x2222222222222222222222222222222222222222222222222222222222222222";
+
+        assert!(receipt_public_inputs_bytes(&receipt, wrong_hash).is_err());
     }
 }

--- a/app/crates/core/prover/src/prover.rs
+++ b/app/crates/core/prover/src/prover.rs
@@ -82,6 +82,38 @@ fn proof_to_uncompressed_bytes(proof: &Proof<Bn254>) -> Vec<u8> {
     out
 }
 
+fn verify_proof_with_processed_vk(
+    pvk: &PreparedVerifyingKey<Bn254>,
+    expected_inputs: usize,
+    proof: &Proof<Bn254>,
+    public_inputs_bytes: &[u8],
+) -> Result<bool> {
+    if !public_inputs_bytes.len().is_multiple_of(FIELD_SIZE) {
+        return Err(anyhow!("Invalid public inputs size"));
+    }
+
+    let num_inputs = public_inputs_bytes.len() / FIELD_SIZE;
+    if num_inputs != expected_inputs {
+        return Err(anyhow!(
+            "Public input count mismatch: got {}, expected {}",
+            num_inputs,
+            expected_inputs
+        ));
+    }
+
+    let mut public_inputs = Vec::with_capacity(num_inputs);
+    for chunk in public_inputs_bytes.chunks_exact(FIELD_SIZE) {
+        public_inputs.push(bytes_to_fr(chunk)?);
+    }
+
+    <ark_groth16::Groth16<Bn254, CircomReduction> as SNARK<Fr>>::verify_with_processed_vk(
+        pvk,
+        &public_inputs,
+        proof,
+    )
+    .map_err(|e| anyhow!("Verification error: {}", e))
+}
+
 /// A circuit that replays R1CS constraints with pre-computed witness
 ///
 /// This is used to create proofs from:
@@ -433,16 +465,8 @@ impl Prover {
 
     /// Verify a proof (for testing purposes)
     pub fn verify(&self, proof_bytes: &[u8], public_inputs_bytes: &[u8]) -> Result<bool> {
-        // Deserialize proof
         let proof = Proof::<Bn254>::deserialize_compressed(proof_bytes)
             .map_err(|e| anyhow!("Failed to load proof: {}", e))?;
-
-        // Parse public inputs
-        if !public_inputs_bytes.len().is_multiple_of(FIELD_SIZE) {
-            return Err(anyhow!("Invalid public inputs size"));
-        }
-
-        let num_inputs = public_inputs_bytes.len() / FIELD_SIZE;
         let expected_inputs = self
             .pk
             .vk
@@ -450,30 +474,7 @@ impl Prover {
             .len()
             .checked_sub(1)
             .ok_or_else(|| anyhow!("Invalid verifying key"))?;
-
-        if num_inputs != expected_inputs {
-            return Err(anyhow!(
-                "Public input count mismatch: got {}, expected {}",
-                num_inputs,
-                expected_inputs
-            ));
-        }
-
-        let mut public_inputs = Vec::with_capacity(num_inputs);
-        for chunk in public_inputs_bytes.chunks_exact(FIELD_SIZE) {
-            public_inputs.push(bytes_to_fr(chunk)?);
-        }
-
-        // Verify
-        let result =
-            <ark_groth16::Groth16<Bn254, CircomReduction> as SNARK<Fr>>::verify_with_processed_vk(
-                &self.pvk,
-                &public_inputs,
-                &proof,
-            )
-            .map_err(|e| anyhow!("Verification error: {}", e))?;
-
-        Ok(result)
+        verify_proof_with_processed_vk(&self.pvk, expected_inputs, &proof, public_inputs_bytes)
     }
 }
 
@@ -497,33 +498,14 @@ pub fn verify_proof(
     let vk = VerifyingKey::<Bn254>::deserialize_compressed(vk_bytes)
         .map_err(|e| anyhow!("Failed to load VK: {}", e))?;
 
-    // Process VK
     let pvk = <ark_groth16::Groth16<Bn254, CircomReduction> as SNARK<Fr>>::process_vk(&vk)
         .map_err(|e| anyhow!("Failed to process VK: {}", e))?;
-
-    // Deserialize proof
     let proof = Proof::<Bn254>::deserialize_compressed(proof_bytes)
         .map_err(|e| anyhow!("Failed to load proof: {}", e))?;
-
-    // Parse public inputs
-    if !public_inputs_bytes.len().is_multiple_of(FIELD_SIZE) {
-        return Err(anyhow!("Invalid public inputs size"));
-    }
-
-    let num_inputs = public_inputs_bytes.len() / FIELD_SIZE;
-    let mut public_inputs = Vec::with_capacity(num_inputs);
-    for chunk in public_inputs_bytes.chunks_exact(FIELD_SIZE) {
-        public_inputs.push(bytes_to_fr(chunk)?);
-    }
-
-    // Verify
-    let result =
-        <ark_groth16::Groth16<Bn254, CircomReduction> as SNARK<Fr>>::verify_with_processed_vk(
-            &pvk,
-            &public_inputs,
-            &proof,
-        )
-        .map_err(|e| anyhow!("Verification error: {}", e))?;
-
-    Ok(result)
+    let expected_inputs = vk
+        .gamma_abc_g1
+        .len()
+        .checked_sub(1)
+        .ok_or_else(|| anyhow!("Invalid verifying key"))?;
+    verify_proof_with_processed_vk(&pvk, expected_inputs, &proof, public_inputs_bytes)
 }

--- a/app/crates/core/stellar/src/contract_state.rs
+++ b/app/crates/core/stellar/src/contract_state.rs
@@ -292,18 +292,7 @@ impl StateFetcher {
             source_account,
             key,
         )?;
-        let sim = self.client.simulate_transaction(&tx).await?;
-
-        let op_result = sim
-            .result
-            .or_else(|| sim.results.into_iter().next())
-            .ok_or_else(|| anyhow!("simulateTransaction returned no op results"))?;
-
-        let retval_b64 = op_result
-            .retval
-            .ok_or_else(|| anyhow!("simulateTransaction missing retval"))?;
-
-        let retval = xdr::ScVal::from_xdr_base64(&retval_b64, xdr::Limits::none())?;
+        let retval = self.simulate_single_retval(&tx).await?;
         let parsed = Self::parse_find_result(&retval)?;
 
         if parsed.found {
@@ -331,6 +320,45 @@ impl StateFetcher {
         })
     }
 
+    /// Checks whether a pool Merkle root is still known by the deployed pool.
+    ///
+    /// # Arguments
+    /// * `root` - Pool Merkle root to check.
+    ///
+    /// # Returns
+    /// Returns `true` when the root is in the pool root-history window.
+    ///
+    /// # Errors
+    /// Returns an error if the simulation fails or the contract returns a
+    /// non-boolean value.
+    pub async fn is_pool_known_root(&self, root: Field) -> Result<bool> {
+        let tx = Self::build_is_known_root_simulation_tx(
+            &self.config.pool,
+            &self.config.deployer,
+            root,
+        )?;
+        let retval = self.simulate_single_retval(&tx).await?;
+        Ok(scval_to_bool(&retval)?)
+    }
+
+    async fn simulate_single_retval(&self, tx: &xdr::TransactionEnvelope) -> Result<xdr::ScVal> {
+        let sim = self.client.simulate_transaction(tx).await?;
+
+        let op_result = sim
+            .result
+            .or_else(|| sim.results.into_iter().next())
+            .ok_or_else(|| anyhow!("simulateTransaction returned no op results"))?;
+
+        let retval_b64 = op_result
+            .retval
+            .ok_or_else(|| anyhow!("simulateTransaction missing retval"))?;
+
+        Ok(xdr::ScVal::from_xdr_base64(
+            &retval_b64,
+            xdr::Limits::none(),
+        )?)
+    }
+
     fn build_find_key_simulation_tx(
         contract_id: &str,
         source_account: &str,
@@ -343,6 +371,22 @@ impl StateFetcher {
             contract_id,
             "find_key",
             vec![Self::field_to_scval_u256(key)],
+            Vec::new(),
+        )
+    }
+
+    fn build_is_known_root_simulation_tx(
+        contract_id: &str,
+        source_account: &str,
+        root: Field,
+    ) -> Result<xdr::TransactionEnvelope> {
+        Self::build_invoke_contract_tx_envelope(
+            source_account,
+            xdr::SequenceNumber(0),
+            100,
+            contract_id,
+            "is_known_root",
+            vec![Self::field_to_scval_u256(root)],
             Vec::new(),
         )
     }

--- a/app/crates/core/types/src/disclosure.rs
+++ b/app/crates/core/types/src/disclosure.rs
@@ -8,8 +8,8 @@ pub const DISCLOSURE_RECEIPT_VERSION: u32 = 1;
 /// Initial selective-disclosure circuit entry point.
 pub const SELECTIVE_DISCLOSURE_1_CIRCUIT: &str = "selectiveDisclosure_1";
 
-/// Uncompressed Groth16 proof size used by the existing Soroban proof format.
-pub const UNCOMPRESSED_GROTH16_PROOF_BYTES: usize = 256;
+/// Compressed Groth16 proof size used by arkworks for BN254 proofs.
+pub const COMPRESSED_GROTH16_PROOF_BYTES: usize = 128;
 
 /// Portable receipt proving ownership of one or more disclosed notes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -23,8 +23,8 @@ pub struct DisclosureReceipt {
     pub context: DisclosureContext,
     /// Named public inputs for the selective disclosure circuit.
     pub public_inputs: DisclosurePublicInputs,
-    /// Uncompressed Groth16 proof encoded as `0x`-prefixed lowercase hex.
-    pub proof_uncompressed_hex: String,
+    /// Compressed Groth16 proof encoded as `0x`-prefixed lowercase hex.
+    pub proof_compressed_hex: String,
     /// Issuance timestamp string.
     pub issued_at: String,
 }
@@ -40,9 +40,9 @@ impl DisclosureReceipt {
         self.context.validate()?;
         self.public_inputs.validate(self.circuit.n_notes)?;
         parse_0x_hex_exact(
-            "proof_uncompressed_hex",
-            &self.proof_uncompressed_hex,
-            UNCOMPRESSED_GROTH16_PROOF_BYTES,
+            "proof_compressed_hex",
+            &self.proof_compressed_hex,
+            COMPRESSED_GROTH16_PROOF_BYTES,
         )?;
 
         if self.issued_at.is_empty() {
@@ -50,6 +50,22 @@ impl DisclosureReceipt {
         }
 
         Ok(())
+    }
+
+    /// Decodes the compressed Groth16 proof bytes carried by this receipt.
+    ///
+    /// # Returns
+    /// Returns the compressed proof encoded in `proof_compressed_hex`.
+    ///
+    /// # Errors
+    /// Returns an error if the proof is not canonical `0x`-prefixed lowercase
+    /// hex or does not decode to the expected compressed proof length.
+    pub fn proof_compressed_bytes(&self) -> Result<Vec<u8>> {
+        parse_0x_hex_exact(
+            "proof_compressed_hex",
+            &self.proof_compressed_hex,
+            COMPRESSED_GROTH16_PROOF_BYTES,
+        )
     }
 }
 
@@ -63,7 +79,8 @@ pub struct DisclosureCircuitMetadata {
     pub levels: u32,
     /// Number of note disclosures represented by this circuit instance.
     pub n_notes: u32,
-    /// Hash of the verifying key encoded as `0x`-prefixed lowercase 32-byte hex.
+    /// Hash of the verifying key encoded as `0x`-prefixed lowercase 32-byte
+    /// hex.
     pub vk_hash: String,
 }
 
@@ -171,8 +188,8 @@ pub struct DisclosureVerificationReport {
 ///
 /// # Arguments
 /// * `name` - Field name used in validation error messages.
-/// * `value` - Hex string to parse. It must start with `0x`, use lowercase
-///   hex digits, and contain at least one byte.
+/// * `value` - Hex string to parse. It must start with `0x`, use lowercase hex
+///   digits, and contain at least one byte.
 ///
 /// # Returns
 /// Returns the decoded bytes when the string is canonical.
@@ -246,7 +263,7 @@ mod tests {
                 note_commitments: vec![field(2)],
                 ext_context_hash: field(3),
             },
-            proof_uncompressed_hex: format!("0x{}", "aa".repeat(UNCOMPRESSED_GROTH16_PROOF_BYTES)),
+            proof_compressed_hex: format!("0x{}", "aa".repeat(COMPRESSED_GROTH16_PROOF_BYTES)),
             issued_at: "2026-05-19T14:00:00Z".to_string(),
         }
     }
@@ -271,7 +288,7 @@ mod tests {
             "circuit": {"name": "selectiveDisclosure_1", "levels": 10, "nNotes": 1, "vkHash": "0x1111111111111111111111111111111111111111111111111111111111111111"},
             "context": {"network": "testnet", "poolAddress": "CAAA", "authorityLabel": "A", "authorityIdentityPayloadHex": "0x61", "purpose": "p", "contextNonce": "0x0000000000000000000000000000000000000000000000000000000000000000"},
             "publicInputs": {"roots": [], "noteCommitments": [], "extContextHash": "0x0000000000000000000000000000000000000000000000000000000000000000"},
-            "proofUncompressedHex": "0x",
+            "proofCompressedHex": "0x",
             "issuedAt": "now"
         }"#;
 
@@ -289,7 +306,7 @@ mod tests {
     #[test]
     fn validate_rejects_malformed_proof_hex() {
         let mut receipt = valid_receipt();
-        receipt.proof_uncompressed_hex = "0xaa".to_string();
+        receipt.proof_compressed_hex = "0xaa".to_string();
 
         assert!(receipt.validate().is_err());
     }

--- a/app/crates/core/types/src/disclosure.rs
+++ b/app/crates/core/types/src/disclosure.rs
@@ -234,7 +234,8 @@ mod tests {
             },
             context: DisclosureContext {
                 network: "testnet".to_string(),
-                pool_address: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_string(),
+                pool_address: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                    .to_string(),
                 authority_label: "Authority XYZ".to_string(),
                 authority_identity_payload_hex: "0x617574686f72697479".to_string(),
                 purpose: "kyc-review".to_string(),

--- a/app/crates/core/types/src/disclosure.rs
+++ b/app/crates/core/types/src/disclosure.rs
@@ -1,0 +1,319 @@
+use crate::Field;
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+
+/// Current selective-disclosure receipt version.
+pub const DISCLOSURE_RECEIPT_VERSION: u32 = 1;
+
+/// Initial selective-disclosure circuit entry point.
+pub const SELECTIVE_DISCLOSURE_1_CIRCUIT: &str = "selectiveDisclosure_1";
+
+/// Uncompressed Groth16 proof size used by the existing Soroban proof format.
+pub const UNCOMPRESSED_GROTH16_PROOF_BYTES: usize = 256;
+
+/// Portable receipt proving ownership of one or more disclosed notes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DisclosureReceipt {
+    /// Receipt schema version.
+    pub version: u32,
+    /// Circuit metadata and verifying-key binding.
+    pub circuit: DisclosureCircuitMetadata,
+    /// Pool, authority, and protocol context bound into `ext_context_hash`.
+    pub context: DisclosureContext,
+    /// Named public inputs for the selective disclosure circuit.
+    pub public_inputs: DisclosurePublicInputs,
+    /// Uncompressed Groth16 proof encoded as `0x`-prefixed lowercase hex.
+    pub proof_uncompressed_hex: String,
+    /// Issuance timestamp string.
+    pub issued_at: String,
+}
+
+impl DisclosureReceipt {
+    /// Validates schema-level invariants before verification.
+    /// This does not perform Groth16 verification or root-history checks.
+    pub fn validate(&self) -> Result<()> {
+        if self.version != DISCLOSURE_RECEIPT_VERSION {
+            return Err(anyhow!("Unsupported disclosure receipt version"));
+        }
+        self.circuit.validate()?;
+        self.context.validate()?;
+        self.public_inputs.validate(self.circuit.n_notes)?;
+        parse_0x_hex_exact(
+            "proof_uncompressed_hex",
+            &self.proof_uncompressed_hex,
+            UNCOMPRESSED_GROTH16_PROOF_BYTES,
+        )?;
+
+        if self.issued_at.is_empty() {
+            return Err(anyhow!("issued_at cannot be empty"));
+        }
+
+        Ok(())
+    }
+}
+
+/// Circuit identity and verifying-key binding carried by a receipt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DisclosureCircuitMetadata {
+    /// Circuit entry-point name, e.g. `selectiveDisclosure_1`.
+    pub name: String,
+    /// Pool Merkle tree depth expected by the circuit.
+    pub levels: u32,
+    /// Number of note disclosures represented by this circuit instance.
+    pub n_notes: u32,
+    /// Hash of the verifying key encoded as `0x`-prefixed lowercase 32-byte hex.
+    pub vk_hash: String,
+}
+
+impl DisclosureCircuitMetadata {
+    /// Validates metadata fields that are independent of any concrete registry.
+    pub fn validate(&self) -> Result<()> {
+        if self.name.is_empty() {
+            return Err(anyhow!("Circuit name cannot be empty"));
+        }
+        if self.levels == 0 {
+            return Err(anyhow!("Circuit levels cannot be zero"));
+        }
+        if self.n_notes == 0 {
+            return Err(anyhow!("Circuit n_notes cannot be zero"));
+        }
+        parse_0x_hex_exact("vk_hash", &self.vk_hash, 32)?;
+        Ok(())
+    }
+}
+
+/// Receipt context that is hashed into `ext_context_hash`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DisclosureContext {
+    /// Network name from the active deployment configuration.
+    pub network: String,
+    /// Pool contract address.
+    pub pool_address: String,
+    /// Human-readable authority label.
+    pub authority_label: String,
+    /// Authority identity payload encoded as `0x`-prefixed lowercase hex.
+    pub authority_identity_payload_hex: String,
+    /// Purpose string shown to the user and bound into the receipt context.
+    pub purpose: String,
+    /// Optional anti-replay nonce encoded as a field element.
+    pub context_nonce: Field,
+}
+
+impl DisclosureContext {
+    /// Validates context metadata before recomputing the context hash.
+    pub fn validate(&self) -> Result<()> {
+        if self.network.is_empty() {
+            return Err(anyhow!("Network cannot be empty"));
+        }
+        if self.pool_address.is_empty() {
+            return Err(anyhow!("pool_address cannot be empty"));
+        }
+        if self.authority_label.is_empty() {
+            return Err(anyhow!("authority_label cannot be empty"));
+        }
+        parse_0x_hex(
+            "authority_identity_payload_hex",
+            &self.authority_identity_payload_hex,
+        )?;
+        if self.purpose.is_empty() {
+            return Err(anyhow!("Purpose cannot be empty"));
+        }
+        Ok(())
+    }
+}
+
+/// Public inputs exposed by `selectiveDisclosure_1`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DisclosurePublicInputs {
+    /// Merkle roots proven by the receipt.
+    pub roots: Vec<Field>,
+    /// Disclosed note commitments proven under `roots`.
+    pub note_commitments: Vec<Field>,
+    /// Hash of pool, authority, purpose, and nonce context.
+    pub ext_context_hash: Field,
+}
+
+impl DisclosurePublicInputs {
+    /// Validates public-input shape against the circuit's note count.
+    pub fn validate(&self, n_notes: u32) -> Result<()> {
+        let n_notes = usize::try_from(n_notes).map_err(|_| anyhow!("n_notes out of range"))?;
+        if self.roots.len() != n_notes {
+            return Err(anyhow!("Roots length does not match n_notes"));
+        }
+        if self.note_commitments.len() != n_notes {
+            return Err(anyhow!("note_commitments length does not match n_notes"));
+        }
+        Ok(())
+    }
+}
+
+/// Verification status returned.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DisclosureVerificationReport {
+    /// Whether the Groth16 proof verified against the receipt public inputs.
+    pub proof_verified: bool,
+    /// Whether the receipt context recomputed to the public `ext_context_hash`.
+    pub context_verified: bool,
+    /// Status of the known-root freshness check.
+    pub known_root_status: bool,
+}
+
+/// Parses a strict `0x`-prefixed lowercase hex string.
+///
+/// The receipt format uses this for proof bytes, verifying-key hashes, and
+/// context payloads so JSON parsing fails before any verifier logic runs.
+/// Uppercase hex and missing prefixes are rejected to keep receipts canonical.
+///
+/// # Arguments
+/// * `name` - Field name used in validation error messages.
+/// * `value` - Hex string to parse. It must start with `0x`, use lowercase
+///   hex digits, and contain at least one byte.
+///
+/// # Returns
+/// Returns the decoded bytes when the string is canonical.
+fn parse_0x_hex(name: &str, value: &str) -> Result<Vec<u8>> {
+    let Some(hex_value) = value.strip_prefix("0x") else {
+        return Err(anyhow!("{name}: expected 0x prefix"));
+    };
+    if hex_value.is_empty() {
+        return Err(anyhow!("{name}: hex payload cannot be empty"));
+    }
+    if !hex_value.len().is_multiple_of(2) {
+        return Err(anyhow!("{name}: hex payload must have even length"));
+    }
+    if hex_value.bytes().any(|b| b.is_ascii_uppercase()) {
+        return Err(anyhow!("{name}: expected lowercase hex"));
+    }
+
+    hex::decode(hex_value).map_err(|e| anyhow!("{name}: invalid hex: {e}"))
+}
+
+/// Parses a strict hex string and checks the decoded byte length.
+///
+/// # Arguments
+/// * `name` - Field name used in validation error messages.
+/// * `value` - Hex string to parse.
+/// * `expected_bytes` - Required decoded byte length.
+///
+/// # Returns
+/// Returns the decoded bytes when the string is canonical and has the expected
+/// length.
+fn parse_0x_hex_exact(name: &str, value: &str, expected_bytes: usize) -> Result<Vec<u8>> {
+    let bytes = parse_0x_hex(name, value)?;
+    if bytes.len() != expected_bytes {
+        return Err(anyhow!(
+            "{name}: expected {} bytes, got {}",
+            expected_bytes,
+            bytes.len()
+        ));
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn field(value: u64) -> Field {
+        Field(crate::U256::from(value))
+    }
+
+    fn valid_receipt() -> DisclosureReceipt {
+        DisclosureReceipt {
+            version: DISCLOSURE_RECEIPT_VERSION,
+            circuit: DisclosureCircuitMetadata {
+                name: SELECTIVE_DISCLOSURE_1_CIRCUIT.to_string(),
+                levels: 10,
+                n_notes: 1,
+                vk_hash: format!("0x{}", "11".repeat(32)),
+            },
+            context: DisclosureContext {
+                network: "testnet".to_string(),
+                pool_address: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_string(),
+                authority_label: "Authority XYZ".to_string(),
+                authority_identity_payload_hex: "0x617574686f72697479".to_string(),
+                purpose: "kyc-review".to_string(),
+                context_nonce: field(7),
+            },
+            public_inputs: DisclosurePublicInputs {
+                roots: vec![field(1)],
+                note_commitments: vec![field(2)],
+                ext_context_hash: field(3),
+            },
+            proof_uncompressed_hex: format!("0x{}", "aa".repeat(UNCOMPRESSED_GROTH16_PROOF_BYTES)),
+            issued_at: "2026-05-19T14:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn receipt_round_trips_and_validates() -> Result<()> {
+        let receipt = valid_receipt();
+        let json = serde_json::to_string(&receipt)?;
+        let parsed: DisclosureReceipt = serde_json::from_str(&json)?;
+
+        assert_eq!(parsed, receipt);
+        parsed.validate()?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn receipt_rejects_unknown_fields() {
+        let json = r#"{
+            "version": 1,
+            "unexpected": true,
+            "circuit": {"name": "selectiveDisclosure_1", "levels": 10, "nNotes": 1, "vkHash": "0x1111111111111111111111111111111111111111111111111111111111111111"},
+            "context": {"network": "testnet", "poolAddress": "CAAA", "authorityLabel": "A", "authorityIdentityPayloadHex": "0x61", "purpose": "p", "contextNonce": "0x0000000000000000000000000000000000000000000000000000000000000000"},
+            "publicInputs": {"roots": [], "noteCommitments": [], "extContextHash": "0x0000000000000000000000000000000000000000000000000000000000000000"},
+            "proofUncompressedHex": "0x",
+            "issuedAt": "now"
+        }"#;
+
+        assert!(serde_json::from_str::<DisclosureReceipt>(json).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_unsupported_version() {
+        let mut receipt = valid_receipt();
+        receipt.version = 2;
+
+        assert!(receipt.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_malformed_proof_hex() {
+        let mut receipt = valid_receipt();
+        receipt.proof_uncompressed_hex = "0xaa".to_string();
+
+        assert!(receipt.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_missing_hex_prefix() {
+        let mut receipt = valid_receipt();
+        receipt.circuit.vk_hash = "11".repeat(32);
+
+        assert!(receipt.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_uppercase_hex() {
+        let mut receipt = valid_receipt();
+        receipt.context.authority_identity_payload_hex = "0xAA".to_string();
+
+        assert!(receipt.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_public_input_count_mismatch() {
+        let mut receipt = valid_receipt();
+        receipt.public_inputs.note_commitments.push(field(4));
+
+        assert!(receipt.validate().is_err());
+    }
+}

--- a/app/crates/core/types/src/lib.rs
+++ b/app/crates/core/types/src/lib.rs
@@ -1,9 +1,11 @@
 mod amounts;
 mod chain_data;
+mod disclosure;
 mod ext_data;
 pub use amounts::*;
 use anyhow::{Result, anyhow};
 pub use chain_data::*;
+pub use disclosure::*;
 pub use ext_data::*;
 
 use serde::{Deserialize, Serialize};

--- a/circuits/build.rs
+++ b/circuits/build.rs
@@ -11,8 +11,8 @@
 //!
 //! To Build the test circuits use `BUILD_TESTS=1 cargo build`
 //!
-//! The script also generates Groth16 proving and verification
-//! keys for the main circuit (policy_tx_2_2) and outputs them to
+//! The script also generates Groth16 proving and verification keys for selected
+//! entry-point circuits (see `GROTH16_KEY_CIRCUITS` below) and outputs them to
 //! `testdata/`.
 //!
 //! The output directory is exposed as en environment variable
@@ -41,6 +41,19 @@ use std::{
 use type_analysis::check_types::check_types;
 
 const CURVE_ID: &str = "bn128";
+
+/// Circom stems whose Groth16 artifacts live under `testdata/`
+/// (`{stem}_proving_key.bin`, etc.). Append here when wiring a new entry-point
+/// through the same key-generation path.
+const GROTH16_KEY_CIRCUITS: &[&str] = &["policy_tx_2_2", "selectiveDisclosure_1"];
+
+/// `testdata/` filenames (`{stem}{suffix}`) that invalidate the build when
+/// changed.
+const GROTH16_TESTDATA_SUFFIXES: &[&str] = &["_proving_key.bin", "_vk.json", "_vk_soroban.bin"];
+
+fn circuit_needs_groth16_keys(name: &str) -> bool {
+    GROTH16_KEY_CIRCUITS.contains(&name)
+}
 
 fn publish_dir_path(crate_dir: &Path) -> Result<PathBuf> {
     let workspace_root = crate_dir.parent().unwrap_or(crate_dir);
@@ -113,18 +126,14 @@ fn main() -> Result<()> {
 
     // Rerun if testdata key files are missing or changed
     let testdata_dir = crate_dir.join("../testdata");
-    println!(
-        "cargo:rerun-if-changed={}",
-        testdata_dir.join("policy_tx_2_2_proving_key.bin").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        testdata_dir.join("policy_tx_2_2_vk.json").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        testdata_dir.join("policy_tx_2_2_vk_soroban.bin").display()
-    );
+    for stem in GROTH16_KEY_CIRCUITS {
+        for suffix in GROTH16_TESTDATA_SUFFIXES {
+            println!(
+                "cargo:rerun-if-changed={}",
+                testdata_dir.join(format!("{stem}{suffix}")).display()
+            );
+        }
+    }
 
     // === CIRCOMLIB DEPENDENCY ===
     // Import circomlib library (only if not already present) and pin it to the
@@ -253,8 +262,9 @@ fn main() -> Result<()> {
                     );
                 }
 
-                // Still check if we need to generate keys for policy_tx_2_2
-                if circuit_name == "policy_tx_2_2" && wasm_path.exists() {
+                // Still check if we need to generate keys for circuits that ship PK/VK under
+                // testdata/
+                if circuit_needs_groth16_keys(circuit_name.as_str()) && wasm_path.exists() {
                     match generate_keys_if_needed(&crate_dir, &out_dir, &circuit_name, &r1cs_file) {
                         Ok(_) => {}
                         Err(e) => {
@@ -339,8 +349,8 @@ fn main() -> Result<()> {
         }
 
         // === GROTH16 Proving/Verifying key generation ===
-        // For now we only generate keys for the policy_tx_2_2 circuit.
-        if circuit_name == "policy_tx_2_2" {
+        // policy_tx_2_2 and selectiveDisclosure_1 (must match `*.circom` file stem).
+        if circuit_needs_groth16_keys(circuit_name.as_str()) {
             if !wasm_success {
                 bail!(
                     "Skipping key generation for {} - WASM compilation failed",
@@ -1052,7 +1062,8 @@ fn check_keys_need_generation(
 ///
 /// * `crate_dir` - The circuits crate directory
 /// * `out_dir` - The output directory containing WASM files
-/// * `circuit_name` - Name of the circuit (e.g., "policy_tx_2_2")
+/// * `circuit_name` - Name of the circuit (e.g., `policy_tx_2_2`,
+///   `selectiveDisclosure_1`)
 /// * `r1cs_file` - Path to the R1CS file for freshness comparison
 ///
 /// # Returns

--- a/circuits/src/selectiveDisclosure.circom
+++ b/circuits/src/selectiveDisclosure.circom
@@ -1,0 +1,63 @@
+pragma circom 2.2.2;
+
+// Selective Disclosure Circuit
+include "./merkleProof.circom";
+include "./poseidon2/poseidon2_hash.circom";
+include "./keypair.circom";
+
+// Allows a user to demonstrate ownership of a note commitment without revealing its secrets
+// * levels: Number of levels in the Merkle tree that holds the note commitments
+// * nNotes: Number of notes to prove ownership of.
+// Right now we allow proving ownership of multiple notes on different roots BUT for the same external context:
+// - Purpose
+// - Authority 
+// - Pool address
+// So that you can prove multiple notes 
+template SelectiveDisclosure(levels, nNotes) {
+    /** PUBLIC INPUTS **/
+    signal input roots[nNotes];
+    signal input noteCommitments[nNotes];
+    signal input extContextHash;
+ 
+    
+    /** PRIVATE INPUTS **/
+    signal input inAmount[nNotes];
+    signal input inPrivateKey[nNotes];
+    signal input inBlinding[nNotes];
+    signal input inPathIndices[nNotes];
+    signal input inPathElements[nNotes][levels];
+    
+    // Components
+    component inKeypair[nNotes];
+    component inCommitmentHasher[nNotes];
+    component inTree[nNotes];
+    
+    for (var ni = 0; ni < nNotes; ni++) {
+        // Verify that the sender actually owns the inputs
+        // He knows the secret keys and the blinding factors.
+        inKeypair[ni] = Keypair();
+        inKeypair[ni].privateKey <== inPrivateKey[ni];
+        
+        // Computes the leaf commitment as hash(amount, publicKey, blinding)
+        inCommitmentHasher[ni] = Poseidon2(3);
+        inCommitmentHasher[ni].inputs[0] <== inAmount[ni];
+        inCommitmentHasher[ni].inputs[1] <== inKeypair[ni].publicKey;
+        inCommitmentHasher[ni].inputs[2] <== inBlinding[ni];
+        inCommitmentHasher[ni].domainSeparation <== 0x01; // Leaf commitment
+        
+        // Ensures it matches the claimed note
+        noteCommitments[ni] === inCommitmentHasher[ni].out;
+        
+        // Verifies the merkle proofs
+        inTree[ni] = MerkleProof(levels);
+        inTree[ni].leaf <== inCommitmentHasher[ni].out;
+        inTree[ni].pathIndices <== inPathIndices[ni];
+        for (var i = 0; i < levels; i++) {
+            inTree[ni].pathElements[i] <== inPathElements[ni][i];
+        }
+        // Ensure root matches the expected value
+        roots[ni] === inTree[ni].root;
+    }
+    // Safety constraint to bind external context 
+    signal extContextSquare <== extContextHash * extContextHash;   
+}

--- a/circuits/src/selectiveDisclosure_1.circom
+++ b/circuits/src/selectiveDisclosure_1.circom
@@ -1,0 +1,8 @@
+pragma circom 2.2.2;
+// Selective disclosure for a single note commitment.
+include "./selectiveDisclosure.circom";
+
+// SelectiveDisclosure(
+//   levels, nNotes
+// )
+component main {public [roots, noteCommitments, extContextHash]} = SelectiveDisclosure(10, 1);

--- a/circuits/src/test/mod.rs
+++ b/circuits/src/test/mod.rs
@@ -11,5 +11,6 @@ mod prove_sparse;
 
 mod prove_keypair;
 mod prove_policy;
+mod prove_selective_disclosure;
 mod prove_transaction;
 pub mod utils;

--- a/circuits/src/test/prove_selective_disclosure.rs
+++ b/circuits/src/test/prove_selective_disclosure.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::test::utils::{
-        circom_tester::{Inputs, generate_keys, prove_and_verify_with_keys},
+        circom_tester::{CircuitKeys, Inputs, generate_keys, prove_and_verify_with_keys},
         general::{load_artifacts, scalar_to_bigint},
         keypair::derive_public_key,
         merkle_tree::{merkle_proof, merkle_root},
@@ -9,7 +9,30 @@ mod tests {
     };
     use anyhow::{Context, Result};
     use num_bigint::BigInt;
+    use std::{
+        panic::{self, AssertUnwindSafe},
+        path::Path,
+    };
     use zkhash::fields::bn256::FpBN256 as Scalar;
+
+    /// Returns `true` when the prover produced a verifying proof for the given
+    /// inputs. Any other outcome (a returned `Err`, a `verified == false`
+    /// result, or a panic from the WASM witness calculator) counts as a
+    /// rejection and yields `false`, so negative tests can assert on this
+    /// uniformly regardless of which layer trips first.
+    /// This is needed because `arkworks` and `wasmer` might panic or return
+    /// depending on in which layer the error is found.
+    fn proof_verifies(
+        wasm: impl AsRef<Path>,
+        r1cs: impl AsRef<Path>,
+        inputs: &Inputs,
+        keys: &CircuitKeys,
+    ) -> bool {
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| {
+            prove_and_verify_with_keys(wasm.as_ref(), r1cs.as_ref(), inputs, keys)
+        }));
+        matches!(outcome, Ok(Ok(ref res)) if res.verified)
+    }
 
     const LEVELS: usize = 10;
     const EXT_CONTEXT_HASH: u64 = 0xC0FFEE_u64;
@@ -35,7 +58,10 @@ mod tests {
 
         let root = merkle_root(frozen.clone());
         let (siblings, path_idx_u64, depth) = merkle_proof(&frozen, note.leaf_index);
-        assert_eq!(depth, LEVELS, "unexpected Merkle depth: expected {LEVELS}, got {depth}");
+        assert_eq!(
+            depth, LEVELS,
+            "unexpected Merkle depth: expected {LEVELS}, got {depth}"
+        );
 
         let path_elements: Vec<BigInt> = siblings.into_iter().map(scalar_to_bigint).collect();
 
@@ -67,8 +93,8 @@ mod tests {
     #[test]
     #[ignore]
     fn test_selective_disclosure_valid_note() -> Result<()> {
-        let (wasm, r1cs) =
-            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let (wasm, r1cs) = load_artifacts("selectiveDisclosure_1")
+            .expect("Cannot find selectiveDisclosure_1 artifacts");
         let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
 
         let note = sample_note(7);
@@ -82,10 +108,9 @@ mod tests {
 
     #[test]
     #[ignore]
-    #[should_panic]
     fn test_selective_disclosure_wrong_private_key_fails() {
-        let (wasm, r1cs) =
-            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let (wasm, r1cs) = load_artifacts("selectiveDisclosure_1")
+            .expect("Cannot find selectiveDisclosure_1 artifacts");
         let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
 
         let note = sample_note(14);
@@ -94,15 +119,17 @@ mod tests {
             build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
         inputs.set("inPrivateKey", vec![Scalar::from(9999u64)]);
 
-        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+        assert!(
+            !proof_verifies(&wasm, &r1cs, &inputs, &keys),
+            "Wrong private key case unexpectedly verified; expected rejection"
+        );
     }
 
     #[test]
     #[ignore]
-    #[should_panic]
     fn test_selective_disclosure_wrong_amount_fails() {
-        let (wasm, r1cs) =
-            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let (wasm, r1cs) = load_artifacts("selectiveDisclosure_1")
+            .expect("Cannot find selectiveDisclosure_1 artifacts");
         let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
 
         let note = sample_note(18);
@@ -111,15 +138,17 @@ mod tests {
             build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
         inputs.set("inAmount", vec![Scalar::from(9999u64)]);
 
-        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+        assert!(
+            !proof_verifies(&wasm, &r1cs, &inputs, &keys),
+            "Wrong amount case unexpectedly verified; expected rejection"
+        );
     }
 
     #[test]
     #[ignore]
-    #[should_panic]
     fn test_selective_disclosure_wrong_blinding_fails() {
-        let (wasm, r1cs) =
-            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let (wasm, r1cs) = load_artifacts("selectiveDisclosure_1")
+            .expect("Cannot find selectiveDisclosure_1 artifacts");
         let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
 
         let note = sample_note(25);
@@ -128,15 +157,17 @@ mod tests {
             build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
         inputs.set("inBlinding", vec![Scalar::from(8888u64)]);
 
-        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+        assert!(
+            !proof_verifies(&wasm, &r1cs, &inputs, &keys),
+            "Wrong blinding case unexpectedly verified; expected rejection"
+        );
     }
 
     #[test]
     #[ignore]
-    #[should_panic]
     fn test_selective_disclosure_wrong_path_fails() {
-        let (wasm, r1cs) =
-            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let (wasm, r1cs) = load_artifacts("selectiveDisclosure_1")
+            .expect("Cannot find selectiveDisclosure_1 artifacts");
         let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
 
         let note = sample_note(21);
@@ -146,15 +177,17 @@ mod tests {
         let zeros: Vec<BigInt> = (0..LEVELS).map(|_| BigInt::from(0u32)).collect();
         inputs.set("inPathElements", zeros);
 
-        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+        assert!(
+            !proof_verifies(&wasm, &r1cs, &inputs, &keys),
+            "Wrong Merkle path case unexpectedly verified; expected rejection"
+        );
     }
 
     #[test]
     #[ignore]
-    #[should_panic]
     fn test_selective_disclosure_wrong_root_fails() {
-        let (wasm, r1cs) =
-            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let (wasm, r1cs) = load_artifacts("selectiveDisclosure_1")
+            .expect("Cannot find selectiveDisclosure_1 artifacts");
         let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
 
         let note = sample_note(28);
@@ -163,15 +196,17 @@ mod tests {
             build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
         inputs.set("roots", vec![scalar_to_bigint(Scalar::from(12345u64))]);
 
-        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+        assert!(
+            !proof_verifies(&wasm, &r1cs, &inputs, &keys),
+            "Wrong root case unexpectedly verified; expected rejection"
+        );
     }
 
     #[test]
     #[ignore]
-    #[should_panic]
     fn test_selective_disclosure_wrong_note_commitment_fails() {
-        let (wasm, r1cs) =
-            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let (wasm, r1cs) = load_artifacts("selectiveDisclosure_1")
+            .expect("Cannot find selectiveDisclosure_1 artifacts");
         let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
 
         let note = sample_note(35);
@@ -183,7 +218,9 @@ mod tests {
             vec![scalar_to_bigint(Scalar::from(99999u64))],
         );
 
-        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+        assert!(
+            !proof_verifies(&wasm, &r1cs, &inputs, &keys),
+            "Wrong note commitment case unexpectedly verified; expected rejection"
+        );
     }
-
 }

--- a/circuits/src/test/prove_selective_disclosure.rs
+++ b/circuits/src/test/prove_selective_disclosure.rs
@@ -1,0 +1,189 @@
+#[cfg(test)]
+mod tests {
+    use crate::test::utils::{
+        circom_tester::{Inputs, generate_keys, prove_and_verify_with_keys},
+        general::{load_artifacts, scalar_to_bigint},
+        keypair::derive_public_key,
+        merkle_tree::{merkle_proof, merkle_root},
+        transaction::{commitment, prepopulated_leaves},
+    };
+    use anyhow::{Context, Result};
+    use num_bigint::BigInt;
+    use zkhash::fields::bn256::FpBN256 as Scalar;
+
+    const LEVELS: usize = 10;
+    const EXT_CONTEXT_HASH: u64 = 0xC0FFEE_u64;
+
+    /// Note material for a single selective-disclosure proof.
+    struct DisclosureNote {
+        leaf_index: usize,
+        priv_key: Scalar,
+        blinding: Scalar,
+        amount: Scalar,
+    }
+
+    fn build_inputs(
+        note: &DisclosureNote,
+        leaves: &[Scalar],
+        ext_context_hash: Scalar,
+    ) -> Result<Inputs> {
+        let pub_key = derive_public_key(note.priv_key);
+        let note_commitment = commitment(note.amount, pub_key, note.blinding);
+
+        let mut frozen = leaves.to_vec();
+        frozen[note.leaf_index] = note_commitment;
+
+        let root = merkle_root(frozen.clone());
+        let (siblings, path_idx_u64, depth) = merkle_proof(&frozen, note.leaf_index);
+        assert_eq!(depth, LEVELS, "unexpected Merkle depth: expected {LEVELS}, got {depth}");
+
+        let path_elements: Vec<BigInt> = siblings.into_iter().map(scalar_to_bigint).collect();
+
+        let mut inputs = Inputs::new();
+        inputs.set("roots", vec![scalar_to_bigint(root)]);
+        inputs.set("noteCommitments", vec![scalar_to_bigint(note_commitment)]);
+        inputs.set("extContextHash", ext_context_hash);
+        inputs.set("inAmount", vec![note.amount]);
+        inputs.set("inPrivateKey", vec![note.priv_key]);
+        inputs.set("inBlinding", vec![note.blinding]);
+        inputs.set("inPathIndices", vec![Scalar::from(path_idx_u64)]);
+        inputs.set("inPathElements", path_elements);
+        Ok(inputs)
+    }
+
+    fn sample_note(leaf_index: usize) -> DisclosureNote {
+        DisclosureNote {
+            leaf_index,
+            priv_key: Scalar::from(4242u64),
+            blinding: Scalar::from(5151u64),
+            amount: Scalar::from(17u64),
+        }
+    }
+
+    fn sample_leaves(note: &DisclosureNote) -> Vec<Scalar> {
+        prepopulated_leaves(LEVELS, 0xD15C_105E_u64, &[note.leaf_index], 24)
+    }
+
+    #[test]
+    #[ignore]
+    fn test_selective_disclosure_valid_note() -> Result<()> {
+        let (wasm, r1cs) =
+            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
+
+        let note = sample_note(7);
+        let leaves = sample_leaves(&note);
+        let inputs = build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH))?;
+        let res = prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys)
+            .context("prove_and_verify failed")?;
+        assert!(res.verified, "selective disclosure proof did not verify");
+        Ok(())
+    }
+
+    #[test]
+    #[ignore]
+    #[should_panic]
+    fn test_selective_disclosure_wrong_private_key_fails() {
+        let (wasm, r1cs) =
+            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
+
+        let note = sample_note(14);
+        let leaves = sample_leaves(&note);
+        let mut inputs =
+            build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
+        inputs.set("inPrivateKey", vec![Scalar::from(9999u64)]);
+
+        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+    }
+
+    #[test]
+    #[ignore]
+    #[should_panic]
+    fn test_selective_disclosure_wrong_amount_fails() {
+        let (wasm, r1cs) =
+            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
+
+        let note = sample_note(18);
+        let leaves = sample_leaves(&note);
+        let mut inputs =
+            build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
+        inputs.set("inAmount", vec![Scalar::from(9999u64)]);
+
+        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+    }
+
+    #[test]
+    #[ignore]
+    #[should_panic]
+    fn test_selective_disclosure_wrong_blinding_fails() {
+        let (wasm, r1cs) =
+            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
+
+        let note = sample_note(25);
+        let leaves = sample_leaves(&note);
+        let mut inputs =
+            build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
+        inputs.set("inBlinding", vec![Scalar::from(8888u64)]);
+
+        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+    }
+
+    #[test]
+    #[ignore]
+    #[should_panic]
+    fn test_selective_disclosure_wrong_path_fails() {
+        let (wasm, r1cs) =
+            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
+
+        let note = sample_note(21);
+        let leaves = sample_leaves(&note);
+        let mut inputs =
+            build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
+        let zeros: Vec<BigInt> = (0..LEVELS).map(|_| BigInt::from(0u32)).collect();
+        inputs.set("inPathElements", zeros);
+
+        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+    }
+
+    #[test]
+    #[ignore]
+    #[should_panic]
+    fn test_selective_disclosure_wrong_root_fails() {
+        let (wasm, r1cs) =
+            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
+
+        let note = sample_note(28);
+        let leaves = sample_leaves(&note);
+        let mut inputs =
+            build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
+        inputs.set("roots", vec![scalar_to_bigint(Scalar::from(12345u64))]);
+
+        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+    }
+
+    #[test]
+    #[ignore]
+    #[should_panic]
+    fn test_selective_disclosure_wrong_note_commitment_fails() {
+        let (wasm, r1cs) =
+            load_artifacts("selectiveDisclosure_1").expect("Cannot find selectiveDisclosure_1 artifacts");
+        let keys = generate_keys(&wasm, &r1cs).expect("Groth16 key generation failed");
+
+        let note = sample_note(35);
+        let leaves = sample_leaves(&note);
+        let mut inputs =
+            build_inputs(&note, &leaves, Scalar::from(EXT_CONTEXT_HASH)).expect("witness inputs");
+        inputs.set(
+            "noteCommitments",
+            vec![scalar_to_bigint(Scalar::from(99999u64))],
+        );
+
+        prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys).unwrap();
+    }
+
+}

--- a/contracts/pool/src/pool.rs
+++ b/contracts/pool/src/pool.rs
@@ -706,6 +706,16 @@ impl PoolContract {
         Ok(MerkleTreeWithHistory::get_last_root(env)?)
     }
 
+    /// Check whether a pool Merkle root is still in the recent root history.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment
+    /// * `root` - Pool Merkle root to check
+    pub fn is_known_root(env: &Env, root: &U256) -> Result<bool, Error> {
+        Ok(MerkleTreeWithHistory::is_known_root(env, root)?)
+    }
+
     /// Update the contract administrator
     ///
     /// Transfers administrative control to a new address. Requires

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -131,6 +131,26 @@ fn setup_test_contracts(env: &Env) -> TestSetup {
     }
 }
 
+fn register_pool(
+    env: &Env,
+    setup: &TestSetup,
+    maximum_deposit_amount: U256,
+    levels: u32,
+) -> Address {
+    env.register(
+        PoolContract,
+        (
+            setup.admin.clone(),
+            setup.token.clone(),
+            setup.verifier.clone(),
+            setup.asp_membership_address.clone(),
+            setup.asp_non_membership_address.clone(),
+            maximum_deposit_amount,
+            levels,
+        ),
+    )
+}
+
 /// Create a test environment that disables snapshot writing under Miri.
 /// Miri's isolation mode blocks filesystem operations, which the Soroban SDK
 /// uses for test snapshots.
@@ -154,18 +174,7 @@ fn pool_constructor_sets_state() {
     let setup = setup_test_contracts(&env);
     let max = U256::from_u32(&env, 100);
     let levels = 8u32;
-    let pool_id = env.register(
-        PoolContract,
-        (
-            setup.admin.clone(),
-            setup.token.clone(),
-            setup.verifier.clone(),
-            setup.asp_membership_address.clone(),
-            setup.asp_non_membership_address.clone(),
-            max.clone(),
-            levels,
-        ),
-    );
+    let pool_id = register_pool(&env, &setup, max.clone(), levels);
     let pool = PoolContractClient::new(&env, &pool_id);
 
     let stored_admin: Address = env.as_contract(&pool_id, || {
@@ -202,18 +211,7 @@ fn merkle_init_only_once() {
     let max = U256::from_u32(&env, 100);
     let levels = 8u32;
     // First init should succeed
-    let pool_id = env.register(
-        PoolContract,
-        (
-            setup.admin.clone(),
-            setup.token.clone(),
-            setup.verifier.clone(),
-            setup.asp_membership_address.clone(),
-            setup.asp_non_membership_address.clone(),
-            max.clone(),
-            levels,
-        ),
-    );
+    let pool_id = register_pool(&env, &setup, max, levels);
 
     env.as_contract(&pool_id, || {
         // Second init should return AlreadyInitialized error
@@ -228,18 +226,7 @@ fn merkle_insert_updates_root_and_index() {
     let setup = setup_test_contracts(&env);
     let max = U256::from_u32(&env, 100);
     let levels = 8u32;
-    let pool_id = env.register(
-        PoolContract,
-        (
-            setup.admin.clone(),
-            setup.token.clone(),
-            setup.verifier.clone(),
-            setup.asp_membership_address.clone(),
-            setup.asp_non_membership_address.clone(),
-            max.clone(),
-            levels,
-        ),
-    );
+    let pool_id = register_pool(&env, &setup, max, levels);
 
     env.as_contract(&pool_id, || {
         let leaf1 = U256::from_u32(&env, 0x01);
@@ -269,23 +256,103 @@ fn merkle_insert_updates_root_and_index() {
 }
 
 #[test]
+fn pool_is_known_root_returns_true_for_latest_root() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 8);
+    let pool = PoolContractClient::new(&env, &pool_id);
+
+    let latest_root = pool.get_root();
+
+    assert!(pool.is_known_root(&latest_root));
+}
+
+#[test]
+fn pool_is_known_root_returns_true_for_recent_historical_root() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 8);
+    let pool = PoolContractClient::new(&env, &pool_id);
+
+    env.as_contract(&pool_id, || {
+        MerkleTreeWithHistory::insert_two_leaves(
+            &env,
+            U256::from_u32(&env, 1),
+            U256::from_u32(&env, 2),
+        )
+        .unwrap_or_else(|err| panic!("expected first insertion to succeed: {err:?}"));
+    });
+    let historical_root = pool.get_root();
+    env.as_contract(&pool_id, || {
+        MerkleTreeWithHistory::insert_two_leaves(
+            &env,
+            U256::from_u32(&env, 3),
+            U256::from_u32(&env, 4),
+        )
+        .unwrap_or_else(|err| panic!("expected second insertion to succeed: {err:?}"));
+    });
+
+    assert!(pool.is_known_root(&historical_root));
+}
+
+#[test]
+fn pool_is_known_root_returns_false_for_zero_root() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 8);
+    let pool = PoolContractClient::new(&env, &pool_id);
+    let zero_root = U256::from_u32(&env, 0);
+
+    assert!(!pool.is_known_root(&zero_root));
+}
+
+#[test]
+fn pool_is_known_root_returns_false_for_evicted_root() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 8);
+    let pool = PoolContractClient::new(&env, &pool_id);
+
+    env.as_contract(&pool_id, || {
+        MerkleTreeWithHistory::insert_two_leaves(
+            &env,
+            U256::from_u32(&env, 1),
+            U256::from_u32(&env, 2),
+        )
+        .unwrap_or_else(|err| panic!("expected first insertion to succeed: {err:?}"));
+    });
+    let evicted_root = pool.get_root();
+
+    for i in 0..90u32 {
+        let left = i
+            .checked_mul(2)
+            .and_then(|value| value.checked_add(3))
+            .unwrap_or_else(|| panic!("left leaf value overflow"));
+        let right = left
+            .checked_add(1)
+            .unwrap_or_else(|| panic!("right leaf value overflow"));
+        env.as_contract(&pool_id, || {
+            MerkleTreeWithHistory::insert_two_leaves(
+                &env,
+                U256::from_u32(&env, left),
+                U256::from_u32(&env, right),
+            )
+            .unwrap_or_else(|err| {
+                panic!("expected history rotation insertion to succeed: {err:?}")
+            });
+        });
+    }
+
+    assert!(!pool.is_known_root(&evicted_root));
+}
+
+#[test]
 fn merkle_insert_fails_when_full() {
     let env = test_env();
     let setup = setup_test_contracts(&env);
     let max = U256::from_u32(&env, 100);
     let levels = 1u32;
-    let pool_id = env.register(
-        PoolContract,
-        (
-            setup.admin.clone(),
-            setup.token.clone(),
-            setup.verifier.clone(),
-            setup.asp_membership_address.clone(),
-            setup.asp_non_membership_address.clone(),
-            max.clone(),
-            levels,
-        ),
-    );
+    let pool_id = register_pool(&env, &setup, max, levels);
 
     env.as_contract(&pool_id, || {
         let leaf1 = U256::from_u32(&env, 0x0A);
@@ -307,18 +374,7 @@ fn merkle_init_rejects_zero_levels() {
     let setup = setup_test_contracts(&env);
     let max = U256::from_u32(&env, 100);
     let levels = 8u32;
-    let pool_id = env.register(
-        PoolContract,
-        (
-            setup.admin.clone(),
-            setup.token.clone(),
-            setup.verifier.clone(),
-            setup.asp_membership_address.clone(),
-            setup.asp_non_membership_address.clone(),
-            max.clone(),
-            levels,
-        ),
-    );
+    let pool_id = register_pool(&env, &setup, max, levels);
     let levels = 0u32;
 
     env.as_contract(&pool_id, || {
@@ -334,18 +390,7 @@ fn transact_rejects_unknown_root() {
     let max = U256::from_u32(&env, 1000);
     let levels = 3u32;
     let root = U256::from_u32(&env, 0xFF); // not a known root
-    let pool_id = env.register(
-        PoolContract,
-        (
-            setup.admin.clone(),
-            setup.token.clone(),
-            setup.verifier.clone(),
-            setup.asp_membership_address.clone(),
-            setup.asp_non_membership_address.clone(),
-            max.clone(),
-            levels,
-        ),
-    );
+    let pool_id = register_pool(&env, &setup, max, levels);
     let pool = PoolContractClient::new(&env, &pool_id);
 
     env.mock_all_auths();
@@ -381,18 +426,7 @@ fn transact_rejects_bad_ext_hash() {
     let setup = setup_test_contracts(&env);
     let max = U256::from_u32(&env, 1000);
     let levels = 3u32;
-    let pool_id = env.register(
-        PoolContract,
-        (
-            setup.admin.clone(),
-            setup.token.clone(),
-            setup.verifier.clone(),
-            setup.asp_membership_address.clone(),
-            setup.asp_non_membership_address.clone(),
-            max.clone(),
-            levels,
-        ),
-    );
+    let pool_id = register_pool(&env, &setup, max, levels);
     let pool = PoolContractClient::new(&env, &pool_id);
 
     env.mock_all_auths();
@@ -429,18 +463,7 @@ fn transact_rejects_bad_public_amount() {
     let setup = setup_test_contracts(&env);
     let max = U256::from_u32(&env, 1000);
     let levels = 3u32;
-    let pool_id = env.register(
-        PoolContract,
-        (
-            setup.admin.clone(),
-            setup.token.clone(),
-            setup.verifier.clone(),
-            setup.asp_membership_address.clone(),
-            setup.asp_non_membership_address.clone(),
-            max.clone(),
-            levels,
-        ),
-    );
+    let pool_id = register_pool(&env, &setup, max, levels);
     let pool = PoolContractClient::new(&env, &pool_id);
 
     env.mock_all_auths();


### PR DESCRIPTION
This PR introduces the core selective-disclosure support:
- Adds types for the JSON-receipt schema in the types crate.
- Adds a small disclosure crate that registers `selectiveDisclosure_1`, serializes public inputs in circuit order, and reuses the generic prover crate for real Groth16 proof generation and verification. (Adds a registry to support more selectiveDisclosure circuit instances).

The PR mocks some parts, and it's mostly theoretical for now (there is some dead code, and some functions/types will probably change). This is intentional as I wanted to make sure it can be merged into main without compromising the current demo functionality.  Next PRs will include breaking changes: new web workers for proving disclosure and UI changes to enable proving/verification in the web app directly.