### PR TITLE
feat(ui): hyperlink contract addresses and ledger numbers to Stellar Expert

### DIFF
--- a/app/js/ui/address-book.js
+++ b/app/js/ui/address-book.js
@@ -258,9 +258,20 @@ export const AddressBook = {
         row.querySelector('.ab-notekey').title = String(noteKey);
         row.querySelector('.ab-enckey').textContent = Utils.truncateHex(String(encryptionKey), 10, 8);
         row.querySelector('.ab-enckey').title = String(encryptionKey);
-        row.querySelector('.ab-date').textContent = record._self
-            ? (record.registeredOnchain === false ? 'You, not registered onchain' : (ledger ? `You, ledger ${ledger}` : 'You'))
-            : (ledger ? `Ledger ${ledger}` : '');
+        const dateEl = row.querySelector('.ab-date');
+        if (ledger && !(record._self && record.registeredOnchain === false)) {
+            const a = document.createElement('a');
+            a.href = `https://stellar.expert/explorer/testnet/ledger/${ledger}`;
+            a.target = '_blank';
+            a.rel = 'noopener noreferrer';
+            a.className = 'hover:text-brand-400 transition-colors inline-flex items-center gap-1';
+            a.innerHTML = `${record._self ? `You, ledger ${ledger}` : `Ledger ${ledger}`} <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>`;
+            dateEl.replaceChildren(a);
+        } else {
+            dateEl.textContent = record._self
+                ? (record.registeredOnchain === false ? 'You, not registered onchain' : 'You')
+                : '';
+        }
 
         row.querySelector('.copy-address-btn')?.addEventListener('click', () => Utils.copyToClipboard(address));
         row.querySelector('.copy-notekey-btn')?.addEventListener('click', () => Utils.copyToClipboard(String(noteKey)));

--- a/app/js/ui/onchain-state.js
+++ b/app/js/ui/onchain-state.js
@@ -23,6 +23,24 @@ function setMonoText(id, value) {
     el.title = value ?? '';
 }
 
+function setAddressLink(id, contractId) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    if (!contractId) {
+        el.textContent = '—';
+        el.title = '';
+        return;
+    }
+    const a = document.createElement('a');
+    a.href = `https://stellar.expert/explorer/testnet/contract/${contractId}`;
+    a.target = '_blank';
+    a.rel = 'noopener noreferrer';
+    a.className = 'hover:text-brand-400 transition-colors inline-flex items-center gap-1';
+    a.innerHTML = `${Utils.truncateHex(contractId, 6, 6)} <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>`;
+    el.replaceChildren(a);
+    el.title = contractId;
+}
+
 function setIndicator(indicatorId, ok) {
     const el = document.getElementById(indicatorId);
     if (!el) return;
@@ -143,8 +161,7 @@ export const OnchainState = {
             // Pool
             setIndicator('pool-indicator', primaryPool !== null);
             setStatus('pool-status', primaryPool !== null , primaryPool?.ledger);
-            setMonoText('pool-address', primaryPool?.contractId ? Utils.truncateHex(primaryPool.contractId, 6, 6) : '—');
-            document.getElementById('pool-address')?.setAttribute('title', primaryPool?.contractId || '');
+            setAddressLink('pool-address', primaryPool?.contractId);
 
             const poolRoot = primaryPool?.merkleRoot ?? null;
             setMonoText('pool-root', poolRoot ? Utils.truncateHex(poolRoot, 10, 8) : '—');
@@ -156,8 +173,7 @@ export const OnchainState = {
             // ASP Membership
             setIndicator('membership-indicator', data?.aspMembership !== undefined);
             setStatus('membership-status', data?.aspMembership !== undefined, data?.aspMembership?.ledger);
-            setMonoText('membership-address', data?.aspMembership?.contractId ? Utils.truncateHex(data.aspMembership.contractId, 6, 6) : '—');
-            document.getElementById('membership-address')?.setAttribute('title', data?.aspMembership?.contractId || '');
+            setAddressLink('membership-address', data?.aspMembership?.contractId);
 
             const memRoot = data?.aspMembership?.root ?? null;
             setMonoText('membership-root', memRoot ? Utils.truncateHex(memRoot, 10, 8) : '—');
@@ -168,8 +184,7 @@ export const OnchainState = {
             // ASP Non-Membership
             setIndicator('nonmembership-indicator', data?.aspNonMembership !== undefined);
             setStatus('nonmembership-status', data?.aspNonMembership !== undefined, data?.aspNonMembership?.ledger);
-            setMonoText('nonmembership-address', data?.aspNonMembership?.contractId ? Utils.truncateHex(data.aspNonMembership.contractId, 6, 6) : '—');
-            document.getElementById('nonmembership-address')?.setAttribute('title', data?.aspNonMembership?.contractId || '');
+            setAddressLink('nonmembership-address', data?.aspNonMembership?.contractId);
 
             const nonRoot = data?.aspNonMembership?.root ?? null;
             setMonoText('nonmembership-root', nonRoot ? Utils.truncateHex(nonRoot, 10, 8) : '—');

--- a/app/js/ui/templates.js
+++ b/app/js/ui/templates.js
@@ -200,7 +200,18 @@ export const Templates = {
         row.querySelector('.note-id').textContent = Utils.truncateHex(note.id, 10, 8);
         // Note.amount is in token decimals - convert to token for display
         row.querySelector('.note-amount').textContent = formatBaseUnitsForDisplay(note.amount);
-        row.querySelector('.note-date').textContent = note.createdAtText || '';
+        const dateEl = row.querySelector('.note-date');
+        if (note.createdAtLedger) {
+            const a = document.createElement('a');
+            a.href = `https://stellar.expert/explorer/testnet/ledger/${note.createdAtLedger}`;
+            a.target = '_blank';
+            a.rel = 'noopener noreferrer';
+            a.className = 'hover:text-brand-400 transition-colors inline-flex items-center gap-1';
+            a.innerHTML = `${note.createdAtText} <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>`;
+            dateEl.replaceChildren(a);
+        } else {
+            dateEl.textContent = note.createdAtText || '';
+        }
 
         const badge = row.querySelector('.status-badge');
         if (note.spent) {


### PR DESCRIPTION


## 👋 External Contributor PR

Use this template when contributing from a fork.

---

## 🚀 What’s this PR do?

Renders contract addresses and ledger numbers as links to the Stellar Expert block explorer, matching the ledger links already in the Stats sidepanel. Previously, they were shown as plaintext.

---

### 📎 Related issues (optional)

Closes #229 

---

## 🧠 Context

**What changed:**
- `onchain-state.js` — Pool / ASP Membership / ASP Non-Membership **addresses** now link to their Stellar Expert `contract` pages.
- `templates.js` (Your Notes) & `address-book.js` (Address Book) — **ledger** numbers now link to their `ledger` pages.

**Design choices / tradeoffs:**
- Links are built as `<a>` elements inside the existing render paths, **no HTML/CSS or template changes**; they keep the existing cell styling (and, for addresses, the truncation + full-address tooltip).
- URL is **hardcoded to `testnet`** (`stellar.expert/explorer/testnet/<kind>/<value>`), matching the existing links in `pool-events.js` / `transactions.js`. The app is testnet-only, so I avoided introducing a network-resolution layer for a single network.
- Kept the change **minimal and local** instead of extracting a shared explorer-URL helper, happy to add one if you'd prefer it for maintainability.

**Test:** connect Freighter on testnet → click an address in On-Chain State, or a ledger in Address Book / Your Notes; all open the correct Stellar Expert page.

---

## ✅ Required Checklist

- [x] I’ve read the [contributing guide](../CONTRIBUTING.md).
- [ ] I’ve mentioned this PR in the project LinkedIn group (required for review so maintainers can see a human behind the contribution).
- [x] I’ve tested this locally, run .githooks/pre-push and provided test instructions for maintainers if needed
- [x] I’ve added relevant docs or comments
- [x] I’ve updated or created tests if needed
