### PR TITLE
Fix advanced transfer submit rejecting balanced inputs

### DIFF
--- a/app/js/ui/transactions.js
+++ b/app/js/ui/transactions.js
@@ -486,6 +486,7 @@ function updateTransferBalance() {
     const isBalanced =
         outputsValid && inputsTotalStroops !== 0n && inputsTotalStroops === outputsTotalStroops && shouldShow;
     setEqValidity(eq, isBalanced, shouldShow);
+    return isBalanced;
 }
 
 function updateTransactBalance() {


### PR DESCRIPTION
`updateTransferBalance` showed a green indicator in the UI but did not return `isBalanced`, so `runSpendFlow` always failed the submit-time check.