### PR TITLE
Reject non-canonical BN256 nullifiers

### DIFF
--- a/contracts/pool/src/pool.rs
+++ b/contracts/pool/src/pool.rs
@@ -51,6 +51,8 @@ pub enum Error {
     NotInitialized = 11,
     /// Arithmetic overflow occurred
     Overflow = 12,
+    /// Public input is not canonical in the BN254 scalar field
+    NonCanonicalPublicInput = 13,
 }
 
 /// Conversion from MerkleTreeWithHistory errors to pool contract errors
@@ -391,6 +393,37 @@ impl PoolContract {
         Ok(())
     }
 
+    /// Reject values outside the canonical BN254 scalar-field range.
+    ///
+    /// `Bn254Fr::from_bytes` expects field elements, so any `U256` that will be
+    /// converted into a verifier public input must be checked before
+    /// conversion.
+    fn validate_bn256_public_input(value: &U256, modulus: &U256) -> Result<(), Error> {
+        if value >= modulus {
+            return Err(Error::NonCanonicalPublicInput);
+        }
+
+        Ok(())
+    }
+
+    /// Validate every `U256` field that contributes to the verifier's public
+    /// input vector. The transaction path checks `ext_data_hash` against
+    /// `hash_ext_data` before proof verification, so this covers the remaining
+    /// public-input values.
+    fn validate_bn256_public_inputs(proof: &Proof, modulus: &U256) -> Result<(), Error> {
+        Self::validate_bn256_public_input(&proof.root, modulus)?;
+        Self::validate_bn256_public_input(&proof.public_amount, modulus)?;
+        for nullifier in proof.input_nullifiers.iter() {
+            Self::validate_bn256_public_input(&nullifier, modulus)?;
+        }
+        Self::validate_bn256_public_input(&proof.output_commitment0, modulus)?;
+        Self::validate_bn256_public_input(&proof.output_commitment1, modulus)?;
+        Self::validate_bn256_public_input(&proof.asp_membership_root, modulus)?;
+        Self::validate_bn256_public_input(&proof.asp_non_membership_root, modulus)?;
+
+        Ok(())
+    }
+
     /// Verify a zero-knowledge proof
     ///
     /// # Arguments
@@ -408,6 +441,7 @@ impl PoolContract {
         }
         let verifier = Self::get_verifier(env)?;
         let client = CircomGroth16VerifierClient::new(env, &verifier);
+        Self::validate_bn256_public_inputs(proof, &bn256_modulus(env))?;
 
         // Public inputs must match the order declared by the policy circuit:
         // [root, public_amount, ext_data_hash, input_nullifiers,

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ExtData, PoolContract, PoolContractClient, Proof,
+    Error, ExtData, PoolContract, PoolContractClient, Proof,
     merkle_with_history::{MerkleDataKey, MerkleTreeWithHistory},
 };
 use asp_membership::{ASPMembership, ASPMembershipClient};
@@ -452,4 +452,160 @@ fn transact_rejects_bad_public_amount() {
     };
 
     assert!(pool.try_transact(&proof, &ext, &sender).is_err());
+}
+
+#[test]
+fn transact_rejects_non_canonical_nullifier() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let maximum_deposit_amount = U256::from_u32(&env, 1000);
+    let levels = 3u32;
+    let pool_id = env.register(
+        PoolContract,
+        (
+            setup.admin.clone(),
+            setup.token.clone(),
+            setup.verifier.clone(),
+            setup.asp_membership_address.clone(),
+            setup.asp_non_membership_address.clone(),
+            maximum_deposit_amount.clone(),
+            levels,
+        ),
+    );
+    let pool = PoolContractClient::new(&env, &pool_id);
+
+    env.mock_all_auths();
+    let sender = Address::generate(&env);
+    let root = pool.get_root();
+    let ext = mk_ext_data(&env, Address::generate(&env), 0);
+    let ext_hash = compute_ext_hash(&env, &ext);
+
+    let asp_membership_root = setup.asp_membership_client.get_root();
+    let asp_non_membership_root = setup.asp_non_membership_client.get_root();
+
+    let proof = Proof {
+        proof: mk_mock_groth16_proof(&env),
+        root,
+        input_nullifiers: {
+            let mut v: Vec<U256> = Vec::new(&env);
+            let non_canonical_nullifier = bn256_modulus(&env);
+            v.push_back(non_canonical_nullifier);
+            v
+        },
+        output_commitment0: U256::from_u32(&env, 0x07),
+        output_commitment1: U256::from_u32(&env, 0x08),
+        public_amount: U256::from_u32(&env, 0),
+        ext_data_hash: ext_hash,
+        asp_membership_root,
+        asp_non_membership_root,
+    };
+
+    assert!(matches!(
+        pool.try_transact(&proof, &ext, &sender),
+        Err(Ok(Error::NonCanonicalPublicInput))
+    ));
+}
+
+#[test]
+fn transact_rejects_non_canonical_output_commitment() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let maximum_deposit_amount = U256::from_u32(&env, 1000);
+    let levels = 3u32;
+    let pool_id = env.register(
+        PoolContract,
+        (
+            setup.admin.clone(),
+            setup.token.clone(),
+            setup.verifier.clone(),
+            setup.asp_membership_address.clone(),
+            setup.asp_non_membership_address.clone(),
+            maximum_deposit_amount.clone(),
+            levels,
+        ),
+    );
+    let pool = PoolContractClient::new(&env, &pool_id);
+
+    env.mock_all_auths();
+    let sender = Address::generate(&env);
+    let root = pool.get_root();
+    let ext = mk_ext_data(&env, Address::generate(&env), 0);
+    let ext_hash = compute_ext_hash(&env, &ext);
+
+    let asp_membership_root = setup.asp_membership_client.get_root();
+    let asp_non_membership_root = setup.asp_non_membership_client.get_root();
+
+    let proof = Proof {
+        proof: mk_mock_groth16_proof(&env),
+        root,
+        input_nullifiers: {
+            let mut v: Vec<U256> = Vec::new(&env);
+            v.push_back(U256::from_u32(&env, 0xEE));
+            v
+        },
+        output_commitment0: bn256_modulus(&env),
+        output_commitment1: U256::from_u32(&env, 0x08),
+        public_amount: U256::from_u32(&env, 0),
+        ext_data_hash: ext_hash,
+        asp_membership_root,
+        asp_non_membership_root,
+    };
+
+    assert!(matches!(
+        pool.try_transact(&proof, &ext, &sender),
+        Err(Ok(Error::NonCanonicalPublicInput))
+    ));
+}
+
+#[test]
+fn transact_does_not_reject_boundary_canonical_public_input() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let maximum_deposit_amount = U256::from_u32(&env, 1000);
+    let levels = 3u32;
+    let pool_id = env.register(
+        PoolContract,
+        (
+            setup.admin.clone(),
+            setup.token.clone(),
+            setup.verifier.clone(),
+            setup.asp_membership_address.clone(),
+            setup.asp_non_membership_address.clone(),
+            maximum_deposit_amount.clone(),
+            levels,
+        ),
+    );
+    let pool = PoolContractClient::new(&env, &pool_id);
+
+    env.mock_all_auths();
+    let sender = Address::generate(&env);
+    let root = pool.get_root();
+    let ext = mk_ext_data(&env, Address::generate(&env), 0);
+    let ext_hash = compute_ext_hash(&env, &ext);
+
+    let asp_membership_root = setup.asp_membership_client.get_root();
+    let asp_non_membership_root = setup.asp_non_membership_client.get_root();
+    let one = U256::from_u32(&env, 1);
+
+    let proof = Proof {
+        proof: mk_mock_groth16_proof(&env),
+        root,
+        input_nullifiers: {
+            let mut v: Vec<U256> = Vec::new(&env);
+            let canonical_boundary_nullifier = bn256_modulus(&env).sub(&one);
+            v.push_back(canonical_boundary_nullifier);
+            v
+        },
+        output_commitment0: bn256_modulus(&env).sub(&one),
+        output_commitment1: U256::from_u32(&env, 0x08),
+        public_amount: U256::from_u32(&env, 0),
+        ext_data_hash: ext_hash,
+        asp_membership_root,
+        asp_non_membership_root,
+    };
+
+    assert!(!matches!(
+        pool.try_transact(&proof, &ext, &sender),
+        Err(Ok(Error::NonCanonicalPublicInput))
+    ));
 }


### PR DESCRIPTION
## Summary

Reject BN256 nullifiers that are not canonical field elements before they are passed to the verifier or written into pool state.

This adds a pool-level canonicality check for input nullifiers. Values greater than or equal to the BN256 scalar modulus now fail with `NonCanonicalPublicInput`.

## Changes

- Add `Error::NonCanonicalPublicInput`.
- Add a small helper to reject `U256 >= bn256_modulus`.
- Validate all input nullifiers before spent checks.
- Add a regression test for non-canonical nullifiers.

## Validation

Ran:

```sh
VERIFIER_VK_JSON=$PWD/deployments/testnet/circuit_keys/policy_tx_2_2_vk.json cargo test -p pool --locked -j 1 -- --nocapture
```

Result:

```text
9 passed; 0 failed
```

Also ran:

```sh
cargo fmt --package pool
git diff --check -- contracts/pool/src/pool.rs contracts/pool/src/test.rs
```
