### PR TITLE
Remove ASP non-membership leaf updates

### DIFF
--- a/contracts/asp-non-membership/src/lib.rs
+++ b/contracts/asp-non-membership/src/lib.rs
@@ -76,14 +76,6 @@ struct LeafInsertedEvent {
     root: U256,
 }
 
-#[contractevent(topics = ["LeafUpdated"])]
-struct LeafUpdatedEvent {
-    key: U256,
-    old_value: U256,
-    new_value: U256,
-    root: U256,
-}
-
 #[contractevent(topics = ["LeafDeleted"])]
 struct LeafDeletedEvent {
     key: U256,
@@ -618,107 +610,6 @@ impl ASPNonMembership {
         LeafDeletedEvent {
             key: key.clone(),
             root: rt_new,
-        }
-        .publish(&env);
-
-        Ok(())
-    }
-
-    /// Update a key-value pair in the tree
-    ///
-    /// Changes the value associated with an existing key. Recomputes all nodes
-    /// along the path from the leaf to the root, removing old nodes and
-    /// creating new ones. Requires admin authorization.
-    ///
-    /// # Arguments
-    ///
-    /// * `env` - The Soroban environment
-    /// * `key` - Key to update
-    /// * `new_value` - New value to associate with the key
-    ///
-    /// # Returns
-    ///
-    /// Returns `Ok(())` on success, emitting a `LeafUpdatedEvent` with the new
-    /// root.
-    ///
-    /// # Errors
-    ///
-    /// * `Error::KeyNotFound` - Key does not exist in the tree or database
-    ///   operations failed
-    pub fn update_leaf(env: Env, key: U256, new_value: U256) -> Result<(), Error> {
-        let store = env.storage().persistent();
-        let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
-        admin.require_auth();
-        let root: U256 = store
-            .get(&DataKey::Root)
-            .unwrap_or(U256::from_u32(&env, 0u32));
-
-        // Compute key bits once
-        let key_bits = Self::split_bits(&env, &key);
-
-        // Find the key
-        let find_result = Self::find_key_internal(&env, &store, &key, &key_bits, &root, 0u32)?;
-
-        if !find_result.found {
-            return Err(Error::KeyNotFound);
-        }
-        // Update the leaf
-        let old_leaf_hash = Self::hash_leaf(&env, key.clone(), find_result.found_value.clone());
-        let new_leaf_hash = Self::hash_leaf(&env, key.clone(), new_value.clone());
-        // Update leaf node
-        let leaf_node = vec![
-            &env,
-            U256::from_u32(&env, 1u32),
-            key.clone(),
-            new_value.clone(),
-        ];
-        store.set(&DataKey::Node(new_leaf_hash.clone()), &leaf_node);
-
-        // Remove old leaf
-        store.remove(&DataKey::Node(old_leaf_hash.clone()));
-
-        // Rebuild path from leaf to root (process siblings in reverse)
-        let mut current_hash = new_leaf_hash;
-        let mut old_current_hash = old_leaf_hash;
-
-        let siblings_len = find_result.siblings.len();
-        for level_idx in 0..siblings_len {
-            let level = siblings_len.saturating_sub(1).saturating_sub(level_idx); // Reverse: process from leaf to root
-            let sibling = find_result.siblings.get(level).ok_or(Error::KeyNotFound)?;
-            let bit = key_bits.get(level).ok_or(Error::KeyNotFound)?;
-
-            let (left_hash, right_hash) = if bit {
-                (sibling.clone(), current_hash)
-            } else {
-                (current_hash, sibling.clone())
-            };
-
-            let (old_left_hash, old_right_hash) = if bit {
-                (sibling.clone(), old_current_hash)
-            } else {
-                (old_current_hash, sibling.clone())
-            };
-
-            current_hash = Self::hash_internal(&env, left_hash.clone(), right_hash.clone());
-            old_current_hash = Self::hash_internal(&env, old_left_hash, old_right_hash);
-
-            // Update internal node
-            let internal_node = vec![&env, left_hash, right_hash];
-            store.set(&DataKey::Node(current_hash.clone()), &internal_node);
-
-            // Remove old internal node
-            store.remove(&DataKey::Node(old_current_hash.clone()));
-        }
-
-        // Update root
-        store.set(&DataKey::Root, &current_hash);
-
-        // Emit event
-        LeafUpdatedEvent {
-            key: key.clone(),
-            old_value: find_result.found_value,
-            new_value: new_value.clone(),
-            root: current_hash,
         }
         .publish(&env);
 

--- a/contracts/asp-non-membership/src/test.rs
+++ b/contracts/asp-non-membership/src/test.rs
@@ -51,28 +51,6 @@ fn test_insert_leaf() {
 }
 
 #[test]
-fn test_update_leaf() {
-    let env = test_env();
-    let admin = Address::generate(&env);
-    let contract_id = env.register(ASPNonMembership, (admin,));
-    env.mock_all_auths();
-    let client = ASPNonMembershipClient::new(&env, &contract_id);
-    // Insert and update leaf
-    let key = U256::from_u32(&env, 1u32);
-    let value1 = U256::from_u32(&env, 42u32);
-    let value2 = U256::from_u32(&env, 100u32);
-    // Insert
-    client.insert_leaf(&key, &value1);
-    let root1 = client.get_root();
-    // Update leaf with new value
-    client.update_leaf(&key, &value2);
-    let root2 = client.get_root();
-
-    // Root should have changed
-    assert_ne!(root1, root2);
-}
-
-#[test]
 fn test_insert_multiple_keys() {
     let env = test_env();
     let admin = Address::generate(&env);
@@ -118,26 +96,6 @@ fn test_duplicate_insert_fails() {
     client.insert_leaf(&key, &second_value);
 }
 
-/// This test is skipped under Miri because the panic formatting path triggers
-/// undefined behavior in the `ethnum` crate's unsafe formatting code.
-/// See: https://github.com/nlordell/ethnum-rs/issues/34
-#[test]
-#[cfg_attr(miri, ignore)]
-#[should_panic]
-fn test_update_nonexistent_key_fails() {
-    let env = test_env();
-    let admin = Address::generate(&env);
-    let contract_id = env.register(ASPNonMembership, (admin,));
-    let client = ASPNonMembershipClient::new(&env, &contract_id);
-    // Mock auth for the contract
-    env.mock_all_auths();
-
-    let key = U256::from_u32(&env, 1u32);
-    let value = U256::from_u32(&env, 42u32);
-
-    client.update_leaf(&key, &value);
-}
-
 /// Test that matches the circuits test: insert key=1, value=42
 #[test]
 fn test_root_consistency_with_circuits_insert_1_42() {
@@ -163,43 +121,6 @@ fn test_root_consistency_with_circuits_insert_1_42() {
 
     let expected_root = U256::from_be_bytes(&env, &Bytes::from_array(&env, &expected_root_bytes));
     assert_eq!(root, expected_root, "Root should match the circuits test");
-}
-
-/// Test that matches the circuits test: insert key=1, value=42, then update to
-/// value=100
-#[test]
-fn test_root_consistency_with_circuits_update_1_100() {
-    let env = test_env();
-    let admin = Address::generate(&env);
-    let contract_id = env.register(ASPNonMembership, (admin,));
-    let client = ASPNonMembershipClient::new(&env, &contract_id);
-    env.mock_all_auths();
-
-    let key = U256::from_u32(&env, 1u32);
-    let value1 = U256::from_u32(&env, 42u32);
-    let value2 = U256::from_u32(&env, 100u32);
-
-    // Insert
-    client.insert_leaf(&key, &value1);
-
-    // Update
-    client.update_leaf(&key, &value2);
-
-    let root = client.get_root();
-
-    // Expected root from circuits test:
-    // 12569474685065514766800302626776627658362290519786081498087070427717152263146
-    // Hex: 0x1bca121020a7041a503dabbb08f8ed11fd45bf8c2c0851e9db040ea7ae6fcbea
-    let expected_root_bytes = [
-        27, 202, 18, 16, 32, 167, 4, 26, 80, 61, 171, 187, 8, 248, 237, 17, 253, 69, 191, 140, 44,
-        8, 81, 233, 219, 4, 14, 167, 174, 111, 203, 234,
-    ];
-
-    let expected_root = U256::from_be_bytes(&env, &Bytes::from_array(&env, &expected_root_bytes));
-    assert_eq!(
-        root, expected_root,
-        "Root should match the circuits test after update"
-    );
 }
 
 /// Test that matches the circuits test: insert key=1, value=42, then insert


### PR DESCRIPTION
## 👋 External Contributor PR

Use this template when contributing from a fork.

---

## 🚀 What’s this PR do?

Removes ASP non-membership leaf update support after maintainer review confirmed there is no current use case for updating leaves.

This removes:

- `ASPNonMembership::update_leaf`
- the `LeafUpdated` contract event
- update-specific contract tests

---

### 📎 Related issues (optional)

Fixes #254

---

## 🧠 Context

The original version of this PR fixed same-value `update_leaf` behavior. After review, the requested direction changed from fixing leaf updates to removing the feature entirely.

The non-membership SMT now keeps insert/delete/proof flows without a public update method or update event. App-side parsing for historical `LeafUpdated` events is left unchanged so any previously indexed raw events can still be parsed and ignored by the existing processor path instead of becoming permanently unhandled.

Validation run:

- `cargo test -p asp-non-membership --lib`
- `cargo check -p state -p types`
- `cargo fmt --all -- --check --config-path rustfmt.toml`
- `git diff --check`

Skipped:

- Full `.githooks/pre-push` was not run locally in Termux.
- `cargo test -p state -p types` was not rerun because it pulls in the heavy Wasmtime/Cranelift test build path; the touched app crates were covered with `cargo check`.

---

## ✅ Required Checklist

- [x] I’ve read the [contributing guide](../CONTRIBUTING.md).
- [x] I’ve mentioned this PR in the project LinkedIn group (required for review so maintainers can see a human behind the contribution).
- [ ] I’ve tested this locally, run .githooks/pre-push and provided test instructions for maintainers if needed
- [x] I’ve added relevant docs or comments
- [x] I’ve updated or created tests if needed