### PR TITLE
Transaction planner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,6 +1825,8 @@ dependencies = [
  "pool",
  "soroban-sdk",
  "soroban-utils",
+ "tx-planner",
+ "types",
  "zkhash",
 ]
 
@@ -5183,6 +5185,14 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
+name = "tx-planner"
+version = "0.1.0"
+dependencies = [
+ "thiserror 2.0.18",
+ "types",
+]
 
 [[package]]
 name = "type_analysis"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "app/crates/core/prover",
     "app/crates/core/state",
     "app/crates/core/stellar",
+    "app/crates/core/tx-planner",
     "app/crates/core/types",
     "app/crates/core/witness",
     "app/crates/platforms/web",

--- a/app/crates/core/tx-planner/Cargo.toml
+++ b/app/crates/core/tx-planner/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tx-planner"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "Transaction planning for private pool operations"
+
+[dependencies]
+thiserror = { workspace = true }
+types = { workspace = true }
+
+[lints]
+workspace = true

--- a/app/crates/core/tx-planner/README.md
+++ b/app/crates/core/tx-planner/README.md
@@ -1,0 +1,47 @@
+# tx-planner
+
+Builds a **transaction plan** for private pool spends: which wallet notes to use, how many on-chain `transact` calls to make, and what each step does.
+
+Each on-chain transaction is a **2-in / 2-out** `transact` (at most two real inputs, two outputs). The planner only emits steps that fit that shape.
+
+## What it optimizes for
+
+The goal is to pay a target `NoteAmount` while keeping wallet and chain cost low:
+
+1. **Fewer on-chain transactions** — each `PlannedStep` is one `transact`. Spending `k` notes usually needs `k - 1` steps (merge pairs, then a final spend). One note that already covers the amount needs a single step.
+
+2. **Fewer notes touched** — spending fewer inputs means fewer commitments consumed and usually less consolidation. Exact matches avoid unnecessary change notes in the pool.
+
+3. **Exact before overshoot** — when the target cannot be matched exactly, prefer the smallest excess (change returned on the final step).
+
+## Coin selection priority
+
+[`find_combination`](src/plan/combination.rs) picks note indices from the wallet. It tries tiers in this order and stops at the first hit:
+
+| Order | Result | Meaning |
+|------:|--------|---------|
+| 1 | Two exact | Two notes sum to the goal |
+| 2 | One exact | A single note equals the goal |
+| 3 | Two overshoot | Two notes cover the goal; excess becomes change |
+| 4 | One overshoot | One note covers the goal; excess becomes change |
+| 5 | Exact k (k ≥ 3) | Smallest k notes that sum exactly to the goal |
+| 6 | Overshoot (greedy) | Fallback when no exact k-subset exists |
+
+Two-note pairs are tried before a single-note exact match so common “pay from two inputs” cases use one `transact` instead of leaving an extra note idle.
+
+At most [`TRANSACTION_LIMIT`](src/plan/combination.rs) notes (10) may be selected; [`plan`](src/plan/mod.rs) rejects larger sets.
+
+## Plan shape
+
+[`plan(amount, notes)`](src/plan/mod.rs) runs coin selection, then builds a [`TransactionPlan`](src/plan/mod.rs):
+
+- **One note** — one step, `Final` (send + optional change).
+- **Several notes** — `Consolidate` steps merge two inputs into one synthetic note, then the last step is `Final` (send + optional change).
+
+The executor (outside this crate) turns each step into proofs and a `transact` invocation.
+
+## Public API
+
+- `plan` — main entry: wallet notes + spend amount → `TransactionPlan` or `PlanError`
+- `find_combination` — coin selection only (for tests or custom wiring)
+- `TransactionPlan`, `SpendableNote`, `PlannedStep`, `StepAction`, `CombinationResult`, `PlanError`

--- a/app/crates/core/tx-planner/src/lib.rs
+++ b/app/crates/core/tx-planner/src/lib.rs
@@ -1,0 +1,8 @@
+//! Transaction planning for private pool operations.
+
+mod plan;
+
+pub use plan::{
+    CombinationResult, PlanError, PlannedStep, SpendableNote, StepAction, StepNote,
+    TRANSACTION_LIMIT, TransactionPlan, find_combination, plan,
+};

--- a/app/crates/core/tx-planner/src/plan/combination.rs
+++ b/app/crates/core/tx-planner/src/plan/combination.rs
@@ -39,17 +39,17 @@ pub fn find_combination(
     sorted_vals.sort_unstable_by_key(|&(_, x)| x);
 
     let two = TwoScan::scan(&sorted_vals, goal)?;
-    if let TwoScan::Exact(a, b) = two {
-        return Ok(CombinationResult::TwoExact(a, b));
+    if let TwoScan::Exact(i, j) = two {
+        return Ok(CombinationResult::TwoExact(i, j));
     }
 
-    let one = OneScan::scan(&sorted_vals, goal)?;
+    let one = OneScan::scan(&sorted_vals, goal);
     if let OneScan::Exact(i) = one {
         return Ok(CombinationResult::OneExact(i));
     }
 
-    if let TwoScan::Overshoot(a, b, excess) = two {
-        return Ok(CombinationResult::TwoOvershoot(a, b, excess));
+    if let TwoScan::Overshoot(i, j, excess) = two {
+        return Ok(CombinationResult::TwoOvershoot(i, j, excess));
     }
 
     if let OneScan::Overshoot(i, excess) = one {
@@ -72,15 +72,8 @@ enum TwoScan {
 impl TwoScan {
     /// Two-pointer scan over ascending `(index, amount)` pairs.
     fn scan(sorted: &[(usize, NoteAmount)], goal: NoteAmount) -> Result<Self, PlanError> {
-        Ok(Self::scan_impl(sorted, goal)?.unwrap_or(Self::Miss))
-    }
-
-    fn scan_impl(
-        sorted: &[(usize, NoteAmount)],
-        goal: NoteAmount,
-    ) -> Result<Option<Self>, PlanError> {
         if sorted.len() < 2 {
-            return Ok(None);
+            return Ok(Self::Miss);
         }
 
         let mut best_overshoot: Option<(usize, usize, NoteAmount)> = None;
@@ -88,28 +81,33 @@ impl TwoScan {
         let mut right = sorted
             .len()
             .checked_sub(1)
-            .ok_or(PlanError::InputAmountOverflow)?;
+            .ok_or_else(|| PlanError::internal("two-scan: right bound underflow"))?;
         while left < right {
-            let sum = sorted[left]
-                .1
-                .checked_add(sorted[right].1)
-                .ok_or(PlanError::InputAmountOverflow)?;
+            let Some(sum) = sorted[left].1.checked_add(sorted[right].1) else {
+                return Err(PlanError::InputAmountOverflow);
+            };
             let Some(diff) = sum.checked_sub(goal) else {
-                left = left.checked_add(1).ok_or(PlanError::InputAmountOverflow)?;
+                left = left
+                    .checked_add(1)
+                    .ok_or_else(|| PlanError::internal("two-scan: left index overflow"))?;
                 continue;
             };
             if diff.is_zero() {
-                return Ok(Some(Self::Exact(sorted[left].0, sorted[right].0)));
+                return Ok(Self::Exact(sorted[left].0, sorted[right].0));
             }
             if diff > NoteAmount::ZERO {
                 if best_overshoot.is_none_or(|(_, _, excess)| diff < excess) {
                     best_overshoot = Some((sorted[left].0, sorted[right].0, diff));
                 }
-                right = right.checked_sub(1).ok_or(PlanError::InputAmountOverflow)?;
+                right = right
+                    .checked_sub(1)
+                    .ok_or_else(|| PlanError::internal("two-scan: right index underflow"))?;
             }
         }
 
-        Ok(best_overshoot.map(|(a, b, excess)| Self::Overshoot(a, b, excess)))
+        Ok(best_overshoot
+            .map(|(i, j, excess)| Self::Overshoot(i, j, excess))
+            .unwrap_or(Self::Miss))
     }
 }
 
@@ -121,27 +119,19 @@ enum OneScan {
 
 impl OneScan {
     /// Linear scan over ascending `(index, amount)` values.
-    fn scan(sorted: &[(usize, NoteAmount)], goal: NoteAmount) -> Result<Self, PlanError> {
-        let mut exact = None;
-        let mut overshoot = None;
-
+    fn scan(sorted: &[(usize, NoteAmount)], goal: NoteAmount) -> Self {
         for &(idx, x) in sorted {
             let Some(diff) = x.checked_sub(goal) else {
                 continue;
             };
             if diff.is_zero() {
-                exact = Some(idx);
+                return Self::Exact(idx);
             } else if diff > NoteAmount::ZERO {
-                overshoot = Some((idx, diff));
-                break;
+                return Self::Overshoot(idx, diff);
             }
         }
 
-        Ok(match (exact, overshoot) {
-            (Some(i), _) => Self::Exact(i),
-            (None, Some((i, excess))) => Self::Overshoot(i, excess),
-            (None, None) => Self::Miss,
-        })
+        Self::Miss
     }
 }
 
@@ -154,13 +144,6 @@ enum KScan {
 impl KScan {
     /// k≥3 DFS on notes `< goal`, then greedy overshoot (largest notes first).
     fn scan(sorted: &[(usize, NoteAmount)], goal: NoteAmount) -> Result<Self, PlanError> {
-        Ok(Self::scan_impl(sorted, goal)?.unwrap_or(Self::Miss))
-    }
-
-    fn scan_impl(
-        sorted: &[(usize, NoteAmount)],
-        goal: NoteAmount,
-    ) -> Result<Option<Self>, PlanError> {
         let mut candidates_desc: Vec<(usize, NoteAmount)> =
             sorted.iter().copied().filter(|&(_, x)| x < goal).collect();
         candidates_desc.reverse();
@@ -181,11 +164,11 @@ impl KScan {
                     best_overshoot: &mut best_overshoot,
                 };
                 if Self::dfs(NoteAmount::ZERO, 0, &mut ctx)? {
-                    return Ok(Some(Self::Exact(path)));
+                    return Ok(Self::Exact(path));
                 }
 
                 if let Some((excess, overshoot_path)) = best_overshoot {
-                    return Ok(Some(Self::Overshoot(overshoot_path, excess)));
+                    return Ok(Self::Overshoot(overshoot_path, excess));
                 }
             }
         }
@@ -194,23 +177,23 @@ impl KScan {
     }
 
     /// Greedily add largest notes until the sum reaches the goal.
-    fn greedy_impl(
-        sorted: &[(usize, NoteAmount)],
-        goal: NoteAmount,
-    ) -> Result<Option<Self>, PlanError> {
+    fn greedy_impl(sorted: &[(usize, NoteAmount)], goal: NoteAmount) -> Result<Self, PlanError> {
         let mut total = NoteAmount::ZERO;
         let mut picks: Vec<usize> = Vec::new();
         for &(idx, x) in sorted.iter().rev() {
-            total = total.checked_add(x).ok_or(PlanError::InputAmountOverflow)?;
+            let Some(next_total) = total.checked_add(x) else {
+                return Err(PlanError::InputAmountOverflow);
+            };
+            total = next_total;
             picks.push(idx);
             if total >= goal {
                 let excess = total
                     .checked_sub(goal)
-                    .ok_or(PlanError::InputAmountOverflow)?;
-                return Ok(Some(Self::Overshoot(picks, excess)));
+                    .ok_or_else(|| PlanError::internal("greedy: excess invariant"))?;
+                return Ok(Self::Overshoot(picks, excess));
             }
         }
-        Ok(None)
+        Ok(Self::Miss)
     }
 
     fn dfs(sum: NoteAmount, index: usize, ctx: &mut DfsContext<'_>) -> Result<bool, PlanError> {
@@ -239,16 +222,19 @@ impl KScan {
         *ctx.iteration_limit = ctx
             .iteration_limit
             .checked_sub(1)
-            .ok_or(PlanError::InputAmountOverflow)?;
+            .ok_or_else(|| PlanError::internal("dfs: iteration limit underflow"))?;
 
-        let next_index = index.checked_add(1).ok_or(PlanError::InputAmountOverflow)?;
+        let next_index = index
+            .checked_add(1)
+            .ok_or_else(|| PlanError::internal("dfs: index overflow"))?;
         let note_index = ctx.candidates[index].0;
         let note_amount = ctx.candidates[index].1;
 
         ctx.path.push(note_index);
-        if let Some(with_note) = sum.checked_add(note_amount)
-            && Self::dfs(with_note, next_index, ctx)?
-        {
+        let Some(with_note) = sum.checked_add(note_amount) else {
+            return Err(PlanError::InputAmountOverflow);
+        };
+        if Self::dfs(with_note, next_index, ctx)? {
             return Ok(true);
         }
         ctx.path.pop();
@@ -278,6 +264,10 @@ mod tests {
         NoteAmount::from(amount)
     }
 
+    fn excess(amount: u128) -> NoteAmount {
+        NoteAmount::from(amount)
+    }
+
     fn find(values: &[NoteAmount], goal: NoteAmount) -> CombinationResult {
         find_combination(values, goal).expect("combination should succeed")
     }
@@ -289,8 +279,14 @@ mod tests {
     }
 
     #[test]
-    fn comb_one_exact() {
+    fn comb_one_exact_0() {
         let dataset = amounts(&[3, 6, 10]);
+        assert_eq!(find(&dataset, goal(10)), CombinationResult::OneExact(2));
+    }
+
+    #[test]
+    fn comb_one_exact_1() {
+        let dataset = amounts(&[3, 6, 10, 13]);
         assert_eq!(find(&dataset, goal(10)), CombinationResult::OneExact(2));
     }
 
@@ -299,7 +295,7 @@ mod tests {
         let dataset = amounts(&[1, 2, 5, 6, 12]);
         assert_eq!(
             find(&dataset, goal(10)),
-            CombinationResult::TwoOvershoot(2, 3, goal(1))
+            CombinationResult::TwoOvershoot(2, 3, excess(1))
         );
     }
 
@@ -308,7 +304,7 @@ mod tests {
         let dataset = amounts(&[15]);
         assert_eq!(
             find(&dataset, goal(10)),
-            CombinationResult::OneOvershoot(0, goal(5))
+            CombinationResult::OneOvershoot(0, excess(5))
         );
     }
 
@@ -326,7 +322,7 @@ mod tests {
         let dataset = amounts(&[2, 3, 6]);
         assert_eq!(
             find(&dataset, goal(10)),
-            CombinationResult::Overshoot(vec![2, 1, 0], goal(1))
+            CombinationResult::Overshoot(vec![2, 1, 0], excess(1))
         );
     }
 

--- a/app/crates/core/tx-planner/src/plan/combination.rs
+++ b/app/crates/core/tx-planner/src/plan/combination.rs
@@ -1,0 +1,338 @@
+//! Coin selection: pick note indices that reach a target amount.
+
+use super::PlanError;
+use types::NoteAmount;
+
+/// Upper bound on combination size explored by [`find_combination`].
+pub const TRANSACTION_LIMIT: usize = 10;
+
+#[derive(Debug, PartialEq)]
+pub enum CombinationResult {
+    /// Tier 1: Exactly two elements that sum exactly to the goal
+    TwoExact(usize, usize),
+    /// Tier 1.5: A single element that matches the goal exactly
+    OneExact(usize),
+    /// Tier 2: Exactly two elements that overshoot the goal
+    TwoOvershoot(usize, usize, NoteAmount),
+    /// Tier 2.5: A single element that overshoots the goal
+    OneOvershoot(usize, NoteAmount),
+    /// Tier 3: Three or more elements (k >= 3) that sum exactly to the goal
+    ExactK(Vec<usize>),
+    /// Tier 4: Multiple elements that overshoot the goal (greedy fallback)
+    Overshoot(Vec<usize>, NoteAmount),
+    /// No combination possible (total sum of all elements < goal)
+    Impossible,
+}
+
+/// Find a combination of elements with sum equal to or larger than the goal,
+/// prioritizing the lowest combination count (with two-note pairs preferred
+/// over single-note exact matches).
+pub fn find_combination(
+    values: &[NoteAmount],
+    goal: NoteAmount,
+) -> Result<CombinationResult, PlanError> {
+    if values.is_empty() {
+        return Ok(CombinationResult::Impossible);
+    }
+
+    let mut sorted_vals: Vec<(usize, NoteAmount)> = values.iter().copied().enumerate().collect();
+    sorted_vals.sort_unstable_by_key(|&(_, x)| x);
+
+    let two = TwoScan::scan(&sorted_vals, goal)?;
+    if let TwoScan::Exact(a, b) = two {
+        return Ok(CombinationResult::TwoExact(a, b));
+    }
+
+    let one = OneScan::scan(&sorted_vals, goal)?;
+    if let OneScan::Exact(i) = one {
+        return Ok(CombinationResult::OneExact(i));
+    }
+
+    if let TwoScan::Overshoot(a, b, excess) = two {
+        return Ok(CombinationResult::TwoOvershoot(a, b, excess));
+    }
+
+    if let OneScan::Overshoot(i, excess) = one {
+        return Ok(CombinationResult::OneOvershoot(i, excess));
+    }
+
+    match KScan::scan(&sorted_vals, goal)? {
+        KScan::Exact(indices) => Ok(CombinationResult::ExactK(indices)),
+        KScan::Overshoot(indices, excess) => Ok(CombinationResult::Overshoot(indices, excess)),
+        KScan::Miss => Ok(CombinationResult::Impossible),
+    }
+}
+
+enum TwoScan {
+    Exact(usize, usize),
+    Overshoot(usize, usize, NoteAmount),
+    Miss,
+}
+
+impl TwoScan {
+    /// Two-pointer scan over ascending `(index, amount)` pairs.
+    fn scan(sorted: &[(usize, NoteAmount)], goal: NoteAmount) -> Result<Self, PlanError> {
+        Ok(Self::scan_impl(sorted, goal)?.unwrap_or(Self::Miss))
+    }
+
+    fn scan_impl(
+        sorted: &[(usize, NoteAmount)],
+        goal: NoteAmount,
+    ) -> Result<Option<Self>, PlanError> {
+        if sorted.len() < 2 {
+            return Ok(None);
+        }
+
+        let mut best_overshoot: Option<(usize, usize, NoteAmount)> = None;
+        let mut left = 0;
+        let mut right = sorted
+            .len()
+            .checked_sub(1)
+            .ok_or(PlanError::InputAmountOverflow)?;
+        while left < right {
+            let sum = sorted[left]
+                .1
+                .checked_add(sorted[right].1)
+                .ok_or(PlanError::InputAmountOverflow)?;
+            let Some(diff) = sum.checked_sub(goal) else {
+                left = left.checked_add(1).ok_or(PlanError::InputAmountOverflow)?;
+                continue;
+            };
+            if diff.is_zero() {
+                return Ok(Some(Self::Exact(sorted[left].0, sorted[right].0)));
+            }
+            if diff > NoteAmount::ZERO {
+                if best_overshoot.is_none_or(|(_, _, excess)| diff < excess) {
+                    best_overshoot = Some((sorted[left].0, sorted[right].0, diff));
+                }
+                right = right.checked_sub(1).ok_or(PlanError::InputAmountOverflow)?;
+            }
+        }
+
+        Ok(best_overshoot.map(|(a, b, excess)| Self::Overshoot(a, b, excess)))
+    }
+}
+
+enum OneScan {
+    Exact(usize),
+    Overshoot(usize, NoteAmount),
+    Miss,
+}
+
+impl OneScan {
+    /// Linear scan over ascending `(index, amount)` values.
+    fn scan(sorted: &[(usize, NoteAmount)], goal: NoteAmount) -> Result<Self, PlanError> {
+        let mut exact = None;
+        let mut overshoot = None;
+
+        for &(idx, x) in sorted {
+            let Some(diff) = x.checked_sub(goal) else {
+                continue;
+            };
+            if diff.is_zero() {
+                exact = Some(idx);
+            } else if diff > NoteAmount::ZERO {
+                overshoot = Some((idx, diff));
+                break;
+            }
+        }
+
+        Ok(match (exact, overshoot) {
+            (Some(i), _) => Self::Exact(i),
+            (None, Some((i, excess))) => Self::Overshoot(i, excess),
+            (None, None) => Self::Miss,
+        })
+    }
+}
+
+enum KScan {
+    Exact(Vec<usize>),
+    Overshoot(Vec<usize>, NoteAmount),
+    Miss,
+}
+
+impl KScan {
+    /// k≥3 DFS on notes `< goal`, then greedy overshoot (largest notes first).
+    fn scan(sorted: &[(usize, NoteAmount)], goal: NoteAmount) -> Result<Self, PlanError> {
+        Ok(Self::scan_impl(sorted, goal)?.unwrap_or(Self::Miss))
+    }
+
+    fn scan_impl(
+        sorted: &[(usize, NoteAmount)],
+        goal: NoteAmount,
+    ) -> Result<Option<Self>, PlanError> {
+        let mut candidates_desc: Vec<(usize, NoteAmount)> =
+            sorted.iter().copied().filter(|&(_, x)| x < goal).collect();
+        candidates_desc.reverse();
+
+        if candidates_desc.len() >= 3 {
+            let max_k = std::cmp::min(candidates_desc.len(), TRANSACTION_LIMIT);
+            for k in 3..=max_k {
+                let mut iteration_limit = 5000;
+                let mut path = Vec::new();
+                let mut best_overshoot = None;
+
+                let mut ctx = DfsContext {
+                    candidates: &candidates_desc,
+                    goal,
+                    target_k: k,
+                    iteration_limit: &mut iteration_limit,
+                    path: &mut path,
+                    best_overshoot: &mut best_overshoot,
+                };
+                if Self::dfs(NoteAmount::ZERO, 0, &mut ctx)? {
+                    return Ok(Some(Self::Exact(path)));
+                }
+
+                if let Some((excess, overshoot_path)) = best_overshoot {
+                    return Ok(Some(Self::Overshoot(overshoot_path, excess)));
+                }
+            }
+        }
+
+        Self::greedy_impl(sorted, goal)
+    }
+
+    /// Greedily add largest notes until the sum reaches the goal.
+    fn greedy_impl(
+        sorted: &[(usize, NoteAmount)],
+        goal: NoteAmount,
+    ) -> Result<Option<Self>, PlanError> {
+        let mut total = NoteAmount::ZERO;
+        let mut picks: Vec<usize> = Vec::new();
+        for &(idx, x) in sorted.iter().rev() {
+            total = total.checked_add(x).ok_or(PlanError::InputAmountOverflow)?;
+            picks.push(idx);
+            if total >= goal {
+                let excess = total
+                    .checked_sub(goal)
+                    .ok_or(PlanError::InputAmountOverflow)?;
+                return Ok(Some(Self::Overshoot(picks, excess)));
+            }
+        }
+        Ok(None)
+    }
+
+    fn dfs(sum: NoteAmount, index: usize, ctx: &mut DfsContext<'_>) -> Result<bool, PlanError> {
+        if ctx.path.len() == ctx.target_k {
+            let Some(diff) = sum.checked_sub(ctx.goal) else {
+                return Ok(false);
+            };
+            if diff.is_zero() {
+                return Ok(true);
+            }
+            if diff > NoteAmount::ZERO
+                && ctx
+                    .best_overshoot
+                    .as_ref()
+                    .is_none_or(|(min_ov, _)| diff < *min_ov)
+            {
+                *ctx.best_overshoot = Some((diff, ctx.path.clone()));
+            }
+            return Ok(false);
+        }
+
+        if sum >= ctx.goal || index >= ctx.candidates.len() || *ctx.iteration_limit <= 0 {
+            return Ok(false);
+        }
+
+        *ctx.iteration_limit = ctx
+            .iteration_limit
+            .checked_sub(1)
+            .ok_or(PlanError::InputAmountOverflow)?;
+
+        let next_index = index.checked_add(1).ok_or(PlanError::InputAmountOverflow)?;
+        let note_index = ctx.candidates[index].0;
+        let note_amount = ctx.candidates[index].1;
+
+        ctx.path.push(note_index);
+        if let Some(with_note) = sum.checked_add(note_amount)
+            && Self::dfs(with_note, next_index, ctx)?
+        {
+            return Ok(true);
+        }
+        ctx.path.pop();
+
+        Self::dfs(sum, next_index, ctx)
+    }
+}
+
+struct DfsContext<'a> {
+    candidates: &'a [(usize, NoteAmount)],
+    goal: NoteAmount,
+    target_k: usize,
+    iteration_limit: &'a mut i32,
+    path: &'a mut Vec<usize>,
+    best_overshoot: &'a mut Option<(NoteAmount, Vec<usize>)>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn amounts(values: &[u128]) -> Vec<NoteAmount> {
+        values.iter().copied().map(NoteAmount::from).collect()
+    }
+
+    fn goal(amount: u128) -> NoteAmount {
+        NoteAmount::from(amount)
+    }
+
+    fn find(values: &[NoteAmount], goal: NoteAmount) -> CombinationResult {
+        find_combination(values, goal).expect("combination should succeed")
+    }
+
+    #[test]
+    fn comb_two_exact() {
+        let dataset = amounts(&[4, 6, 10]);
+        assert_eq!(find(&dataset, goal(10)), CombinationResult::TwoExact(0, 1));
+    }
+
+    #[test]
+    fn comb_one_exact() {
+        let dataset = amounts(&[3, 6, 10]);
+        assert_eq!(find(&dataset, goal(10)), CombinationResult::OneExact(2));
+    }
+
+    #[test]
+    fn comb_two_overshoot() {
+        let dataset = amounts(&[1, 2, 5, 6, 12]);
+        assert_eq!(
+            find(&dataset, goal(10)),
+            CombinationResult::TwoOvershoot(2, 3, goal(1))
+        );
+    }
+
+    #[test]
+    fn comb_one_overshoot() {
+        let dataset = amounts(&[15]);
+        assert_eq!(
+            find(&dataset, goal(10)),
+            CombinationResult::OneOvershoot(0, goal(5))
+        );
+    }
+
+    #[test]
+    fn comb_k_exact() {
+        let dataset = amounts(&[2, 3, 5]);
+        assert_eq!(
+            find(&dataset, goal(10)),
+            CombinationResult::ExactK(vec![2, 1, 0])
+        );
+    }
+
+    #[test]
+    fn comb_k_overshoot() {
+        let dataset = amounts(&[2, 3, 6]);
+        assert_eq!(
+            find(&dataset, goal(10)),
+            CombinationResult::Overshoot(vec![2, 1, 0], goal(1))
+        );
+    }
+
+    #[test]
+    fn comb_two_exact_before_one_exact() {
+        let dataset = amounts(&[4, 6, 10]);
+        assert_eq!(find(&dataset, goal(10)), CombinationResult::TwoExact(0, 1));
+    }
+}

--- a/app/crates/core/tx-planner/src/plan/error.rs
+++ b/app/crates/core/tx-planner/src/plan/error.rs
@@ -1,0 +1,36 @@
+#[derive(Debug, thiserror::Error)]
+pub enum PlanError {
+    #[error("no spendable notes")]
+    NoSpendableNotes,
+
+    #[error("no combination of notes reaches the goal amount")]
+    NoCombination,
+
+    #[error("coin selection picked {selected} notes, exceeding limit of {max_notes}")]
+    TooManyNotes { selected: usize, max_notes: usize },
+
+    #[error("note index {index} is out of range for the wallet")]
+    NoteIndexOutOfRange { index: usize },
+
+    #[error("input amount overflow")]
+    InputAmountOverflow,
+
+    #[error("planner produced an invalid transaction plan")]
+    InvalidPlan,
+
+    #[error("no spendable note with commitment {commitment}")]
+    CommitmentNotFound { commitment: types::Field },
+
+    #[error("note {commitment} has amount {actual}, expected {expected}")]
+    NoteAmountMismatch {
+        commitment: types::Field,
+        actual: types::NoteAmount,
+        expected: types::NoteAmount,
+    },
+
+    #[error("no spendable note with amount {amount}")]
+    NoNoteForAmount { amount: types::NoteAmount },
+
+    #[error("multiple spendable notes with amount {amount}")]
+    AmbiguousNoteForAmount { amount: types::NoteAmount },
+}

--- a/app/crates/core/tx-planner/src/plan/error.rs
+++ b/app/crates/core/tx-planner/src/plan/error.rs
@@ -15,6 +15,9 @@ pub enum PlanError {
     #[error("input amount overflow")]
     InputAmountOverflow,
 
+    #[error("planner internal error: {reason}")]
+    InternalError { reason: &'static str },
+
     #[error("planner produced an invalid transaction plan")]
     InvalidPlan,
 
@@ -33,4 +36,10 @@ pub enum PlanError {
 
     #[error("multiple spendable notes with amount {amount}")]
     AmbiguousNoteForAmount { amount: types::NoteAmount },
+}
+
+impl PlanError {
+    pub(crate) const fn internal(reason: &'static str) -> Self {
+        Self::InternalError { reason }
+    }
 }

--- a/app/crates/core/tx-planner/src/plan/mod.rs
+++ b/app/crates/core/tx-planner/src/plan/mod.rs
@@ -1,0 +1,669 @@
+//! Transaction planning types and [`plan`] entry point.
+
+mod combination;
+mod error;
+
+pub use combination::{CombinationResult, TRANSACTION_LIMIT, find_combination};
+pub use error::PlanError;
+
+use types::{Field, NoteAmount};
+
+/// Full plan: one or more on-chain `transact` calls (2-in / 2-out each).
+#[derive(Clone, Debug)]
+pub struct TransactionPlan {
+    steps: Vec<PlannedStep>,
+}
+
+/// One on-chain `transact` (at most 2 real inputs after padding).
+#[derive(Clone, Debug)]
+pub struct PlannedStep {
+    pub inputs: (StepNote, Option<StepNote>),
+    pub action: StepAction,
+}
+
+#[derive(Clone, Debug)]
+pub enum StepAction {
+    /// Merge two notes into one.
+    Consolidate { output: NoteAmount },
+    /// Final plan spend step.
+    Final {
+        outputs: (NoteAmount, Option<NoteAmount>),
+    },
+}
+
+/// One row in the wallet index (planner input only).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SpendableNote {
+    /// Stable id (matches DB / UI note id).
+    pub commitment: Field,
+    pub amount: NoteAmount,
+}
+
+/// One row in the wallet index (planner step input only).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StepNote {
+    /// Stable id (matches DB / UI note id).
+    ///
+    /// If `None` then the note does not exist at the time of planning.
+    pub commitment: Option<Field>,
+    pub amount: NoteAmount,
+}
+
+impl TransactionPlan {
+    pub fn len(&self) -> usize {
+        self.steps.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.steps.is_empty()
+    }
+
+    fn assemble(steps: Vec<PlannedStep>) -> Option<Self> {
+        match steps.last() {
+            Some(PlannedStep {
+                action: StepAction::Final { .. },
+                ..
+            }) => Some(Self { steps }),
+            _ => None,
+        }
+    }
+
+    /// Last step in the plan.
+    pub fn final_step(&self) -> &PlannedStep {
+        self.steps
+            .last()
+            .expect("transaction plan always has atleast one step")
+    }
+}
+
+impl IntoIterator for TransactionPlan {
+    type IntoIter = std::vec::IntoIter<PlannedStep>;
+    type Item = PlannedStep;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.steps.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a TransactionPlan {
+    type IntoIter = std::slice::Iter<'a, PlannedStep>;
+    type Item = &'a PlannedStep;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.steps.iter()
+    }
+}
+
+/// Build a plan from unspent notes and a target spend amount.
+pub fn plan(
+    amount: NoteAmount,
+    notes: &[SpendableNote],
+) -> std::result::Result<TransactionPlan, PlanError> {
+    if notes.is_empty() {
+        return Err(PlanError::NoSpendableNotes);
+    }
+
+    let values: Vec<NoteAmount> = notes.iter().map(|n| n.amount).collect();
+    let combo = find_combination(&values, amount)?;
+
+    let (indices, change) = match combo {
+        CombinationResult::Impossible => return Err(PlanError::NoCombination),
+        CombinationResult::OneExact(i) => (vec![i], None),
+        CombinationResult::TwoExact(a, b) => (vec![a, b], None),
+        CombinationResult::OneOvershoot(i, excess) => (vec![i], Some(excess)),
+        CombinationResult::TwoOvershoot(a, b, excess) => (vec![a, b], Some(excess)),
+        CombinationResult::ExactK(indices) => (indices, None),
+        CombinationResult::Overshoot(indices, excess) => (indices, Some(excess)),
+    };
+
+    if indices.len() > TRANSACTION_LIMIT {
+        return Err(PlanError::TooManyNotes {
+            selected: indices.len(),
+            max_notes: TRANSACTION_LIMIT,
+        });
+    }
+
+    for &index in &indices {
+        if index >= notes.len() {
+            return Err(PlanError::NoteIndexOutOfRange { index });
+        }
+    }
+
+    let n_steps = indices.len().saturating_sub(1).max(1);
+    let mut steps = Vec::with_capacity(n_steps);
+    let note0 = StepNote::from_spendable(notes[indices[0]].clone());
+    if indices.len() == 1 {
+        // single note
+        let action = StepAction::Final {
+            outputs: (amount, change),
+        };
+        let step = PlannedStep {
+            inputs: (note0, None),
+            action,
+        };
+        steps.push(step);
+    } else {
+        // multiple notes
+        let mut sum = note0.amount;
+        let mut prev_note = note0;
+        for index in indices.iter().skip(1) {
+            let current_note = StepNote::from_spendable(notes[*index].clone());
+            sum = sum
+                .checked_add(current_note.amount)
+                .ok_or(PlanError::InputAmountOverflow)?;
+            let action = StepAction::Consolidate { output: sum };
+            let step = PlannedStep {
+                inputs: (prev_note, Some(current_note)),
+                action,
+            };
+            steps.push(step);
+            prev_note = StepNote::from_amount(sum);
+        }
+
+        // last step is final
+        if let Some(last_step) = steps.last_mut() {
+            last_step.action = StepAction::Final {
+                outputs: (amount, change),
+            };
+        }
+    }
+
+    TransactionPlan::assemble(steps).ok_or(PlanError::InvalidPlan)
+}
+
+impl StepNote {
+    fn from_spendable(note: SpendableNote) -> Self {
+        StepNote {
+            commitment: Some(note.commitment),
+            amount: note.amount,
+        }
+    }
+
+    fn from_amount(amount: NoteAmount) -> Self {
+        StepNote {
+            commitment: None,
+            amount,
+        }
+    }
+}
+
+impl PlannedStep {
+    /// Resolve this step's inputs against the current wallet notes.
+    ///
+    /// Inputs with a known commitment are matched by commitment and amount.
+    /// Inputs without a commitment (merge intermediates) are matched by amount,
+    /// excluding the sibling input's commitment when present. Exactly one match
+    /// is required.
+    pub fn resolve(&self, notes: &[SpendableNote]) -> Result<Vec<SpendableNote>, PlanError> {
+        let mut out = Vec::with_capacity(2);
+        out.push(resolve_input_note(
+            &self.inputs.0,
+            notes,
+            self.inputs.1.as_ref(),
+        )?);
+        if let Some(second) = &self.inputs.1 {
+            out.push(resolve_input_note(second, notes, Some(&self.inputs.0))?);
+        }
+        Ok(out)
+    }
+}
+
+fn resolve_input_note(
+    input: &StepNote,
+    notes: &[SpendableNote],
+    sibling: Option<&StepNote>,
+) -> Result<SpendableNote, PlanError> {
+    match input.commitment {
+        Some(commitment) => notes
+            .iter()
+            .find(|note| note.commitment == commitment)
+            .cloned()
+            .ok_or(PlanError::CommitmentNotFound { commitment })
+            .and_then(|note| {
+                if note.amount != input.amount {
+                    Err(PlanError::NoteAmountMismatch {
+                        commitment,
+                        actual: note.amount,
+                        expected: input.amount,
+                    })
+                } else {
+                    Ok(note)
+                }
+            }),
+        None => {
+            let excluded = sibling.and_then(|note| note.commitment);
+            let matches: Vec<&SpendableNote> = notes
+                .iter()
+                .filter(|note| note.amount == input.amount)
+                .filter(|note| excluded != Some(note.commitment))
+                .collect();
+            match matches.len() {
+                0 => Err(PlanError::NoNoteForAmount {
+                    amount: input.amount,
+                }),
+                1 => Ok(matches[0].clone()),
+                _ => Err(PlanError::AmbiguousNoteForAmount {
+                    amount: input.amount,
+                }),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use types::Field;
+
+    static NOTE_SALT: AtomicUsize = AtomicUsize::new(0);
+
+    fn note(amount: u128) -> SpendableNote {
+        let salt = NOTE_SALT.fetch_add(1, Ordering::Relaxed);
+        let commitment_value = amount
+            .checked_add(1_000)
+            .and_then(|base| base.checked_add(salt as u128))
+            .expect("test note commitment value overflow");
+        SpendableNote {
+            commitment: Field::from(NoteAmount::from(commitment_value)),
+            amount: NoteAmount::from(amount),
+        }
+    }
+
+    fn goal_amount(amount: u128) -> NoteAmount {
+        NoteAmount::from(amount)
+    }
+
+    fn step_at(plan: &TransactionPlan, index: usize) -> &PlannedStep {
+        plan.into_iter()
+            .nth(index)
+            .unwrap_or_else(|| panic!("step index {index} out of range"))
+    }
+
+    fn assert_step_count(plan: &TransactionPlan, expected: usize) {
+        assert_eq!(plan.len(), expected, "unexpected step count: {plan:?}");
+    }
+
+    fn assert_final_outputs(step: &PlannedStep, send: u128, change: Option<u128>) {
+        match &step.action {
+            StepAction::Final { outputs } => {
+                assert_eq!(outputs.0, NoteAmount::from(send));
+                assert_eq!(outputs.1, change.map(NoteAmount::from));
+            }
+            other => panic!("expected final, got {other:?}"),
+        }
+    }
+
+    fn assert_consolidate_output(step: &PlannedStep, output: u128) {
+        match &step.action {
+            StepAction::Consolidate { output: out } => {
+                assert_eq!(*out, NoteAmount::from(output));
+            }
+            other => panic!("expected consolidate, got {other:?}"),
+        }
+    }
+
+    /// Sum of all spendable note amounts passed into [`plan`].
+    fn balance(notes: &[SpendableNote]) -> NoteAmount {
+        notes
+            .iter()
+            .map(|n| n.amount)
+            .fold(NoteAmount::ZERO, |sum, amount| {
+                sum.checked_add(amount)
+                    .expect("note amounts must not overflow in tests")
+            })
+    }
+
+    fn final_action(plan: &TransactionPlan) -> &StepAction {
+        match &plan.final_step().action {
+            action @ StepAction::Final { .. } => action,
+            other => panic!("expected last plan step to be final, got {other:?}"),
+        }
+    }
+
+    fn send_amount(action: &StepAction) -> NoteAmount {
+        let StepAction::Final { outputs } = action else {
+            panic!("expected final step action");
+        };
+        outputs.0
+    }
+
+    fn change_amount(action: &StepAction) -> NoteAmount {
+        let StepAction::Final { outputs } = action else {
+            panic!("expected final step action");
+        };
+        outputs.1.unwrap_or(NoteAmount::ZERO)
+    }
+
+    /// Sum of wallet notes the plan spends (each real commitment counted once).
+    fn consumed_balance(plan: &TransactionPlan) -> NoteAmount {
+        let mut seen: Vec<&Field> = Vec::new();
+        let mut total = NoteAmount::ZERO;
+        for step in plan {
+            for input in [Some(&step.inputs.0), step.inputs.1.as_ref()] {
+                let Some(input) = input else { continue };
+                let Some(commitment) = &input.commitment else {
+                    continue;
+                };
+                if seen.contains(&commitment) {
+                    continue;
+                }
+                seen.push(commitment);
+                total = total
+                    .checked_add(input.amount)
+                    .expect("note amounts must not overflow in tests");
+            }
+        }
+        total
+    }
+
+    /// Unspent wallet notes plus change from the final step.
+    fn remaining_balance(
+        wallet: NoteAmount,
+        plan: &TransactionPlan,
+        action: &StepAction,
+    ) -> NoteAmount {
+        let consumed = consumed_balance(plan);
+        let unspent = wallet
+            .checked_sub(consumed)
+            .expect("consumed must not exceed wallet in tests");
+        unspent
+            .checked_add(change_amount(action))
+            .expect("note amounts must not overflow in tests")
+    }
+
+    /// `initial - send` must equal unspent notes plus final change.
+    fn assert_balance(wallet: NoteAmount, plan: &TransactionPlan) {
+        let action = final_action(plan);
+        let send = send_amount(action);
+        let remaining = remaining_balance(wallet, plan, action);
+        assert_eq!(
+            wallet
+                .checked_sub(send)
+                .expect("wallet must cover send in tests"),
+            remaining,
+            "initial balance minus send must equal unspent notes plus change"
+        );
+        let consumed = consumed_balance(plan);
+        assert_eq!(
+            consumed,
+            send.checked_add(change_amount(action))
+                .expect("note amounts must not overflow in tests"),
+            "consumed notes must equal send plus change"
+        );
+    }
+
+    #[test]
+    fn plan_no_spendable_notes() {
+        let err = plan(goal_amount(10), &[]).expect_err("empty notes should not plan");
+        assert!(matches!(err, PlanError::NoSpendableNotes));
+    }
+
+    #[test]
+    fn plan_no_combination() {
+        let notes = vec![note(1), note(2), note(3)];
+        let err =
+            plan(goal_amount(100), &notes).expect_err("goal above wallet sum should not plan");
+        assert!(matches!(err, PlanError::NoCombination));
+    }
+
+    #[test]
+    fn plan_step_count_scales_with_note_count() {
+        let notes_1 = vec![note(10)];
+        assert_step_count(
+            &plan(goal_amount(10), &notes_1).expect("plan should succeed"),
+            1,
+        );
+
+        let notes_2 = vec![note(4), note(6), note(20)];
+        assert_step_count(
+            &plan(goal_amount(10), &notes_2).expect("plan should succeed"),
+            1,
+        );
+
+        let notes_3 = vec![note(2), note(3), note(5)];
+        assert_step_count(
+            &plan(goal_amount(10), &notes_3).expect("plan should succeed"),
+            2,
+        );
+    }
+
+    #[test]
+    fn plan_consolidate_final() {
+        let plan =
+            plan(goal_amount(10), &[note(2), note(3), note(5)]).expect("plan should succeed");
+        assert_step_count(&plan, 2);
+        assert!(matches!(
+            step_at(&plan, 0).action,
+            StepAction::Consolidate { .. }
+        ));
+        assert!(matches!(step_at(&plan, 1).action, StepAction::Final { .. }));
+    }
+
+    #[test]
+    fn plan_consolidate_consolidate_final() {
+        let plan = plan(goal_amount(10), &[note(1), note(3), note(1), note(5)])
+            .expect("plan should succeed");
+        assert_step_count(&plan, 3);
+        assert!(matches!(
+            step_at(&plan, 0).action,
+            StepAction::Consolidate { .. }
+        ));
+        assert!(matches!(
+            step_at(&plan, 1).action,
+            StepAction::Consolidate { .. }
+        ));
+        assert!(matches!(step_at(&plan, 2).action, StepAction::Final { .. }));
+    }
+
+    #[test]
+    fn plan_two_exact_0() {
+        let send = 10;
+        let notes = vec![note(4), note(6), note(10)];
+        let plan = plan(goal_amount(send), &notes).expect("plan should succeed");
+        assert_step_count(&plan, 1);
+        assert_final_outputs(plan.final_step(), send, None);
+        assert_balance(balance(&notes), &plan);
+    }
+
+    #[test]
+    fn plan_two_exact_1() {
+        let send = 10;
+        let notes = vec![note(4), note(6), note(20)];
+        let plan = plan(goal_amount(send), &notes).expect("plan should succeed");
+        assert_step_count(&plan, 1);
+        assert_final_outputs(plan.final_step(), send, None);
+        assert_balance(balance(&notes), &plan);
+    }
+
+    #[test]
+    fn plan_two_overshoot() {
+        let send = 10;
+        let notes = vec![note(1), note(2), note(5), note(6)];
+        let plan = plan(goal_amount(send), &notes).expect("plan should succeed");
+        assert_step_count(&plan, 1);
+        assert_final_outputs(plan.final_step(), send, Some(1));
+        assert_balance(balance(&notes), &plan);
+    }
+
+    #[test]
+    fn plan_one_overshoot() {
+        let send = 10;
+        let notes = vec![note(15)];
+        let plan = plan(goal_amount(send), &notes).expect("plan should succeed");
+        assert_step_count(&plan, 1);
+        assert!(step_at(&plan, 0).inputs.1.is_none());
+        assert_final_outputs(plan.final_step(), send, Some(5));
+        assert_balance(balance(&notes), &plan);
+    }
+
+    #[test]
+    fn plan_one_exact() {
+        let send = 10;
+        let notes = vec![note(3), note(6), note(10)];
+        let plan = plan(goal_amount(send), &notes).expect("plan should succeed");
+        assert_eq!(step_at(&plan, 0).inputs.0.amount, NoteAmount::from(10));
+        assert!(step_at(&plan, 0).inputs.1.is_none());
+        assert_final_outputs(plan.final_step(), send, None);
+        assert_balance(balance(&notes), &plan);
+    }
+
+    #[test]
+    fn plan_k_3_exact_0() {
+        let send = 10;
+        let notes = vec![note(2), note(3), note(5)];
+        let plan = plan(goal_amount(send), &notes).expect("plan should succeed");
+        assert_step_count(&plan, 2);
+        assert_balance(balance(&notes), &plan);
+        assert_consolidate_output(step_at(&plan, 0), 8);
+        assert_final_outputs(plan.final_step(), send, None);
+    }
+
+    #[test]
+    fn plan_k_3_overshoot_0() {
+        let send = 10;
+        let notes = vec![note(2), note(3), note(6)];
+        let plan = plan(goal_amount(send), &notes).expect("plan should succeed");
+        assert_step_count(&plan, 2);
+        assert_consolidate_output(step_at(&plan, 0), 9);
+        assert_final_outputs(plan.final_step(), send, Some(1));
+        assert_balance(balance(&notes), &plan);
+    }
+
+    #[test]
+    fn plan_k_3_exact_1() {
+        let send = 10;
+        let notes = vec![note(1), note(2), note(3), note(5)];
+        let plan = plan(goal_amount(send), &notes).expect("plan should succeed");
+        assert_step_count(&plan, 2);
+        assert_balance(balance(&notes), &plan);
+        assert_final_outputs(plan.final_step(), send, None);
+    }
+
+    #[test]
+    fn plan_k_3_overshoot_1() {
+        let send = 10;
+        let notes = vec![note(2), note(2), note(4), note(5)];
+        let plan = plan(goal_amount(send), &notes).expect("plan should succeed");
+        assert_step_count(&plan, 2);
+        assert_final_outputs(plan.final_step(), send, Some(1));
+        assert_balance(balance(&notes), &plan);
+    }
+
+    #[test]
+    fn plan_k_4_exact_0() {
+        let send = 10;
+        let notes = vec![note(1), note(1), note(3), note(5)];
+        let plan = plan(goal_amount(send), &notes).expect("plan should succeed");
+        assert_step_count(&plan, 3);
+        assert_balance(balance(&notes), &plan);
+        assert_final_outputs(plan.final_step(), send, None);
+    }
+
+    #[test]
+    fn plan_k_4_overshoot_0() {
+        let send = 10;
+        let notes = vec![note(2), note(2), note(2), note(5)];
+        let plan = plan(goal_amount(send), &notes).expect("plan should succeed");
+        assert_step_count(&plan, 3);
+        assert_final_outputs(plan.final_step(), send, Some(1));
+        assert_balance(balance(&notes), &plan);
+    }
+
+    #[test]
+    fn plan_k_4_exact_1() {
+        let send = 10;
+        let notes = vec![note(1), note(1), note(1), note(3), note(5)];
+        let plan = plan(goal_amount(send), &notes).expect("plan should succeed");
+        assert_step_count(&plan, 3);
+        assert_balance(balance(&notes), &plan);
+        assert_final_outputs(plan.final_step(), send, None);
+    }
+
+    #[test]
+    fn plan_k_4_overshoot_1() {
+        let send = 10;
+        let notes = vec![note(2), note(2), note(2), note(2), note(5)];
+        let plan = plan(goal_amount(send), &notes).expect("plan should succeed");
+        assert_step_count(&plan, 3);
+        assert_final_outputs(plan.final_step(), send, Some(1));
+        assert_balance(balance(&notes), &plan);
+    }
+
+    fn committed_note(amount: u128, commitment: u128) -> SpendableNote {
+        SpendableNote {
+            commitment: Field::from(NoteAmount::from(commitment)),
+            amount: NoteAmount::from(amount),
+        }
+    }
+
+    #[test]
+    fn resolve_final() {
+        let wallet = vec![committed_note(7, 101)];
+        let tx_plan = plan(NoteAmount::from(7), &wallet).expect("plan should succeed");
+        let step = tx_plan.into_iter().next().expect("one step");
+        let inputs = step.resolve(&wallet).expect("resolve should succeed");
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0].commitment, Field::from(NoteAmount::from(101)));
+    }
+
+    #[test]
+    fn resolve_consolidate_final() {
+        let spend = 10;
+        let wallet = vec![
+            committed_note(2, 101),
+            committed_note(3, 102),
+            committed_note(5, 103),
+        ];
+        let tx_plan = plan(goal_amount(spend), &wallet).expect("plan should succeed");
+        assert_step_count(&tx_plan, 2);
+
+        let mut steps = tx_plan.into_iter();
+
+        // consolidate step
+        let step0 = steps.next().expect("step 0");
+        let inputs0 = step0.resolve(&wallet).expect("resolve step 0");
+
+        let StepAction::Consolidate {
+            output: merge_amount,
+        } = step0.action
+        else {
+            panic!("expected first step to consolidate");
+        };
+        let merged = SpendableNote {
+            commitment: Field::from(NoteAmount::from(900)),
+            amount: merge_amount,
+        };
+        let merged_commitment = merged.commitment;
+
+        // update wallet
+        let mut wallet = wallet
+            .iter()
+            .filter(|note| {
+                note.commitment != inputs0[0].commitment && note.commitment != inputs0[1].commitment
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        wallet.push(merged);
+        assert_eq!(
+            wallet.len(),
+            2,
+            "wallet expected to have two after consolidation step"
+        );
+
+        // final step
+        let step1 = steps.next().expect("step 1");
+        let inputs1 = step1.resolve(&wallet).expect("resolve step 1");
+        assert!(
+            inputs1
+                .iter()
+                .any(|input| input.commitment == merged_commitment),
+            "expected new committed note to be input for final step"
+        );
+        let StepAction::Final { outputs } = step1.action else {
+            panic!("expected last step to be final");
+        };
+        assert_eq!(outputs.0, spend.into(), "final output is spend amount");
+        assert!(outputs.1.is_none(), "no change");
+    }
+}

--- a/app/crates/core/tx-planner/src/plan/mod.rs
+++ b/app/crates/core/tx-planner/src/plan/mod.rs
@@ -72,7 +72,7 @@ impl TransactionPlan {
     pub fn final_step(&self) -> &PlannedStep {
         self.steps
             .last()
-            .expect("transaction plan always has atleast one step")
+            .expect("transaction plan always has at least one step")
     }
 }
 
@@ -109,9 +109,9 @@ pub fn plan(
     let (indices, change) = match combo {
         CombinationResult::Impossible => return Err(PlanError::NoCombination),
         CombinationResult::OneExact(i) => (vec![i], None),
-        CombinationResult::TwoExact(a, b) => (vec![a, b], None),
+        CombinationResult::TwoExact(i, j) => (vec![i, j], None),
         CombinationResult::OneOvershoot(i, excess) => (vec![i], Some(excess)),
-        CombinationResult::TwoOvershoot(a, b, excess) => (vec![a, b], Some(excess)),
+        CombinationResult::TwoOvershoot(i, j, excess) => (vec![i, j], Some(excess)),
         CombinationResult::ExactK(indices) => (indices, None),
         CombinationResult::Overshoot(indices, excess) => (indices, Some(excess)),
     };
@@ -148,9 +148,10 @@ pub fn plan(
         let mut prev_note = note0;
         for index in indices.iter().skip(1) {
             let current_note = StepNote::from_spendable(notes[*index].clone());
-            sum = sum
-                .checked_add(current_note.amount)
-                .ok_or(PlanError::InputAmountOverflow)?;
+            let Some(next_sum) = sum.checked_add(current_note.amount) else {
+                return Err(PlanError::InputAmountOverflow);
+            };
+            sum = next_sum;
             let action = StepAction::Consolidate { output: sum };
             let step = PlannedStep {
                 inputs: (prev_note, Some(current_note)),

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -24,6 +24,8 @@ soroban-sdk = { workspace = true, features = ["testutils"] }
 soroban-utils = { workspace = true }
 
 # Shared deps
+tx-planner = { path = "../app/crates/core/tx-planner" }
+types = { workspace = true }
 zkhash = { workspace = true }
 
 [lints]

--- a/e2e-tests/src/tests/e2e_pool_2_in_2_out.rs
+++ b/e2e-tests/src/tests/e2e_pool_2_in_2_out.rs
@@ -7,7 +7,7 @@
 //! It bridges the gap between the different crates and versions.
 use super::utils::{
     LEVELS, NonMembership, build_membership_trees, bytes32_to_bigint, deploy_contracts,
-    generate_proof, non_membership_overrides_from_pubs, scalar_to_u256, u256_to_scalar,
+    generate_proof, non_membership_overrides_from_pubs, scalar_to_u256, test_env, u256_to_scalar,
     wrap_groth16_proof,
 };
 use anyhow::Result;
@@ -20,25 +20,8 @@ use circuits::test::utils::{
     transaction_case::{InputNote, OutputNote, TxCase, prepare_transaction_witness},
 };
 use pool::{ExtData, PoolContractClient, Proof, hash_ext_data};
-use soroban_sdk::{Address, Bytes, Env, I256, U256, Vec as SorobanVec, testutils::Address as _};
+use soroban_sdk::{Address, Bytes, I256, U256, Vec as SorobanVec, testutils::Address as _};
 use zkhash::fields::bn256::FpBN256 as Scalar;
-
-/// Create a test environment that disables snapshot writing under Miri.
-/// Miri's isolation mode blocks filesystem operations, which the Soroban SDK
-/// uses for test snapshots.
-fn test_env() -> Env {
-    #[cfg(miri)]
-    {
-        use soroban_sdk::testutils::EnvTestConfig;
-        Env::new_with_config(EnvTestConfig {
-            capture_snapshot_at_drop: false,
-        })
-    }
-    #[cfg(not(miri))]
-    {
-        Env::default()
-    }
-}
 
 /// Full E2E test: Generate a real proof, deploy contracts, and call transact
 /// which verifies the zk-proof

--- a/e2e-tests/src/tests/e2e_pool_2tx_plan.rs
+++ b/e2e-tests/src/tests/e2e_pool_2tx_plan.rs
@@ -1,0 +1,407 @@
+//! E2E: tx-planner multi-step spend (consolidate + final) with real proofs.
+
+use super::utils::{
+    DeployedContracts, LEVELS, NonMembership, build_membership_trees, bytes32_to_bigint,
+    deploy_contracts, generate_proof, non_membership_overrides_from_pubs, scalar_to_u256, test_env,
+    u256_to_scalar, wrap_groth16_proof,
+};
+use anyhow::Result;
+use asp_membership::ASPMembershipClient;
+use asp_non_membership::ASPNonMembershipClient;
+use circuits::test::utils::{
+    general::{poseidon2_hash2, scalar_to_bigint},
+    keypair::derive_public_key,
+    merkle_tree::merkle_root,
+    transaction::{commitment, prepopulated_leaves},
+    transaction_case::{InputNote, OutputNote, TxCase, prepare_transaction_witness},
+};
+use pool::{ExtData, PoolContractClient, Proof, hash_ext_data};
+use soroban_sdk::{Address, Bytes, Env, I256, U256, Vec as SorobanVec, testutils::Address as _};
+use tx_planner::{PlannedStep, SpendableNote, StepAction, plan};
+use types::{Field, NoteAmount};
+use zkhash::{
+    ark_ff::{BigInteger, PrimeField},
+    fields::bn256::FpBN256 as Scalar,
+};
+
+const USER_SKEY: u64 = 1001;
+
+struct TestNote {
+    input: InputNote,
+}
+
+impl TestNote {
+    fn new(leaf_index: usize, priv_key: u64, blinding: u64, amount: u64) -> Self {
+        Self {
+            input: InputNote {
+                leaf_index,
+                priv_key: Scalar::from(priv_key),
+                blinding: Scalar::from(blinding),
+                amount: Scalar::from(amount),
+            },
+        }
+    }
+
+    fn commitment(&self) -> Field {
+        scalar_to_field(commitment(
+            self.input.amount,
+            derive_public_key(self.input.priv_key),
+            self.input.blinding,
+        ))
+    }
+
+    fn as_spendable_note(&self) -> SpendableNote {
+        SpendableNote {
+            commitment: self.commitment(),
+            amount: note_amount(self.input.amount),
+        }
+    }
+
+    fn set_in_tree(&self, leaves: &mut [Scalar]) {
+        let pub_key = derive_public_key(self.input.priv_key);
+        leaves[self.input.leaf_index] = commitment(self.input.amount, pub_key, self.input.blinding);
+    }
+}
+
+fn scalar_to_field(s: Scalar) -> Field {
+    let bytes = s.into_bigint().to_bytes_be();
+    let mut buf = [0u8; 32];
+    buf.copy_from_slice(&bytes);
+    Field::try_from_be_bytes(buf).expect("valid field element")
+}
+
+fn note_amount(amount: Scalar) -> NoteAmount {
+    NoteAmount::from(u128::from(
+        amount.into_bigint().as_ref().first().copied().unwrap_or(0),
+    ))
+}
+
+fn spendable_notes(notes: &[TestNote]) -> Vec<SpendableNote> {
+    notes.iter().map(|n| n.as_spendable_note()).collect()
+}
+
+fn tx_case_for_step<'a>(step: &PlannedStep, wallet: &'a [TestNote], user_pub: Scalar) -> TxCase {
+    let find_note = |wallet: &'a [TestNote], commitment: Field| -> &'a TestNote {
+        wallet
+            .iter()
+            .find(|n| n.commitment() == commitment)
+            .expect("wallet note for commitment")
+    };
+
+    let resolved = step
+        .resolve(&spendable_notes(wallet))
+        .expect("resolve step");
+    let inputs = resolved
+        .iter()
+        .map(|n| find_note(wallet, n.commitment).input.clone())
+        .collect::<Vec<_>>();
+
+    match step.action {
+        StepAction::Consolidate { output } => {
+            let amount = Scalar::from(u128::from(output));
+            TxCase::new(
+                inputs,
+                vec![
+                    OutputNote {
+                        pub_key: user_pub,
+                        blinding: Scalar::from(900u64),
+                        amount,
+                    },
+                    OutputNote {
+                        pub_key: Scalar::from(0u64),
+                        blinding: Scalar::from(0u64),
+                        amount: Scalar::from(0u64),
+                    },
+                ],
+            )
+        }
+        StepAction::Final { outputs } => {
+            let send = Scalar::from(u128::from(outputs.0));
+            let change = outputs.1.map(|c| Scalar::from(u128::from(c)));
+            let (out0, out1) = match change {
+                Some(change) => (
+                    OutputNote {
+                        pub_key: Scalar::from(501u64),
+                        blinding: Scalar::from(601u64),
+                        amount: send,
+                    },
+                    OutputNote {
+                        pub_key: user_pub,
+                        blinding: Scalar::from(602u64),
+                        amount: change,
+                    },
+                ),
+                None => (
+                    OutputNote {
+                        pub_key: Scalar::from(501u64),
+                        blinding: Scalar::from(601u64),
+                        amount: send,
+                    },
+                    OutputNote {
+                        pub_key: Scalar::from(0u64),
+                        blinding: Scalar::from(0u64),
+                        amount: Scalar::from(0u64),
+                    },
+                ),
+            };
+            TxCase::new(inputs, vec![out0, out1])
+        }
+    }
+}
+
+fn update_wallet(
+    step: &PlannedStep,
+    wallet: &mut Vec<TestNote>,
+    leaves: &mut [Scalar],
+    merge_leaf_index: usize,
+    pool_client: &PoolContractClient,
+) -> Result<()> {
+    let StepAction::Consolidate { output } = step.action else {
+        panic!("expected consolidate step");
+    };
+    let merged_note = TestNote::new(
+        merge_leaf_index,
+        USER_SKEY,
+        900,
+        u64::try_from(u128::from(output)).expect("note amount fits in u64"),
+    );
+    merged_note.set_in_tree(leaves);
+    let dummy_leaf_index = merge_leaf_index
+        .checked_add(1)
+        .expect("merge output pair index");
+    leaves[dummy_leaf_index] =
+        commitment(Scalar::from(0u64), Scalar::from(0u64), Scalar::from(0u64));
+
+    assert_eq!(
+        merkle_root(leaves.to_vec()),
+        u256_to_scalar(&pool_client.get_root()),
+        "off-chain leaves must match pool after consolidate"
+    );
+
+    let spent = step.resolve(&spendable_notes(wallet))?;
+
+    let spent: Vec<Field> = spent.iter().map(|n| n.commitment).collect();
+    wallet.retain(|n| !spent.contains(&n.commitment()));
+    wallet.push(merged_note);
+
+    Ok(())
+}
+
+fn run_step(
+    env: &Env,
+    contracts: &DeployedContracts,
+    case: &TxCase,
+    leaves: &mut [Scalar],
+    ext_data: &ExtData,
+    bootstrap_pool_through: Option<usize>,
+) -> Result<()> {
+    let asp_membership = ASPMembershipClient::new(env, &contracts.asp_membership);
+    let asp_non_membership = ASPNonMembershipClient::new(env, &contracts.asp_non_membership);
+    let pool_client = PoolContractClient::new(env, &contracts.pool);
+    let ext_data_hash_bytes = hash_ext_data(env, ext_data);
+
+    let mut membership_trees =
+        build_membership_trees(case, |j| 0xFEED_FACEu64 ^ ((j as u64) << 40));
+    membership_trees[0].index = 0;
+    membership_trees[1].index = 1;
+
+    let keys = case
+        .inputs
+        .iter()
+        .map(|input| NonMembership {
+            key_non_inclusion: scalar_to_bigint(derive_public_key(input.priv_key)),
+        })
+        .collect::<Vec<_>>();
+
+    let witness = prepare_transaction_witness(case, leaves.to_vec(), LEVELS)?;
+    let result = generate_proof(
+        case,
+        leaves.to_vec(),
+        Scalar::from(0u64),
+        &membership_trees,
+        &keys,
+        Some(bytes32_to_bigint(&ext_data_hash_bytes)),
+    )?;
+    assert!(result.verified, "Proof should verify locally");
+
+    if bootstrap_pool_through.is_some() {
+        let mut memb_leaves = membership_trees[0].leaves;
+        memb_leaves[membership_trees[0].index] = poseidon2_hash2(
+            witness.public_keys[0],
+            membership_trees[0].blinding,
+            Some(Scalar::from(1u64)),
+        );
+        memb_leaves[membership_trees[1].index] = poseidon2_hash2(
+            witness.public_keys[1],
+            membership_trees[1].blinding,
+            Some(Scalar::from(1u64)),
+        );
+        for leaf in memb_leaves {
+            asp_membership.insert_leaf(&scalar_to_u256(env, leaf));
+        }
+
+        for (key, value) in non_membership_overrides_from_pubs(&witness.public_keys) {
+            let key_bytes = key.to_bytes_be().1;
+            let mut padded_key = [0u8; 32];
+            let start = padded_key.len().saturating_sub(key_bytes.len());
+            padded_key[start..].copy_from_slice(&key_bytes);
+
+            let value_bytes = value.to_bytes_be().1;
+            let mut padded_value = [0u8; 32];
+            let start = padded_value.len().saturating_sub(value_bytes.len());
+            padded_value[start..].copy_from_slice(&value_bytes);
+            asp_non_membership.insert_leaf(
+                &U256::from_be_bytes(env, &Bytes::from_array(env, &padded_key)),
+                &U256::from_be_bytes(env, &Bytes::from_array(env, &padded_value)),
+            );
+        }
+    }
+
+    for note in &case.inputs {
+        let pk = derive_public_key(note.priv_key);
+        leaves[note.leaf_index] = commitment(note.amount, pk, note.blinding);
+    }
+
+    if let Some(pool_through) = bootstrap_pool_through {
+        assert_eq!(leaves.len() % 2, 0, "Leaves should be even for this test");
+        for pair in leaves[..pool_through].chunks_exact(2) {
+            let leaf_1 = scalar_to_u256(env, pair[0]);
+            let leaf_2 = scalar_to_u256(env, pair[1]);
+            env.as_contract(&contracts.pool, || {
+                let _ = pool::merkle_with_history::MerkleTreeWithHistory::insert_two_leaves(
+                    env, leaf_1, leaf_2,
+                );
+            });
+        }
+    }
+
+    let circuit_root = scalar_to_u256(env, witness.root);
+    assert_eq!(
+        circuit_root,
+        pool_client.get_root(),
+        "Pool root should match circuit root"
+    );
+
+    let asp_membership_root = asp_membership.get_root();
+    let asp_non_membership_root = asp_non_membership.get_root();
+
+    let groth16_proof = wrap_groth16_proof(env, result);
+    let mut input_nullifiers = SorobanVec::new(env);
+    for nul in &witness.nullifiers {
+        input_nullifiers.push_back(scalar_to_u256(env, *nul));
+    }
+
+    let output_commitment0 = scalar_to_u256(
+        env,
+        commitment(
+            case.outputs[0].amount,
+            case.outputs[0].pub_key,
+            case.outputs[0].blinding,
+        ),
+    );
+    let output_commitment1 = scalar_to_u256(
+        env,
+        commitment(
+            case.outputs[1].amount,
+            case.outputs[1].pub_key,
+            case.outputs[1].blinding,
+        ),
+    );
+
+    let proof = Proof {
+        proof: groth16_proof,
+        root: circuit_root,
+        input_nullifiers,
+        output_commitment0,
+        output_commitment1,
+        public_amount: U256::from_u32(env, 0),
+        ext_data_hash: ext_data_hash_bytes,
+        asp_membership_root,
+        asp_non_membership_root,
+    };
+
+    let sender = Address::generate(env);
+    match pool_client.try_transact(&proof, ext_data, &sender) {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => panic!("Transaction failed: {e:?}"),
+        Err(e) => panic!("Transaction invoke failed: {e:?}"),
+    }
+
+    Ok(())
+}
+
+/// Wallet [2, 3, 5], spend 10 → consolidate(2+3) then final(5+5), two on-chain
+/// txs.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn test_e2e_planned_consolidate_final() -> Result<()> {
+    let env = test_env();
+    env.mock_all_auths();
+
+    let user_pub = derive_public_key(Scalar::from(USER_SKEY));
+
+    let mut wallet = vec![
+        TestNote::new(0, USER_SKEY, 201, 2),
+        TestNote::new(1, USER_SKEY, 211, 3),
+        TestNote::new(6, USER_SKEY, 221, 5),
+    ];
+
+    let tx_plan = plan(NoteAmount::from(10u128), &spendable_notes(&wallet))?;
+    assert_eq!(tx_plan.len(), 2);
+
+    let mut leaves = prepopulated_leaves(LEVELS, 0xDEAD_BEEFu64, &[0, 1, 6], 24);
+    for note in &wallet {
+        note.set_in_tree(&mut leaves);
+    }
+    // Leave empty pairs at the tail for each planned on-chain tx.
+    let zero = U256::from_be_bytes(
+        &env,
+        &Bytes::from_array(
+            &env,
+            &[
+                37, 48, 34, 136, 219, 153, 53, 3, 68, 151, 65, 131, 206, 49, 13, 99, 181, 58, 187,
+                158, 240, 248, 87, 87, 83, 238, 211, 110, 1, 24, 249, 206,
+            ],
+        ),
+    );
+    let reserved_pairs = tx_plan.len();
+    let reserved_leaves = reserved_pairs.checked_mul(2).expect("reserved leaf count");
+    let first_merge_leaf_index = leaves
+        .len()
+        .checked_sub(reserved_leaves)
+        .expect("tree has reserved tail");
+    for leaf in &mut leaves[first_merge_leaf_index..] {
+        *leaf = u256_to_scalar(&zero);
+    }
+
+    let ext_data = ExtData {
+        recipient: Address::generate(&env),
+        ext_amount: I256::from_i32(&env, 0),
+        encrypted_output0: Bytes::new(&env),
+        encrypted_output1: Bytes::new(&env),
+    };
+    let contracts = deploy_contracts(&env);
+    let pool_client = PoolContractClient::new(&env, &contracts.pool);
+
+    let mut next_merge_leaf_index = first_merge_leaf_index;
+    for (step_idx, step) in tx_plan.into_iter().enumerate() {
+        let case = tx_case_for_step(&step, &wallet, user_pub);
+        let bootstrap = (step_idx == 0).then_some(first_merge_leaf_index);
+        run_step(&env, &contracts, &case, &mut leaves, &ext_data, bootstrap)?;
+
+        if matches!(step.action, StepAction::Consolidate { .. }) {
+            update_wallet(
+                &step,
+                &mut wallet,
+                &mut leaves,
+                next_merge_leaf_index,
+                &pool_client,
+            )?;
+            next_merge_leaf_index = next_merge_leaf_index
+                .checked_add(2)
+                .expect("next merge leaf index");
+        }
+    }
+
+    Ok(())
+}

--- a/e2e-tests/src/tests/mod.rs
+++ b/e2e-tests/src/tests/mod.rs
@@ -4,4 +4,5 @@
 //! proof generation through on-chain verification.
 
 mod e2e_pool_2_in_2_out;
+mod e2e_pool_2tx_plan;
 pub mod utils;

--- a/e2e-tests/src/tests/utils.rs
+++ b/e2e-tests/src/tests/utils.rs
@@ -42,6 +42,23 @@ pub const ASP_MEMBERSHIP_LEVELS: u32 = 10;
 /// Maximum deposit amount allowed per transaction
 pub const MAX_DEPOSIT: u32 = 1_000_000;
 
+/// Create a test environment that disables snapshot writing under Miri.
+/// Miri's isolation mode blocks filesystem operations, which the Soroban SDK
+/// uses for test snapshots.
+pub fn test_env() -> Env {
+    #[cfg(miri)]
+    {
+        use soroban_sdk::testutils::EnvTestConfig;
+        Env::new_with_config(EnvTestConfig {
+            capture_snapshot_at_drop: false,
+        })
+    }
+    #[cfg(not(miri))]
+    {
+        Env::default()
+    }
+}
+
 /// Returns the path to the pre-generated proving key for the policy_tx_2_2
 /// circuit. Uses CARGO_MANIFEST_DIR to find the workspace root.
 fn proving_key_path() -> std::path::PathBuf {


### PR DESCRIPTION
Note merger feature that joins notes to fulfill the transfer/withdraw amount.
The current PR focus mostly on the planning rather than execution.

Prioritizes,
- doing less transactions;
- reduce the number of owned notes.

Assumes only the 2-in 2-out circuit currently.
For example,
- if the user has notes `1`, `1`, `2`, and needs to send `4`, two transactions are planned `1 + 1 -> 2 + 0` and then `2 + 2 -> 4 + 0`;
- if the user has notes `2`, `5`, and needs to send `4`, a transaction is planned `2 + 5 -> 4 + 3`. This reduces the number of owned notes by one, easing future withdraws.

I suggest making this crate actually part of the a new SDK crate.
Some nice abstractions are needed overall, thinking here mostly to support the execution of the `TransactionPlanner`. Execution requires creating transactions (potentially with pool syncs between each step) and pushing them.

A E2E test was introduced, based mostly on the existing one, though it would be good to refactor it in the future when better abstractions are in place.

Closes #232.