### PR TITLE
feat: add push notifications to remind users after 5 days of inactivity

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -44,12 +44,12 @@ if [ ! -d "$CIRCUIT_OUT" ]; then
     exit 1
 fi
 
-cp "$CIRCUIT_OUT"/*.r1cs $TRUNK_STAGING_DIR/circuits/
-cp "$CIRCUIT_OUT"/*.wasm $TRUNK_STAGING_DIR/circuits/
+cp "$CIRCUIT_OUT"/*.r1cs "$TRUNK_STAGING_DIR/circuits/"
+cp "$CIRCUIT_OUT"/*.wasm "$TRUNK_STAGING_DIR/circuits/"
 
 # Static files
-cp app/admin.html $TRUNK_STAGING_DIR/ 2>/dev/null || true
-cp app/disclosure.html $TRUNK_STAGING_DIR/ 2>/dev/null || true
+cp app/admin.html "$TRUNK_STAGING_DIR/" 2>/dev/null || true
+cp app/disclosure.html "$TRUNK_STAGING_DIR/" 2>/dev/null || true
 
 # Distribution legal files (licenses + notices).
 sh deployments/scripts/stage-dist-legal.sh "$TRUNK_STAGING_DIR"
@@ -63,10 +63,10 @@ sh deployments/scripts/package-circuits-source-bundle.sh "$TRUNK_STAGING_DIR/cir
 stage = "build"
 command = "sh"
 command_arguments = ["-c", """
-./app/node_modules/.bin/esbuild app/js/ui.js --external:./web.js --bundle --outfile=$TRUNK_STAGING_DIR/js/ui.js --format=esm
-./app/node_modules/.bin/esbuild app/js/admin.js --external:./web.js --bundle --outfile=$TRUNK_STAGING_DIR/js/admin.js --format=esm
-./app/node_modules/.bin/esbuild app/js/disclosure.js --external:./web.js --bundle --outfile=$TRUNK_STAGING_DIR/js/disclosure.js --format=esm
+./app/node_modules/.bin/esbuild app/js/ui.js --external:./web.js --bundle --outfile="$TRUNK_STAGING_DIR/js/ui.js" --format=esm
+./app/node_modules/.bin/esbuild app/js/admin.js --external:./web.js --bundle --outfile="$TRUNK_STAGING_DIR/js/admin.js" --format=esm
+./app/node_modules/.bin/esbuild app/js/disclosure.js --external:./web.js --bundle --outfile="$TRUNK_STAGING_DIR/js/disclosure.js" --format=esm
 
 # Service worker must be served from the root (not bundled with ui.js) so it has full-page scope
-cp app/js/sw.js $TRUNK_STAGING_DIR/sw.js
+cp app/js/sw.js "$TRUNK_STAGING_DIR/sw.js"
 """]

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -66,4 +66,7 @@ command_arguments = ["-c", """
 ./app/node_modules/.bin/esbuild app/js/ui.js --external:./web.js --bundle --outfile=$TRUNK_STAGING_DIR/js/ui.js --format=esm
 ./app/node_modules/.bin/esbuild app/js/admin.js --external:./web.js --bundle --outfile=$TRUNK_STAGING_DIR/js/admin.js --format=esm
 ./app/node_modules/.bin/esbuild app/js/disclosure.js --external:./web.js --bundle --outfile=$TRUNK_STAGING_DIR/js/disclosure.js --format=esm
+
+# Service worker must be served from the root (not bundled with ui.js) so it has full-page scope
+cp app/js/sw.js $TRUNK_STAGING_DIR/sw.js
 """]

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -44,11 +44,11 @@ if [ ! -d "$CIRCUIT_OUT" ]; then
     exit 1
 fi
 
-cp "$CIRCUIT_OUT"/*.r1cs $TRUNK_STAGING_DIR/circuits/
-cp "$CIRCUIT_OUT"/*.wasm $TRUNK_STAGING_DIR/circuits/
+cp "$CIRCUIT_OUT"/*.r1cs "$TRUNK_STAGING_DIR/circuits/"
+cp "$CIRCUIT_OUT"/*.wasm "$TRUNK_STAGING_DIR/circuits/"
 
 # Static files
-cp app/admin.html $TRUNK_STAGING_DIR/ 2>/dev/null || true
+cp app/admin.html "$TRUNK_STAGING_DIR/" 2>/dev/null || true
 
 # Distribution legal files (licenses + notices).
 sh deployments/scripts/stage-dist-legal.sh "$TRUNK_STAGING_DIR"
@@ -62,9 +62,9 @@ sh deployments/scripts/package-circuits-source-bundle.sh "$TRUNK_STAGING_DIR/cir
 stage = "build"
 command = "sh"
 command_arguments = ["-c", """
-./app/node_modules/.bin/esbuild app/js/ui.js --external:./web.js --bundle --outfile=$TRUNK_STAGING_DIR/js/ui.js --format=esm
-./app/node_modules/.bin/esbuild app/js/admin.js --external:./web.js --bundle --outfile=$TRUNK_STAGING_DIR/js/admin.js --format=esm
+./app/node_modules/.bin/esbuild app/js/ui.js --external:./web.js --bundle --outfile="$TRUNK_STAGING_DIR/js/ui.js" --format=esm
+./app/node_modules/.bin/esbuild app/js/admin.js --external:./web.js --bundle --outfile="$TRUNK_STAGING_DIR/js/admin.js" --format=esm
 
 # Service worker must be served from the root (not bundled with ui.js) so it has full-page scope
-cp app/js/sw.js $TRUNK_STAGING_DIR/sw.js
+cp app/js/sw.js "$TRUNK_STAGING_DIR/sw.js"
 """]

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -64,4 +64,7 @@ command = "sh"
 command_arguments = ["-c", """
 ./app/node_modules/.bin/esbuild app/js/ui.js --external:./web.js --bundle --outfile=$TRUNK_STAGING_DIR/js/ui.js --format=esm
 ./app/node_modules/.bin/esbuild app/js/admin.js --external:./web.js --bundle --outfile=$TRUNK_STAGING_DIR/js/admin.js --format=esm
+
+# Service worker must be served from the root (not bundled with ui.js) so it has full-page scope
+cp app/js/sw.js $TRUNK_STAGING_DIR/sw.js
 """]

--- a/app/index.html
+++ b/app/index.html
@@ -1000,8 +1000,12 @@
                             <span class="w-5 h-5 rounded-full border border-current flex items-center justify-center text-[10px] font-semibold">2</span>
                             <span>Storage</span>
                         </li>
-                        <li data-step="keys" data-state="pending" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-dark-700 bg-dark-900/40 text-dark-400">
+                        <li data-step="notifications" data-state="pending" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-dark-700 bg-dark-900/40 text-dark-400">
                             <span class="w-5 h-5 rounded-full border border-current flex items-center justify-center text-[10px] font-semibold">3</span>
+                            <span>Notifications</span>
+                        </li>
+                        <li data-step="keys" data-state="pending" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-dark-700 bg-dark-900/40 text-dark-400">
+                            <span class="w-5 h-5 rounded-full border border-current flex items-center justify-center text-[10px] font-semibold">4</span>
                             <span>Privacy keys</span>
                         </li>
                     </ol>

--- a/app/index.html
+++ b/app/index.html
@@ -1018,8 +1018,12 @@
                             <span class="w-5 h-5 rounded-full border border-current flex items-center justify-center text-[10px] font-semibold">2</span>
                             <span>Storage</span>
                         </li>
-                        <li data-step="keys" data-state="pending" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-dark-700 bg-dark-900/40 text-dark-400">
+                        <li data-step="notifications" data-state="pending" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-dark-700 bg-dark-900/40 text-dark-400">
                             <span class="w-5 h-5 rounded-full border border-current flex items-center justify-center text-[10px] font-semibold">3</span>
+                            <span>Notifications</span>
+                        </li>
+                        <li data-step="keys" data-state="pending" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-dark-700 bg-dark-900/40 text-dark-400">
+                            <span class="w-5 h-5 rounded-full border border-current flex items-center justify-center text-[10px] font-semibold">4</span>
                             <span>Privacy keys</span>
                         </li>
                     </ol>

--- a/app/js/sw.js
+++ b/app/js/sw.js
@@ -1,0 +1,32 @@
+const FIVE_DAYS_MS = 5 * 24 * 60 * 60 * 1000;
+const META_CACHE = 'poolstellar-meta';
+const LAST_VISIT_URL = '/last-visit';
+
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (e) => e.waitUntil(self.clients.claim()));
+
+self.addEventListener('periodicsync', (e) => {
+    if (e.tag === 'check-last-visit') {
+        e.waitUntil(checkAndNotify());
+    }
+});
+
+async function checkAndNotify() {
+    const cache = await caches.open(META_CACHE);
+    const res = await cache.match(LAST_VISIT_URL);
+    if (!res) return;
+
+    const lastVisit = parseInt(await res.text(), 10);
+    if (!lastVisit || Date.now() - lastVisit < FIVE_DAYS_MS) return;
+
+    // Skip if the user already has the tab open
+    const openClients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    if (openClients.some((c) => c.visibilityState === 'visible')) return;
+
+    await self.registration.showNotification('PoolStellar Reminder', {
+        body: "It's been over 5 days since you last opened PoolStellar. Open the app to stay within the RPC retention window.",
+        icon: '/assets/logo.svg',
+        tag: 'reopen-reminder',
+        renotify: false,
+    });
+}

--- a/app/js/ui.js
+++ b/app/js/ui.js
@@ -11,6 +11,7 @@ import { AddressBook } from './ui/address-book.js';
 import { Transactions } from './ui/transactions.js';
 import { OnchainState } from './ui/onchain-state.js';
 import { PoolEvents } from './ui/pool-events.js';
+import { updateLastVisit, registerServiceWorker } from './ui/push-notifications.js';
 
 // Initialize on DOM ready
 document.addEventListener('DOMContentLoaded', async () => {
@@ -22,7 +23,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     AddressBook.init();
     OnchainState.init();
     PoolEvents.init();
-    
+
+    updateLastVisit();
+    registerServiceWorker();
+
     // On first page load, attempt to onboard immediately (Freighter + WASM + keys).
     // If the user rejects, they can click "Connect Freighter" to retry.
     Wallet.connect({ auto: true }).catch(() => {});

--- a/app/js/ui/onboarding-wizard.js
+++ b/app/js/ui/onboarding-wizard.js
@@ -423,7 +423,6 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
 
     if (needsNotificationsStep) {
         setStepState('notifications', 'current');
-        setNotificationsPrompted();
         renderStepContent(`
             <div class="space-y-3 text-sm text-dark-300">
                 <p class="text-xs text-dark-500">Step 3/4 · Optional, but recommended.</p>
@@ -447,6 +446,7 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
                 text: 'Not now',
                 variant: 'secondary',
                 onClick: () => {
+                    setNotificationsPrompted();
                     abort.signal.removeEventListener('abort', onAbort);
                     resolve();
                 },
@@ -465,6 +465,7 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
                         if (permission === 'granted') {
                             await registerServiceWorker();
                         }
+                        setNotificationsPrompted();
                         abort.signal.removeEventListener('abort', onAbort);
                         resolve();
                     } catch (e) {

--- a/app/js/ui/onboarding-wizard.js
+++ b/app/js/ui/onboarding-wizard.js
@@ -1,5 +1,12 @@
 import { getHandle } from '../wasm-facade.js';
 import { deriveKeysFromWallet } from '../wallet.js';
+import {
+    hasNotificationSupport,
+    getNotificationsPrompted,
+    setNotificationsPrompted,
+    requestNotificationPermission,
+    registerServiceWorker,
+} from './push-notifications.js';
 
 const STORAGE_PERSIST_FLAG = 'poolstellar_storage_persist_prompted';
 
@@ -259,7 +266,13 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
     const prompted = storageAvailable ? getPersistPromptedFlag() : true;
     const needsStorageStep = storageAvailable && !persisted && !prompted;
 
-    if (!needsDisclaimer && !needsStorageStep && !needsKeys) {
+    const notificationsSupported = hasNotificationSupport();
+    const notificationsPrompted = notificationsSupported ? getNotificationsPrompted() : true;
+    const notificationsPermission = notificationsSupported ? Notification.permission : 'denied';
+    const needsNotificationsStep =
+        notificationsSupported && !notificationsPrompted && notificationsPermission === 'default';
+
+    if (!needsDisclaimer && !needsStorageStep && !needsNotificationsStep && !needsKeys) {
         return {
             pubKey: existingKeys.noteKeypair.public,
             encryptionKeypair: {
@@ -283,6 +296,7 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
 
     setStepState('disclaimer', needsDisclaimer ? 'current' : 'done');
     setStepState('storage', needsStorageStep ? 'pending' : 'done');
+    setStepState('notifications', needsNotificationsStep ? 'pending' : 'done');
     setStepState('keys', needsKeys ? 'pending' : 'done');
 
     if (needsDisclaimer) {
@@ -292,7 +306,7 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
 
         const intro = document.createElement('p');
         intro.className = 'text-xs text-dark-500';
-        intro.textContent = 'Step 1/3 · Please review and accept the Terms & Conditions to continue.';
+        intro.textContent = 'Step 1/4 · Please review and accept the Terms & Conditions to continue.';
         wrap.appendChild(intro);
 
         const md = document.createElement('div');
@@ -347,7 +361,7 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
         setPersistPromptedFlag();
         renderStepContent(`
             <div class="space-y-3 text-sm text-dark-300">
-                <p class="text-xs text-dark-500">Step 2/3 · Optional, but recommended.</p>
+                <p class="text-xs text-dark-500">Step 2/4 · Optional, but recommended.</p>
                 <h3 class="text-base font-semibold text-dark-100">Enable durable storage?</h3>
                 <p>
                     This app stores your local database in the browser (SQLite via OPFS).
@@ -407,6 +421,67 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
         setStepState('storage', 'done');
     }
 
+    if (needsNotificationsStep) {
+        setStepState('notifications', 'current');
+        setNotificationsPrompted();
+        renderStepContent(`
+            <div class="space-y-3 text-sm text-dark-300">
+                <p class="text-xs text-dark-500">Step 3/4 · Optional, but recommended.</p>
+                <h3 class="text-base font-semibold text-dark-100">Enable reminders?</h3>
+                <p>
+                    PoolStellar relies on the Stellar RPC retention window (7 days). If you don't open
+                    the app for more than 5 days, we'll send a browser notification to remind you to
+                    sync before your local state falls outside the window.
+                </p>
+                <p class="text-xs text-dark-500">
+                    No push server is involved — reminders are triggered locally by your browser.
+                </p>
+            </div>
+        `);
+
+        await new Promise((resolve) => {
+            const onAbort = () => resolve();
+            abort.signal.addEventListener('abort', onAbort, { once: true });
+
+            const notNow = makeButton({
+                text: 'Not now',
+                variant: 'secondary',
+                onClick: () => {
+                    abort.signal.removeEventListener('abort', onAbort);
+                    resolve();
+                },
+            });
+
+            const enable = makeButton({
+                text: 'Enable reminders',
+                variant: 'primary',
+                onClick: async () => {
+                    try {
+                        setError('');
+                        notNow.disabled = true;
+                        enable.disabled = true;
+                        setButtonLoading?.('Requesting notification permission…');
+                        const permission = await requestNotificationPermission();
+                        if (permission === 'granted') {
+                            await registerServiceWorker();
+                        }
+                        abort.signal.removeEventListener('abort', onAbort);
+                        resolve();
+                    } catch (e) {
+                        notNow.disabled = false;
+                        enable.disabled = false;
+                        setError(e?.message || 'Failed to request notification permission');
+                    }
+                },
+            });
+
+            renderActions([notNow, enable]);
+        });
+
+        if (cancelled) throw new Error('Onboarding cancelled');
+        setStepState('notifications', 'done');
+    }
+
     let keys = existingKeys;
     if (needsKeys) {
         setStepState('keys', 'current');
@@ -416,7 +491,7 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
 
         const intro = document.createElement('p');
         intro.className = 'text-xs text-dark-500';
-        intro.textContent = 'Step 3/3 · Create your privacy keys.';
+        intro.textContent = 'Step 4/4 · Create your privacy keys.';
         wrap.appendChild(intro);
 
         const title = document.createElement('h3');

--- a/app/js/ui/onboarding-wizard.js
+++ b/app/js/ui/onboarding-wizard.js
@@ -1,5 +1,12 @@
 import { getHandle } from '../wasm-facade.js';
 import { deriveKeysFromWallet } from '../wallet.js';
+import {
+    hasNotificationSupport,
+    getNotificationsPrompted,
+    setNotificationsPrompted,
+    requestNotificationPermission,
+    registerServiceWorker,
+} from './push-notifications.js';
 
 const STORAGE_PERSIST_FLAG = 'poolstellar_storage_persist_prompted';
 
@@ -248,7 +255,13 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
     const prompted = storageAvailable ? getPersistPromptedFlag() : true;
     const needsStorageStep = storageAvailable && !persisted && !prompted;
 
-    if (!needsDisclaimer && !needsStorageStep && !needsKeys) {
+    const notificationsSupported = hasNotificationSupport();
+    const notificationsPrompted = notificationsSupported ? getNotificationsPrompted() : true;
+    const notificationsPermission = notificationsSupported ? Notification.permission : 'denied';
+    const needsNotificationsStep =
+        notificationsSupported && !notificationsPrompted && notificationsPermission === 'default';
+
+    if (!needsDisclaimer && !needsStorageStep && !needsNotificationsStep && !needsKeys) {
         return {
             privKey: existingKeys.noteKeypair.private,
             pubKey: existingKeys.noteKeypair.public,
@@ -273,6 +286,7 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
 
     setStepState('disclaimer', needsDisclaimer ? 'current' : 'done');
     setStepState('storage', needsStorageStep ? 'pending' : 'done');
+    setStepState('notifications', needsNotificationsStep ? 'pending' : 'done');
     setStepState('keys', needsKeys ? 'pending' : 'done');
 
     if (needsDisclaimer) {
@@ -282,7 +296,7 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
 
         const intro = document.createElement('p');
         intro.className = 'text-xs text-dark-500';
-        intro.textContent = 'Step 1/3 · Please review and accept the Terms & Conditions to continue.';
+        intro.textContent = 'Step 1/4 · Please review and accept the Terms & Conditions to continue.';
         wrap.appendChild(intro);
 
         const md = document.createElement('div');
@@ -337,7 +351,7 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
         setPersistPromptedFlag();
         renderStepContent(`
             <div class="space-y-3 text-sm text-dark-300">
-                <p class="text-xs text-dark-500">Step 2/3 · Optional, but recommended.</p>
+                <p class="text-xs text-dark-500">Step 2/4 · Optional, but recommended.</p>
                 <h3 class="text-base font-semibold text-dark-100">Enable durable storage?</h3>
                 <p>
                     This app stores your local database in the browser (SQLite via OPFS).
@@ -397,6 +411,67 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
         setStepState('storage', 'done');
     }
 
+    if (needsNotificationsStep) {
+        setStepState('notifications', 'current');
+        setNotificationsPrompted();
+        renderStepContent(`
+            <div class="space-y-3 text-sm text-dark-300">
+                <p class="text-xs text-dark-500">Step 3/4 · Optional, but recommended.</p>
+                <h3 class="text-base font-semibold text-dark-100">Enable reminders?</h3>
+                <p>
+                    PoolStellar relies on the Stellar RPC retention window (7 days). If you don't open
+                    the app for more than 5 days, we'll send a browser notification to remind you to
+                    sync before your local state falls outside the window.
+                </p>
+                <p class="text-xs text-dark-500">
+                    No push server is involved — reminders are triggered locally by your browser.
+                </p>
+            </div>
+        `);
+
+        await new Promise((resolve) => {
+            const onAbort = () => resolve();
+            abort.signal.addEventListener('abort', onAbort, { once: true });
+
+            const notNow = makeButton({
+                text: 'Not now',
+                variant: 'secondary',
+                onClick: () => {
+                    abort.signal.removeEventListener('abort', onAbort);
+                    resolve();
+                },
+            });
+
+            const enable = makeButton({
+                text: 'Enable reminders',
+                variant: 'primary',
+                onClick: async () => {
+                    try {
+                        setError('');
+                        notNow.disabled = true;
+                        enable.disabled = true;
+                        setButtonLoading?.('Requesting notification permission…');
+                        const permission = await requestNotificationPermission();
+                        if (permission === 'granted') {
+                            await registerServiceWorker();
+                        }
+                        abort.signal.removeEventListener('abort', onAbort);
+                        resolve();
+                    } catch (e) {
+                        notNow.disabled = false;
+                        enable.disabled = false;
+                        setError(e?.message || 'Failed to request notification permission');
+                    }
+                },
+            });
+
+            renderActions([notNow, enable]);
+        });
+
+        if (cancelled) throw new Error('Onboarding cancelled');
+        setStepState('notifications', 'done');
+    }
+
     let keys = existingKeys;
     if (needsKeys) {
         setStepState('keys', 'current');
@@ -406,7 +481,7 @@ export async function runOnboardingWizard({ address, setButtonLoading } = {}) {
 
         const intro = document.createElement('p');
         intro.className = 'text-xs text-dark-500';
-        intro.textContent = 'Step 3/3 · Create your privacy keys.';
+        intro.textContent = 'Step 4/4 · Create your privacy keys.';
         wrap.appendChild(intro);
 
         const title = document.createElement('h3');

--- a/app/js/ui/push-notifications.js
+++ b/app/js/ui/push-notifications.js
@@ -1,0 +1,63 @@
+const NOTIFICATIONS_PROMPTED_FLAG = 'poolstellar_notifications_prompted';
+const META_CACHE = 'poolstellar-meta';
+const LAST_VISIT_URL = '/last-visit';
+
+export function hasNotificationSupport() {
+    return typeof Notification !== 'undefined' && 'serviceWorker' in navigator;
+}
+
+export function getNotificationsPrompted() {
+    try {
+        return window.localStorage.getItem(NOTIFICATIONS_PROMPTED_FLAG) === '1';
+    } catch {
+        return false;
+    }
+}
+
+export function setNotificationsPrompted() {
+    try {
+        window.localStorage.setItem(NOTIFICATIONS_PROMPTED_FLAG, '1');
+    } catch {
+        // ignore
+    }
+}
+
+export async function requestNotificationPermission() {
+    if (!hasNotificationSupport()) return 'unsupported';
+    try {
+        return await Notification.requestPermission();
+    } catch (e) {
+        console.debug('[PushNotifications] requestPermission failed:', e);
+        return 'denied';
+    }
+}
+
+export async function registerServiceWorker() {
+    if (!('serviceWorker' in navigator)) return;
+    try {
+        const reg = await navigator.serviceWorker.register('/sw.js');
+        if ('periodicSync' in reg) {
+            try {
+                const status = await navigator.permissions.query({ name: 'periodic-background-sync' });
+                if (status.state === 'granted') {
+                    await reg.periodicSync.register('check-last-visit', {
+                        minInterval: 24 * 60 * 60 * 1000,
+                    });
+                }
+            } catch (e) {
+                console.debug('[PushNotifications] periodicSync registration failed:', e);
+            }
+        }
+    } catch (e) {
+        console.debug('[PushNotifications] SW registration failed:', e);
+    }
+}
+
+export async function updateLastVisit() {
+    try {
+        const cache = await caches.open(META_CACHE);
+        await cache.put(LAST_VISIT_URL, new Response(String(Date.now())));
+    } catch (e) {
+        console.debug('[PushNotifications] updateLastVisit failed:', e);
+    }
+}

--- a/app/js/ui/push-notifications.js
+++ b/app/js/ui/push-notifications.js
@@ -17,8 +17,8 @@ export function getNotificationsPrompted() {
 export function setNotificationsPrompted() {
     try {
         window.localStorage.setItem(NOTIFICATIONS_PROMPTED_FLAG, '1');
-    } catch {
-        // ignore
+    } catch (e) {
+        console.error('[PushNotifications] setNotificationsPrompted failed:', e);
     }
 }
 


### PR DESCRIPTION
Closes #160

## Summary
- Adds a service worker (`sw.js`) that fires a browser notification if the user has been away for more than 5 days
- Adds a `push-notifications.js` module handling permission requests, SW registration, and last-visit tracking via Cache API
- Wires a notifications step into the onboarding wizard to prompt users for permission on first use
- Calls `updateLastVisit()` and `registerServiceWorker()` on every page load

## How it works
On each visit the current timestamp is stored in the Cache API. A `periodicsync` event (`check-last-visit`, min interval 24 h) wakes the service worker in the background; if more than 5 days have elapsed and no app tab is visible, a desktop notification is shown.

## Test plan
- [x] Connect wallet — onboarding wizard shows a Notifications step and requests browser permission
- [x] Grant permission → service worker registers at `/sw.js` with scope `/`
- [x] In DevTools console, fake last visit: `const c = await caches.open('poolstellar-meta'); await c.put('/last-visit', new Response(String(Date.now() - 6*24*60*60*1000)))`
- [x] Navigate away from the tab, then in Application → Service Workers trigger periodic sync tag `check-last-visit` → notification fires