### PR TITLE
Refactor web client to execute* API with unified transact path

### DIFF
--- a/app/crates/platforms/web/src/client/mod.rs
+++ b/app/crates/platforms/web/src/client/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     protocol::{
-        AdminASPRequest, DepositPrepared, DepositRequest, PreparedProverTx, ProverWorkerRequest,
-        ProverWorkerResponse, StorageWorkerRequest, StorageWorkerResponse,
+        AdminASPRequest, ProverWorkerRequest, ProverWorkerResponse, StorageWorkerRequest,
+        StorageWorkerResponse,
     },
     workers::{prover::ProverWorker, storage::StorageWorker},
 };
@@ -13,14 +13,20 @@ use js_sys::{Array, BigInt, Function, Object, Reflect};
 use prover::{encryption::KEY_DERIVATION_MESSAGE, flows::N_OUTPUTS};
 use std::{rc::Rc, str::FromStr};
 use stellar::StateFetcher as CoreStateFetcher;
-use tx_planner::Transact;
 use types::{
-    AspMembershipSync, ContractConfig, ContractsStateData, EncryptionPublicKey, ExtAmount, Field,
-    KeyDerivationSignature, NoteAmount, NotePublicKey, SMT_DEPTH,
+    ContractConfig, EncryptionPublicKey, ExtAmount, Field, KeyDerivationSignature, NoteAmount,
+    NotePublicKey,
 };
 use wasm_bindgen::{JsCast, prelude::*};
 
 mod transact;
+
+fn execute_hashes_to_js(result: Option<Vec<String>>) -> Result<JsValue, JsError> {
+    match result {
+        None => Ok(JsValue::NULL),
+        Some(hashes) => Ok(serde_wasm_bindgen::to_value(&hashes)?),
+    }
+}
 
 fn emit_progress(
     on_status: &Option<Function>,
@@ -164,252 +170,6 @@ impl WebClient {
             _ => Ok(resp),
         }
     }
-
-    async fn prove_deposit_inner(
-        &self,
-        pool_contract_id: String,
-        user_address: String,
-        membership_blinding: BigInt,
-        amount: BigInt,
-        output_amounts: Array,
-        on_status: Option<Function>,
-    ) -> Result<Option<DepositPrepared>, JsError> {
-        let expected_outputs =
-            u32::try_from(N_OUTPUTS).map_err(|_| JsError::new("N_OUTPUTS exceeds u32"))?;
-        if output_amounts.length() != expected_outputs {
-            return Err(JsError::new(&format!(
-                "output_amounts must have length {N_OUTPUTS}"
-            )));
-        }
-
-        let membership_blinding = parse_field_bigint_numeric(&membership_blinding)?;
-
-        let amount = parse_ext_amount_decimal(&amount)?;
-        if amount <= ExtAmount::ZERO {
-            return Err(JsError::new("amount must be > 0 for deposit"));
-        }
-
-        emit_progress(
-            &on_status,
-            "deposit",
-            "sync_check",
-            "Checking sync & ASP membership…",
-            None,
-            None,
-        );
-
-        let mut out_amounts = [NoteAmount::ZERO; N_OUTPUTS];
-        for (i, out) in out_amounts.iter_mut().enumerate().take(N_OUTPUTS) {
-            let idx = u32::try_from(i).map_err(|_| JsError::new("output index exceeds u32"))?;
-            let v = output_amounts.get(idx);
-            let bi: BigInt = v
-                .dyn_into()
-                .map_err(|_| JsError::new("output_amounts must be BigInt[]"))?;
-            *out = parse_note_amount_decimal(&bi)?;
-        }
-
-        let params = loop {
-            emit_progress(
-                &on_status,
-                "deposit",
-                "fetch_chain_state",
-                "Fetching on-chain state…",
-                None,
-                None,
-            );
-            let ContractsStateData {
-                pools,
-                asp_membership,
-                asp_non_membership,
-            } = self
-                .fetcher
-                .contracts_data_for_pool(&pool_contract_id)
-                .await
-                .map_err(|e| JsError::new(&e.to_string()))?;
-
-            let pool = pools
-                .into_iter()
-                .next()
-                .ok_or_else(|| JsError::new("the pool data is not fetched"))?;
-            let pool_root = pool.merkle_root;
-
-            emit_progress(
-                &on_status,
-                "deposit",
-                "load_state",
-                "Loading local keys…",
-                None,
-                None,
-            );
-            let keys = match self
-                .storage_request(StorageWorkerRequest::UserKeys(user_address.clone()), 1_000)
-                .await?
-            {
-                StorageWorkerResponse::UserKeys(keys) => {
-                    keys.ok_or_else(|| JsError::new("user keys not found in worker storage"))?
-                }
-                other => return Err(JsError::new(&format!("Unexpected response: {:?}", other))),
-            };
-            let note_pubkey: NotePublicKey = keys.note_keypair.public;
-
-            emit_progress(
-                &on_status,
-                "deposit",
-                "fetch_chain_state",
-                "Fetching ASP non-membership proof…",
-                None,
-                None,
-            );
-            let non_membership_proof = self
-                .fetcher
-                .get_nonmembership_proof(
-                    &note_pubkey,
-                    asp_non_membership.root,
-                    SMT_DEPTH as usize,
-                    &user_address,
-                )
-                .await
-                .map_err(|e| JsError::new(&e.to_string()))?;
-
-            let req = DepositRequest {
-                user_address: user_address.clone(),
-                membership_blinding,
-                amount,
-                pool_root,
-                pool_address: pool.contract_id,
-                aspmem_root: asp_membership.root,
-                aspmem_contract_id: asp_membership.contract_id.clone(),
-                aspmem_ledger: asp_membership.ledger,
-                output_amounts: out_amounts,
-                smt_depth: SMT_DEPTH,
-                tree_depth: pool.merkle_levels,
-                non_membership_proof,
-            };
-
-            emit_progress(
-                &on_status,
-                "deposit",
-                "load_state",
-                "Building witness inputs…",
-                None,
-                None,
-            );
-            match self
-                .storage_request(StorageWorkerRequest::Deposit(req), 5_000)
-                .await?
-            {
-                StorageWorkerResponse::DepositParams(p) => break p,
-                StorageWorkerResponse::AspMembershipSync(AspMembershipSync::RegisterAtASP) => {
-                    log::warn!("[DEPOSIT] the account {user_address} should register within ASP");
-                    return Ok(None);
-                }
-                StorageWorkerResponse::AspMembershipSync(AspMembershipSync::SyncRequired(gap)) => {
-                    log::info!("[DEPOSIT] sync is needed - waiting the indexer");
-                    emit_progress(
-                        &on_status,
-                        "deposit",
-                        "sync_wait",
-                        if let Some(gap) = gap {
-                            format!("Waiting to sync {gap} ledger(s) from the chain...")
-                        } else {
-                            "Waiting to sync ledgers from the chain...".to_string()
-                        },
-                        None,
-                        None,
-                    );
-                    TimeoutFuture::new(1_000).await;
-                    continue;
-                }
-                other => {
-                    return Err(JsError::new(&format!(
-                        "Unexpected storage worker response: {:?}",
-                        other
-                    )));
-                }
-            }
-        };
-
-        emit_progress(&on_status, "deposit", "prove", "Proving…", None, None);
-        self.ping_prover()
-            .await
-            .map_err(|e| JsError::new(&format!("failed to load prover: {e:?}")))?;
-
-        let prepared = match self
-            .prover_request(ProverWorkerRequest::Deposit(params), 20_000)
-            .await?
-        {
-            ProverWorkerResponse::DepositPrepared(p) => p,
-            other => {
-                return Err(JsError::new(&format!(
-                    "Unexpected prover worker response: {:?}",
-                    other
-                )));
-            }
-        };
-
-        Ok(Some(prepared))
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    async fn prove_transact_from_js(
-        &self,
-        pool_contract_id: String,
-        user_address: String,
-        membership_blinding: BigInt,
-        ext_recipient: String,
-        ext_amount: BigInt,
-        input_note_ids: Array,
-        output_amounts: Array,
-        out_recipient_note_keys_hex: Array,
-        out_recipient_enc_keys_hex: Array,
-        on_status: Option<Function>,
-    ) -> Result<Option<PreparedProverTx>, JsError> {
-        let expected_outputs =
-            u32::try_from(N_OUTPUTS).map_err(|_| JsError::new("N_OUTPUTS exceeds u32"))?;
-        if out_recipient_note_keys_hex.length() != expected_outputs {
-            return Err(JsError::new(&format!(
-                "out_recipient_note_keys_hex must have length {N_OUTPUTS}"
-            )));
-        }
-        if out_recipient_enc_keys_hex.length() != expected_outputs {
-            return Err(JsError::new(&format!(
-                "out_recipient_enc_keys_hex must have length {N_OUTPUTS}"
-            )));
-        }
-
-        let membership_blinding = parse_field_bigint_numeric(&membership_blinding)?;
-        let ext_amount = parse_ext_amount_decimal(&ext_amount)?;
-        let input_commitments = parse_input_note_ids(
-            &input_note_ids,
-            0,
-            2,
-            "input_note_ids must have length 0..=2",
-        )?;
-        let out_amounts = parse_output_amounts(&output_amounts)?;
-        let (out_note_pks, out_enc_pks) =
-            parse_output_recipient_keys(&out_recipient_note_keys_hex, &out_recipient_enc_keys_hex)?;
-
-        let step = Transact::new(
-            input_commitments,
-            out_amounts,
-            ext_amount,
-            ext_recipient,
-            out_note_pks,
-            out_enc_pks,
-        );
-
-        self.prove_transact_inner(
-            &pool_contract_id,
-            &user_address,
-            membership_blinding,
-            &step,
-            "transact",
-            &on_status,
-            None,
-            None,
-        )
-        .await
-    }
 }
 
 #[wasm_bindgen]
@@ -552,41 +312,41 @@ impl WebClient {
         }
     }
 
-    #[wasm_bindgen(js_name = proveDeposit)]
-    pub async fn prove_deposit(
+    #[wasm_bindgen(js_name = executeDeposit)]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn execute_deposit(
         &self,
         pool_contract_id: String,
         user_address: String,
         membership_blinding: BigInt,
         amount: BigInt,
         output_amounts: Array,
+        submit_fn: Function,
         on_status: Option<Function>,
     ) -> Result<JsValue, JsError> {
-        let prepared = self
-            .prove_deposit_inner(
+        let result = self
+            .execute_deposit_inner(
                 pool_contract_id,
                 user_address,
                 membership_blinding,
                 amount,
                 output_amounts,
+                submit_fn,
                 on_status,
             )
             .await?;
-        match prepared {
-            None => Ok(JsValue::NULL),
-            Some(p) => Ok(serde_wasm_bindgen::to_value(&p)?),
-        }
+        execute_hashes_to_js(result)
     }
 
-    #[wasm_bindgen(js_name = planSpend)]
-    pub async fn plan_spend(
+    #[wasm_bindgen(js_name = plan)]
+    pub async fn plan(
         &self,
-        user_address: String,
         pool_contract_id: String,
+        user_address: String,
         amount: BigInt,
     ) -> Result<JsValue, JsError> {
         let preview = self
-            .plan_spend_inner(pool_contract_id, user_address, amount)
+            .plan_inner(pool_contract_id, user_address, amount)
             .await?;
         Ok(serde_wasm_bindgen::to_value(&preview)?)
     }
@@ -612,7 +372,7 @@ impl WebClient {
             .map_err(|e| JsError::new(&e.to_string()))?;
         let target = SpendTarget::transfer(recipient_note, recipient_enc);
 
-        match self
+        let result = self
             .execute_spend_inner(
                 pool_contract_id,
                 user_address,
@@ -623,11 +383,8 @@ impl WebClient {
                 submit_fn,
                 on_status,
             )
-            .await?
-        {
-            None => Ok(JsValue::NULL),
-            Some(hashes) => Ok(serde_wasm_bindgen::to_value(&hashes)?),
-        }
+            .await?;
+        execute_hashes_to_js(result)
     }
 
     #[wasm_bindgen(js_name = executeWithdraw)]
@@ -646,7 +403,7 @@ impl WebClient {
 
         let target = SpendTarget::withdraw(withdraw_recipient);
 
-        match self
+        let result = self
             .execute_spend_inner(
                 pool_contract_id,
                 user_address,
@@ -657,16 +414,13 @@ impl WebClient {
                 submit_fn,
                 on_status,
             )
-            .await?
-        {
-            None => Ok(JsValue::NULL),
-            Some(hashes) => Ok(serde_wasm_bindgen::to_value(&hashes)?),
-        }
+            .await?;
+        execute_hashes_to_js(result)
     }
 
-    #[wasm_bindgen(js_name = proveTransact)]
+    #[wasm_bindgen(js_name = executeTransact)]
     #[allow(clippy::too_many_arguments)]
-    pub async fn prove_transact(
+    pub async fn execute_transact_wasm(
         &self,
         pool_contract_id: String,
         user_address: String,
@@ -677,10 +431,11 @@ impl WebClient {
         output_amounts: Array,
         out_recipient_note_keys_hex: Array,
         out_recipient_enc_keys_hex: Array,
+        submit_fn: Function,
         on_status: Option<Function>,
     ) -> Result<JsValue, JsError> {
-        let prepared = self
-            .prove_transact_from_js(
+        let result = self
+            .execute_transact_inner(
                 pool_contract_id,
                 user_address,
                 membership_blinding,
@@ -690,13 +445,12 @@ impl WebClient {
                 output_amounts,
                 out_recipient_note_keys_hex,
                 out_recipient_enc_keys_hex,
+                submit_fn,
                 on_status,
+                "transact",
             )
             .await?;
-        match prepared {
-            None => Ok(JsValue::NULL),
-            Some(p) => Ok(serde_wasm_bindgen::to_value(&p)?),
-        }
+        execute_hashes_to_js(result)
     }
 }
 

--- a/app/crates/platforms/web/src/client/transact.rs
+++ b/app/crates/platforms/web/src/client/transact.rs
@@ -1,21 +1,39 @@
-//! Pool `transact` proving and planned multi-step execution (`executeTransfer`
-//! / `executeWithdraw`).
+//! Pool transaction proving and execution (`executeDeposit`, `executeTransact`,
+//! `executeTransfer`, `executeWithdraw`).
 
 use super::{
-    WebClient, emit_progress, parse_field_bigint_numeric, parse_note_amount_decimal,
-    parse_u32_decimal,
+    WebClient, emit_progress, parse_ext_amount_decimal, parse_field_bigint_numeric,
+    parse_input_note_ids, parse_note_amount_decimal, parse_output_amounts,
+    parse_output_recipient_keys, parse_u32_decimal,
 };
 use crate::protocol::{
     PreparedProverTx, ProverWorkerRequest, ProverWorkerResponse, StorageWorkerRequest,
     StorageWorkerResponse, TransactRequest,
 };
 use gloo_timers::future::TimeoutFuture;
-use js_sys::{BigInt, Function, Promise};
+use js_sys::{Array, BigInt, Function, Promise};
+use prover::flows::N_OUTPUTS;
 use serde::Serialize;
 use tx_planner::{SpendSession, SpendSessionError, SpendTarget, SpendableNote, Transact, plan};
-use types::{AspMembershipSync, ContractsStateData, Field, NotePublicKey, SMT_DEPTH};
+use types::{
+    AspMembershipSync, ContractsStateData, EncryptionPublicKey, ExtAmount, Field, NoteAmount,
+    NotePublicKey, SMT_DEPTH,
+};
 use wasm_bindgen::{JsCast, JsError, JsValue};
 use wasm_bindgen_futures::JsFuture;
+
+struct ExecuteCtx {
+    pool_contract_id: String,
+    user_address: String,
+    membership_blinding: Field,
+    submit_fn: Function,
+    on_status: Option<Function>,
+}
+
+struct ExecutedTransact {
+    hash: String,
+    output_commitments: [Field; 2],
+}
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -244,6 +262,97 @@ impl WebClient {
         Ok(Some(prepared))
     }
 
+    async fn execute_transact(
+        &self,
+        ctx: ExecuteCtx,
+        step: Transact,
+        flow: &'static str,
+    ) -> Result<Option<Vec<String>>, JsError> {
+        let Some(executed) = self.prove_and_submit(&ctx, &step, flow, None, None).await? else {
+            return Ok(None);
+        };
+        Ok(Some(vec![executed.hash]))
+    }
+
+    async fn execute_plan(
+        &self,
+        ctx: ExecuteCtx,
+        amount: NoteAmount,
+        target: SpendTarget,
+        flow: &'static str,
+    ) -> Result<Option<Vec<String>>, JsError> {
+        let wallet = self
+            .load_spendable_wallet(&ctx.pool_contract_id, &ctx.user_address)
+            .await?;
+        let mut session = SpendSession::setup(wallet, amount, ctx.pool_contract_id.clone(), target)
+            .map_err(spend_session_err)?;
+
+        let total_u32 = u32::try_from(session.len())
+            .map_err(|_| JsError::new("plan produces too many steps for u32"))?;
+
+        let mut hashes = Vec::new();
+        while let Some(step) = session.step().map_err(spend_session_err)? {
+            let current = u32::try_from(session.step_index().saturating_add(1))
+                .map_err(|_| JsError::new("step index exceeds u32"))?;
+
+            let Some(executed) = self
+                .prove_and_submit(&ctx, &step, flow, Some(current), Some(total_u32))
+                .await?
+            else {
+                return Ok(None);
+            };
+            session
+                .complete_step(&executed.output_commitments)
+                .map_err(spend_session_err)?;
+            hashes.push(executed.hash);
+        }
+
+        Ok(Some(hashes))
+    }
+
+    async fn prove_and_submit(
+        &self,
+        ctx: &ExecuteCtx,
+        step: &Transact,
+        flow: &'static str,
+        step_current: Option<u32>,
+        step_total: Option<u32>,
+    ) -> Result<Option<ExecutedTransact>, JsError> {
+        let prepared = self
+            .prove_transact_inner(
+                &ctx.pool_contract_id,
+                &ctx.user_address,
+                ctx.membership_blinding,
+                step,
+                flow,
+                &ctx.on_status,
+                step_current,
+                step_total,
+            )
+            .await?;
+        let Some(prepared) = prepared else {
+            return Ok(None);
+        };
+
+        let message = match (step_current, step_total) {
+            (Some(current), Some(total)) => format!("Submitting step {current}/{total}…"),
+            _ => "Submitting…".to_string(),
+        };
+        emit_progress(
+            &ctx.on_status,
+            flow,
+            "submit",
+            message,
+            step_current,
+            step_total,
+        );
+        let hash = Self::call_js_submit(&ctx.submit_fn, &prepared).await?;
+        Ok(Some(ExecutedTransact {
+            hash,
+            output_commitments: prepared.prepared.output_commitments,
+        }))
+    }
+
     async fn call_js_submit(
         submit_fn: &Function,
         proved: &PreparedProverTx,
@@ -267,7 +376,121 @@ impl WebClient {
         })
     }
 
-    pub(super) async fn plan_spend_inner(
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn execute_transact_inner(
+        &self,
+        pool_contract_id: String,
+        user_address: String,
+        membership_blinding: BigInt,
+        ext_recipient: String,
+        ext_amount: BigInt,
+        input_note_ids: Array,
+        output_amounts: Array,
+        out_recipient_note_keys_hex: Array,
+        out_recipient_enc_keys_hex: Array,
+        submit_fn: Function,
+        on_status: Option<Function>,
+        flow: &'static str,
+    ) -> Result<Option<Vec<String>>, JsError> {
+        let expected_outputs =
+            u32::try_from(N_OUTPUTS).map_err(|_| JsError::new("N_OUTPUTS exceeds u32"))?;
+        if out_recipient_note_keys_hex.length() != expected_outputs {
+            return Err(JsError::new(&format!(
+                "out_recipient_note_keys_hex must have length {N_OUTPUTS}"
+            )));
+        }
+        if out_recipient_enc_keys_hex.length() != expected_outputs {
+            return Err(JsError::new(&format!(
+                "out_recipient_enc_keys_hex must have length {N_OUTPUTS}"
+            )));
+        }
+
+        let membership_blinding = parse_field_bigint_numeric(&membership_blinding)?;
+        let ext_amount = parse_ext_amount_decimal(&ext_amount)?;
+        let input_commitments = parse_input_note_ids(
+            &input_note_ids,
+            0,
+            2,
+            "input_note_ids must have length 0..=2",
+        )?;
+        let out_amounts = parse_output_amounts(&output_amounts)?;
+        let (out_note_pks, out_enc_pks) =
+            parse_output_recipient_keys(&out_recipient_note_keys_hex, &out_recipient_enc_keys_hex)?;
+
+        let step = Transact::new(
+            input_commitments,
+            out_amounts,
+            ext_amount,
+            ext_recipient,
+            out_note_pks,
+            out_enc_pks,
+        );
+
+        let ctx = ExecuteCtx {
+            pool_contract_id,
+            user_address,
+            membership_blinding,
+            submit_fn,
+            on_status,
+        };
+        self.execute_transact(ctx, step, flow).await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn execute_deposit_inner(
+        &self,
+        pool_contract_id: String,
+        user_address: String,
+        membership_blinding: BigInt,
+        amount: BigInt,
+        output_amounts: Array,
+        submit_fn: Function,
+        on_status: Option<Function>,
+    ) -> Result<Option<Vec<String>>, JsError> {
+        let membership_blinding = parse_field_bigint_numeric(&membership_blinding)?;
+        let ext_amount = parse_ext_amount_decimal(&amount)?;
+        if ext_amount <= ExtAmount::ZERO {
+            return Err(JsError::new("amount must be > 0 for deposit"));
+        }
+        let out_amounts = parse_output_amounts(&output_amounts)?;
+
+        let keys = match self
+            .storage_request(StorageWorkerRequest::UserKeys(user_address.clone()), 1_000)
+            .await?
+        {
+            StorageWorkerResponse::UserKeys(keys) => {
+                keys.ok_or_else(|| JsError::new("user keys not found in worker storage"))?
+            }
+            other => {
+                return Err(JsError::new(&format!(
+                    "Unexpected storage response loading user keys: {:?}",
+                    other
+                )));
+            }
+        };
+        let note_pk: NotePublicKey = keys.note_keypair.public;
+        let enc_pk: EncryptionPublicKey = keys.encryption_keypair.public;
+
+        let step = Transact::new(
+            Vec::new(),
+            out_amounts,
+            ext_amount,
+            pool_contract_id.clone(),
+            [Some(note_pk.clone()), Some(note_pk)],
+            [Some(enc_pk.clone()), Some(enc_pk)],
+        );
+
+        let ctx = ExecuteCtx {
+            pool_contract_id,
+            user_address,
+            membership_blinding,
+            submit_fn,
+            on_status,
+        };
+        self.execute_transact(ctx, step, "deposit").await
+    }
+
+    pub(super) async fn plan_inner(
         &self,
         pool_contract_id: String,
         user_address: String,
@@ -305,52 +528,13 @@ impl WebClient {
             return Err(JsError::new("amount must be > 0"));
         }
 
-        let wallet = self
-            .load_spendable_wallet(&pool_contract_id, &user_address)
-            .await?;
-        let mut session = SpendSession::setup(wallet, amount, pool_contract_id.clone(), target)
-            .map_err(spend_session_err)?;
-
-        let total_u32 = u32::try_from(session.len())
-            .map_err(|_| JsError::new("plan produces too many steps for u32"))?;
-
-        let mut hashes = Vec::new();
-        while let Some(step) = session.step().map_err(spend_session_err)? {
-            let current = u32::try_from(session.step_index().saturating_add(1))
-                .map_err(|_| JsError::new("step index exceeds u32"))?;
-
-            let prepared = self
-                .prove_transact_inner(
-                    &pool_contract_id,
-                    &user_address,
-                    membership_blinding,
-                    &step,
-                    flow,
-                    &on_status,
-                    Some(current),
-                    Some(total_u32),
-                )
-                .await?;
-            let prepared = match prepared {
-                None => return Ok(None),
-                Some(p) => p,
-            };
-
-            emit_progress(
-                &on_status,
-                flow,
-                "submit",
-                format!("Submitting step {current}/{total_u32}…"),
-                Some(current),
-                Some(total_u32),
-            );
-            let hash = Self::call_js_submit(&submit_fn, &prepared).await?;
-            session
-                .complete_step(&prepared.prepared.output_commitments)
-                .map_err(spend_session_err)?;
-            hashes.push(hash);
-        }
-
-        Ok(Some(hashes))
+        let ctx = ExecuteCtx {
+            pool_contract_id,
+            user_address,
+            membership_blinding,
+            submit_fn,
+            on_status,
+        };
+        self.execute_plan(ctx, amount, target, flow).await
     }
 }

--- a/app/crates/platforms/web/src/protocol.rs
+++ b/app/crates/platforms/web/src/protocol.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use prover::flows::{DepositParams, N_OUTPUTS, TransactParams};
+use prover::flows::{N_OUTPUTS, TransactParams};
 pub type Address = String;
 use types::{
     AspMembershipSync, AspNonMembershipProof, ContractsEventData, EncryptionKeyPair, ExtAmount,
@@ -23,6 +23,7 @@ pub struct DisclaimerStatePayload {
     pub accepted: bool,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Serialize, Deserialize)]
 pub enum StorageWorkerRequest {
     Ping,
@@ -40,11 +41,11 @@ pub enum StorageWorkerRequest {
     },
     RecentPoolActivity(u32),
     RecentPubKeys(u32),
-    Deposit(DepositRequest),
     Transact(TransactRequest),
     DeriveASPleaf(AdminASPRequest),
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Serialize, Deserialize)]
 pub enum StorageWorkerResponse {
     Pong,
@@ -57,41 +58,23 @@ pub enum StorageWorkerResponse {
     RecentPoolActivity(Vec<PoolLedgerActivity>),
     PubKeys(Vec<PublicKeyEntry>),
     AspMembershipSync(AspMembershipSync),
-    DepositParams(DepositParams),
     TransactParams(TransactParams),
     DeriveASPleaf(Field),
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ProverWorkerRequest {
     Ping,
-    Deposit(DepositParams),
     Transact(TransactParams),
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ProverWorkerResponse {
     Pong,
     Error(String),
-    DepositPrepared(DepositPrepared),
     TransactPrepared(PreparedProverTx),
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DepositRequest {
-    pub user_address: Address,
-    pub membership_blinding: Field,
-    pub amount: ExtAmount,
-    pub pool_root: Option<Field>,
-    pub pool_address: Address,
-    pub aspmem_root: Field,
-    pub aspmem_contract_id: Address,
-    pub aspmem_ledger: u32,
-    pub output_amounts: [NoteAmount; N_OUTPUTS],
-    pub smt_depth: u32,
-    pub tree_depth: u32,
-    pub non_membership_proof: AspNonMembershipProof,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -126,19 +109,6 @@ pub struct PreparedTxPublic {
     pub ext_data_hash_be: [u8; 32],
     pub asp_membership_root: Field,
     pub asp_non_membership_root: Field,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DepositPrepared {
-    /// Uncompressed Soroban-ready proof bytes: A(64) || B(128) || C(64) = 256
-    /// bytes.
-    pub proof_uncompressed: Vec<u8>,
-    /// extData passed to the pool contract.
-    pub ext_data: ExtData,
-    /// Public inputs and derived values used to build the on-chain `Proof`
-    /// struct.
-    pub prepared: PreparedTxPublic,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/app/crates/platforms/web/src/workers/prover.rs
+++ b/app/crates/platforms/web/src/workers/prover.rs
@@ -1,12 +1,12 @@
 use crate::protocol::{
-    DepositPrepared, PreparedProverTx, PreparedTxPublic, ProverWorkerRequest, ProverWorkerResponse,
+    PreparedProverTx, PreparedTxPublic, ProverWorkerRequest, ProverWorkerResponse,
 };
 use anyhow::{Context as _, Result};
 use futures::try_join;
 use gloo_timers::future::TimeoutFuture;
 use gloo_worker::{Registrable, oneshot::oneshot};
 use prover::{
-    flows::{TransactArtifacts, deposit, transact},
+    flows::{TransactArtifacts, transact},
     prover::Prover,
 };
 use sha2::{Digest as _, Sha256};
@@ -174,17 +174,6 @@ pub(crate) async fn router(req: ProverWorkerRequest) -> Result<ProverWorkerRespo
 
                 TimeoutFuture::new(50).await;
             }
-        }
-        ProverWorkerRequest::Deposit(params) => {
-            log::debug!("[{WORKER_NAME}] deposit");
-            let transact_artifacts = deposit(params, hash_ext_data_offchain)?;
-            log::debug!("[{WORKER_NAME}] prove_from_artifacts");
-            let prepared = prove_from_artifacts(transact_artifacts)?;
-            ProverWorkerResponse::DepositPrepared(DepositPrepared {
-                proof_uncompressed: prepared.proof_uncompressed,
-                ext_data: prepared.ext_data,
-                prepared: prepared.prepared,
-            })
         }
         ProverWorkerRequest::Transact(params) => {
             log::debug!("[{WORKER_NAME}] transact");

--- a/app/crates/platforms/web/src/workers/storage.rs
+++ b/app/crates/platforms/web/src/workers/storage.rs
@@ -8,7 +8,7 @@ use gloo_worker::{Registrable, oneshot::oneshot};
 use prover::{
     crypto::asp_membership_leaf,
     encryption::{derive_encryption_and_note_keypairs, generate_random_blinding},
-    flows::{DepositParams, N_OUTPUTS, TransactInputNote, TransactOutput, TransactParams},
+    flows::{N_OUTPUTS, TransactInputNote, TransactOutput, TransactParams},
     merkle::{MerklePrefixTree, MerkleProof},
 };
 use state::{
@@ -300,54 +300,6 @@ pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerRes
             let user_leaf = asp_membership_leaf(&pubkey, &membership_blinding)?;
             log::trace!("[{WORKER_NAME}] derived user leaf from the pubkey for the admin");
             StorageWorkerResponse::DeriveASPleaf(user_leaf)
-        }
-        StorageWorkerRequest::Deposit(req) => {
-            log::trace!("[{WORKER_NAME}] deposit");
-
-            let (note_privkey, note_pubkey, encryption_pubkey) =
-                load_user_key_material(&req.user_address)?;
-
-            let membership_proof = match build_membership_proof(
-                &req.aspmem_contract_id,
-                &note_pubkey,
-                req.membership_blinding,
-                req.aspmem_root,
-                req.aspmem_ledger,
-                req.tree_depth,
-            )? {
-                Ok(p) => p,
-                Err(status) => return Ok(StorageWorkerResponse::AspMembershipSync(status)),
-            };
-
-            let pool_root = req
-                .pool_root
-                .ok_or_else(|| anyhow::anyhow!("missing pool_root"))?;
-
-            let outputs = (0..N_OUTPUTS)
-                .map(|i| {
-                    Ok(TransactOutput {
-                        amount: req.output_amounts[i],
-                        blinding: generate_random_blinding()?,
-                        recipient_note_pubkey: Some(note_pubkey.clone()),
-                        recipient_encryption_pubkey: Some(encryption_pubkey.clone()),
-                    })
-                })
-                .collect::<Result<Vec<_>>>()?;
-
-            let params = DepositParams {
-                priv_key: note_privkey,
-                encryption_pubkey,
-                pool_root,
-                pool_address: req.pool_address,
-                amount: req.amount,
-                outputs,
-                membership_proof,
-                non_membership_proof: req.non_membership_proof,
-                tree_depth: req.tree_depth,
-                smt_depth: req.smt_depth,
-            };
-
-            StorageWorkerResponse::DepositParams(params)
         }
         StorageWorkerRequest::Transact(req) => {
             log::trace!("[{WORKER_NAME}] transact");

--- a/app/js/ui/transactions.js
+++ b/app/js/ui/transactions.js
@@ -244,107 +244,60 @@ function showSubmittedToasts(hashes) {
 
 const ASP_NOT_READY_MSG = 'Cannot prepare transaction yet (ASP registration required or membership blinding is incorrect).';
 
-function spendPlanStepCount(plan) {
+function planStepCount(plan) {
     const n = plan?.stepCount ?? plan?.step_count;
     if (typeof n === 'number' && Number.isFinite(n)) return Math.trunc(n);
     if (typeof n === 'bigint') return Number(n);
     return null;
 }
 
-function spendPlanHintText(stepCount) {
+function planHintText(stepCount) {
     if (stepCount === 1) return 'Requires 1 on-chain transaction.';
     return `Requires ${stepCount} on-chain transactions.`;
 }
 
-async function fetchSpendPlanStepCount(userAddress, poolContractId, amountStroops) {
-    const plan = await getHandle().webClient.planSpend(userAddress, poolContractId, amountStroops);
-    const stepCount = spendPlanStepCount(plan);
+async function fetchPlanStepCount(poolContractId, userAddress, amountStroops) {
+    const plan = await getHandle().webClient.plan(poolContractId, userAddress, amountStroops);
+    const stepCount = planStepCount(plan);
     if (stepCount == null || stepCount < 1) {
-        throw new Error('Could not plan spend');
+        throw new Error('Could not load plan');
     }
     return stepCount;
 }
 
-async function requireSpendPlanApproval(userAddress, poolContractId, amountStroops) {
-    const stepCount = await fetchSpendPlanStepCount(userAddress, poolContractId, amountStroops);
+async function requirePlanApproval(poolContractId, userAddress, amountStroops) {
+    const stepCount = await fetchPlanStepCount(poolContractId, userAddress, amountStroops);
     if (stepCount > 1) {
         const ok = window.confirm(
-            `This spend requires ${stepCount} on-chain transactions (${stepCount} wallet approvals). Continue?`,
+            `This requires ${stepCount} on-chain transactions (${stepCount} wallet approvals). Continue?`,
         );
         if (!ok) return null;
     }
     return stepCount;
 }
 
-async function submitProvedAdvanced(ctx, proved) {
-    if (proved == null) {
-        Toast.show(ASP_NOT_READY_MSG, 'error', 7000);
-        return;
-    }
-    ctx.setLoadingText(ctx.btn, 'Ready to sign…');
-    const txHash = await submitProvedPoolTransact(proved, {
-        address: ctx.userAddress,
-        rpcUrl: App.state.wallet.sorobanRpcUrl,
-        networkPassphrase: App.state.wallet.networkPassphrase,
-        poolContractId: ctx.poolContractId,
-    }, { onStatus: ctx.onStatus });
-    showSubmittedToasts([txHash]);
-}
-
-function callProveTransact(ctx, {
-    extRecipient,
-    extAmount,
-    inputNoteIds,
-    outputAmounts,
-    noteKeys,
-    encKeys,
-}) {
-    return getHandle().webClient.proveTransact(
-        ctx.poolContractId,
-        ctx.userAddress,
-        ctx.membershipBlinding,
-        extRecipient,
-        extAmount,
-        inputNoteIds,
-        outputAmounts,
-        noteKeys,
-        encKeys,
-        ctx.onStatus,
-    );
-}
-
-async function runSpendFlow({
-    btn,
-    advancedCheckboxId,
-    amountInputId,
-    membershipBlindingId,
-    proveAdvanced,
-    executeSimple,
-}) {
+async function prepareExecuteContext(btn, membershipBlindingId) {
     requireWalletReady();
     const userAddress = App.state.wallet.address;
     const membershipBlinding = parseMembershipBlinding(membershipBlindingId);
-    const advanced = isAdvancedMode(advancedCheckboxId);
-
     setLoading(btn, 'Validating…');
     const onStatus = p => p?.message && setLoadingText(btn, p.message);
-    const setLoadingTextForBtn = text => setLoadingText(btn, text);
     const config = await getContractConfig();
     const poolContractId = getActivePoolContractId(config);
-    const ctx = {
+    const submitFn = makePoolSubmitFn(poolContractId, userAddress, onStatus);
+    const client = getHandle().webClient;
+    return {
         btn,
         userAddress,
         membershipBlinding,
         poolContractId,
+        submitFn,
         onStatus,
-        setLoadingText: setLoadingTextForBtn,
+        client,
     };
+}
 
-    if (advanced) {
-        await proveAdvanced(ctx);
-        return;
-    }
-
+async function executeFromAmount(ctx, { btn, amountInputId, run }) {
     const amountRes = tryParseXlmToStroopsBigInt(
         document.getElementById(amountInputId)?.value,
         { allowNegative: false },
@@ -352,12 +305,18 @@ async function runSpendFlow({
     if (!amountRes.ok) throw new Error(amountRes.error);
     if (amountRes.value <= 0n) throw new Error('Amount must be greater than zero');
 
-    const stepCount = await requireSpendPlanApproval(userAddress, poolContractId, amountRes.value);
-    if (stepCount == null) return;
+    const stepCount = await requirePlanApproval(
+        ctx.poolContractId,
+        ctx.userAddress,
+        amountRes.value,
+    );
+    if (stepCount == null) return undefined;
 
     setLoadingText(btn, stepCount === 1 ? 'Proving…' : `Proving (1/${stepCount})…`);
-    const submitFn = makePoolSubmitFn(poolContractId, userAddress, onStatus);
-    const hashes = await executeSimple(ctx, amountRes.value, submitFn);
+    return run(ctx, amountRes.value);
+}
+
+function showExecuteResult(hashes) {
     if (hashes == null) {
         Toast.show(ASP_NOT_READY_MSG, 'error', 7000);
         return;
@@ -365,7 +324,7 @@ async function runSpendFlow({
     showSubmittedToasts(hashes);
 }
 
-function wireSpendPlanHint(amountInputId, hintId, advancedCheckboxId) {
+function wirePlanHint(amountInputId, hintId, advancedCheckboxId) {
     const input = document.getElementById(amountInputId);
     const hint = document.getElementById(hintId);
     let timer;
@@ -393,13 +352,13 @@ function wireSpendPlanHint(amountInputId, hintId, advancedCheckboxId) {
         try {
             const config = await getContractConfig();
             const poolContractId = getActivePoolContractId(config);
-            const stepCount = await fetchSpendPlanStepCount(
-                App.state.wallet.address,
+            const stepCount = await fetchPlanStepCount(
                 poolContractId,
+                App.state.wallet.address,
                 res.value,
             );
             if (hint) {
-                hint.textContent = spendPlanHintText(stepCount);
+                hint.textContent = planHintText(stepCount);
                 hint.classList.remove('hidden');
             }
         } catch {
@@ -646,10 +605,7 @@ export const Transactions = {
 
         btn?.addEventListener('click', async () => {
             try {
-                requireWalletReady();
                 const advanced = isAdvancedMode('deposit-advanced-mode');
-                const userAddress = App.state.wallet.address;
-                const membershipBlinding = parseMembershipBlinding('deposit-membership-blinding');
 
                 let amountStroops;
                 let outputAmounts;
@@ -665,33 +621,19 @@ export const Transactions = {
                     outputAmounts = [amountStroops, 0n];
                 }
 
-                setLoading(btn, 'Validating…');
-                const onStatus = p => p?.message && setLoadingText(btn, p.message);
-                const config = await getContractConfig();
-                const poolContractId = getActivePoolContractId(config);
+                const ctx = await prepareExecuteContext(btn, 'deposit-membership-blinding');
                 setLoadingText(btn, 'Proving…');
-                const proved = await getHandle().webClient.proveDeposit(
-                    poolContractId,
-                    userAddress,
-                    membershipBlinding,
+                const hashes = await ctx.client.executeDeposit(
+                    ctx.poolContractId,
+                    ctx.userAddress,
+                    ctx.membershipBlinding,
                     amountStroops,
                     outputAmounts,
-                    onStatus,
+                    ctx.submitFn,
+                    ctx.onStatus,
                 );
 
-                if (proved == null) {
-                    Toast.show(ASP_NOT_READY_MSG, 'error', 7000);
-                    return;
-                }
-
-                setLoadingText(btn, 'Ready to sign…');
-                const txHash = await submitProvedPoolTransact(proved, {
-                    address: userAddress,
-                    rpcUrl: App.state.wallet.sorobanRpcUrl,
-                    networkPassphrase: App.state.wallet.networkPassphrase,
-                    poolContractId,
-                }, { onStatus });
-                showSubmittedToasts([txHash]);
+                showExecuteResult(hashes);
             } catch (e) {
                 Toast.show(e?.message || 'Deposit failed', 'error', 7000);
             } finally {
@@ -707,53 +649,59 @@ export const Transactions = {
         const btn = document.getElementById('btn-withdraw');
         inputs?.addEventListener('input', updateWithdrawTotal);
         wireSpendAdvancedToggle('withdraw-advanced-mode', 'withdraw-advanced-section', 'withdraw-amount-section');
-        wireSpendPlanHint('withdraw-amount', 'withdraw-plan-hint', 'withdraw-advanced-mode');
+        wirePlanHint('withdraw-amount', 'withdraw-plan-hint', 'withdraw-advanced-mode');
         updateWithdrawTotal();
 
         btn?.addEventListener('click', async () => {
             try {
-                await runSpendFlow({
-                    btn,
-                    advancedCheckboxId: 'withdraw-advanced-mode',
-                    amountInputId: 'withdraw-amount',
-                    membershipBlindingId: 'withdraw-membership-blinding',
-                    proveAdvanced: async (ctx) => {
-                        const recipient = document.getElementById('withdraw-recipient')?.value?.trim()
-                            || ctx.userAddress;
-                        const inputNoteIds = collectNoteIds('withdraw-inputs');
-                        if (inputNoteIds.length === 0) throw new Error('Provide at least 1 input note');
-                        if (inputNoteIds.length > 2) throw new Error('At most 2 input notes are supported');
+                const advanced = isAdvancedMode('withdraw-advanced-mode');
+                const ctx = await prepareExecuteContext(btn, 'withdraw-membership-blinding');
+                const recipient = document.getElementById('withdraw-recipient')?.value?.trim()
+                    || ctx.userAddress;
 
-                        const total = sumInputNotesStroops('withdraw-inputs');
-                        if (total <= 0n) {
-                            throw new Error('Selected notes must have a positive total');
-                        }
+                let hashes;
+                if (advanced) {
+                    const inputNoteIds = collectNoteIds('withdraw-inputs');
+                    if (inputNoteIds.length === 0) throw new Error('Provide at least 1 input note');
+                    if (inputNoteIds.length > 2) throw new Error('At most 2 input notes are supported');
 
-                        ctx.setLoadingText(ctx.btn, 'Proving…');
-                        const proved = await callProveTransact(ctx, {
-                            extRecipient: recipient,
-                            extAmount: -total,
-                            inputNoteIds,
-                            outputAmounts: [0n, 0n],
-                            noteKeys: [null, null],
-                            encKeys: [null, null],
-                        });
-                        await submitProvedAdvanced(ctx, proved);
-                    },
-                    executeSimple: async (ctx, amountStroops, submitFn) => {
-                        const recipient = document.getElementById('withdraw-recipient')?.value?.trim()
-                            || ctx.userAddress;
-                        return getHandle().webClient.executeWithdraw(
-                            ctx.poolContractId,
-                            ctx.userAddress,
-                            ctx.membershipBlinding,
+                    const total = sumInputNotesStroops('withdraw-inputs');
+                    if (total <= 0n) {
+                        throw new Error('Selected notes must have a positive total');
+                    }
+
+                    setLoadingText(btn, 'Proving…');
+                    hashes = await ctx.client.executeTransact(
+                        ctx.poolContractId,
+                        ctx.userAddress,
+                        ctx.membershipBlinding,
+                        recipient,
+                        -total,
+                        inputNoteIds,
+                        [0n, 0n],
+                        [null, null],
+                        [null, null],
+                        ctx.submitFn,
+                        ctx.onStatus,
+                    );
+                } else {
+                    hashes = await executeFromAmount(ctx, {
+                        btn,
+                        amountInputId: 'withdraw-amount',
+                        run: (c, amountStroops) => c.client.executeWithdraw(
+                            c.poolContractId,
+                            c.userAddress,
+                            c.membershipBlinding,
                             recipient,
                             amountStroops,
-                            submitFn,
-                            ctx.onStatus,
-                        );
-                    },
-                });
+                            c.submitFn,
+                            c.onStatus,
+                        ),
+                    });
+                    if (hashes === undefined) return;
+                }
+
+                showExecuteResult(hashes);
             } catch (e) {
                 Toast.show(e?.message || 'Withdraw failed', 'error', 7000);
             } finally {
@@ -776,7 +724,7 @@ export const Transactions = {
         inputs?.addEventListener('input', updateTransferBalance);
         outputs?.addEventListener('input', updateTransferBalance);
         wireSpendAdvancedToggle('transfer-advanced-mode', 'transfer-advanced-section', 'transfer-amount-section');
-        wireSpendPlanHint('transfer-amount', 'transfer-plan-hint', 'transfer-advanced-mode');
+        wirePlanHint('transfer-amount', 'transfer-plan-hint', 'transfer-advanced-mode');
         updateTransferBalance();
 
         btn?.addEventListener('click', async () => {
@@ -787,41 +735,51 @@ export const Transactions = {
                     throw new Error('Recipient note key + encryption key are required');
                 }
 
-                await runSpendFlow({
-                    btn,
-                    advancedCheckboxId: 'transfer-advanced-mode',
-                    amountInputId: 'transfer-amount',
-                    membershipBlindingId: 'transfer-membership-blinding',
-                    proveAdvanced: async (ctx) => {
-                        const inputNoteIds = collectNoteIds('transfer-inputs');
-                        if (inputNoteIds.length === 0) throw new Error('Provide at least 1 input note');
-                        if (inputNoteIds.length > 2) throw new Error('At most 2 input notes are supported');
-                        if (!updateTransferBalance()) throw new Error('Input notes must equal output amounts');
+                const advanced = isAdvancedMode('transfer-advanced-mode');
+                const ctx = await prepareExecuteContext(btn, 'transfer-membership-blinding');
 
-                        const outputAmounts = collectOutputAmounts('transfer-outputs');
+                let hashes;
+                if (advanced) {
+                    const inputNoteIds = collectNoteIds('transfer-inputs');
+                    if (inputNoteIds.length === 0) throw new Error('Provide at least 1 input note');
+                    if (inputNoteIds.length > 2) throw new Error('At most 2 input notes are supported');
+                    if (!updateTransferBalance()) throw new Error('Input notes must equal output amounts');
 
-                        ctx.setLoadingText(ctx.btn, 'Proving…');
-                        const proved = await callProveTransact(ctx, {
-                            extRecipient: ctx.poolContractId,
-                            extAmount: 0n,
-                            inputNoteIds,
-                            outputAmounts,
-                            noteKeys: [recipientNoteKey, recipientNoteKey],
-                            encKeys: [recipientEncKey, recipientEncKey],
-                        });
-                        await submitProvedAdvanced(ctx, proved);
-                    },
-                    executeSimple: async (ctx, amountStroops, submitFn) => getHandle().webClient.executeTransfer(
+                    const outputAmounts = collectOutputAmounts('transfer-outputs');
+
+                    setLoadingText(btn, 'Proving…');
+                    hashes = await ctx.client.executeTransact(
                         ctx.poolContractId,
                         ctx.userAddress,
                         ctx.membershipBlinding,
-                        amountStroops,
-                        recipientNoteKey,
-                        recipientEncKey,
-                        submitFn,
+                        ctx.poolContractId,
+                        0n,
+                        inputNoteIds,
+                        outputAmounts,
+                        [recipientNoteKey, recipientNoteKey],
+                        [recipientEncKey, recipientEncKey],
+                        ctx.submitFn,
                         ctx.onStatus,
-                    ),
-                });
+                    );
+                } else {
+                    hashes = await executeFromAmount(ctx, {
+                        btn,
+                        amountInputId: 'transfer-amount',
+                        run: (c, amountStroops) => c.client.executeTransfer(
+                            c.poolContractId,
+                            c.userAddress,
+                            c.membershipBlinding,
+                            amountStroops,
+                            recipientNoteKey,
+                            recipientEncKey,
+                            c.submitFn,
+                            c.onStatus,
+                        ),
+                    });
+                    if (hashes === undefined) return;
+                }
+
+                showExecuteResult(hashes);
             } catch (e) {
                 Toast.show(e?.message || 'Transfer failed', 'error', 7000);
             } finally {
@@ -859,11 +817,10 @@ export const Transactions = {
 
         btn?.addEventListener('click', async () => {
             try {
-                requireWalletReady();
-                const userAddress = App.state.wallet.address;
-                const membershipBlinding = parseMembershipBlinding('transact-membership-blinding');
+                const ctx = await prepareExecuteContext(btn, 'transact-membership-blinding');
                 const extAmountStroops = decimalToBaseUnitsBigInt(amount.value, { allowNegative: true });
-                const extRecipient = document.getElementById('transact-recipient')?.value?.trim() || userAddress;
+                const extRecipient = document.getElementById('transact-recipient')?.value?.trim()
+                    || ctx.userAddress;
                 if (extAmountStroops < 0n && !extRecipient) {
                     throw new Error('Withdrawal recipient is required when public amount is negative');
                 }
@@ -873,46 +830,21 @@ export const Transactions = {
                 const outputAmounts = collectOutputAmounts('transact-outputs');
                 const { noteKeys, encKeys } = collectAdvancedRecipients('transact-outputs');
 
-                setLoading(btn, 'Validating…');
-                const onStatus = p => p?.message && setLoadingText(btn, p.message);
-	                const config = await getContractConfig();
-                const poolContractId = getActivePoolContractId(config);
-	                setLoadingText(btn, 'Proving…');
-	                const proved = await callProveTransact(
-	                    {
-	                        userAddress,
-	                        membershipBlinding,
-	                        poolContractId,
-	                        onStatus,
-	                    },
-	                    {
-	                        extRecipient,
-	                        extAmount: extAmountStroops,
-	                        inputNoteIds,
-	                        outputAmounts,
-	                        noteKeys,
-	                        encKeys,
-	                    },
-	                );
-	                if (proved == null) {
-	                    Toast.show('Cannot prepare transaction yet (ASP registration required or membership blinding is incorrect).', 'error', 7000);
-	                    return;
-	                }
-
-	                setLoadingText(btn, 'Ready to sign…');
-	                const txHash = await submitProvedPoolTransact(proved, {
-	                    address: userAddress,
-	                    rpcUrl: App.state.wallet.sorobanRpcUrl,
-	                    networkPassphrase: App.state.wallet.networkPassphrase,
-	                    poolContractId: poolContractId,
-	                }, { onStatus });
-                Toast.show(
-                    `Submitted: ${Utils.truncateHex(txHash, 10, 8)}`,
-                    'success',
-                    7000,
-                    { linkUrl: txLink(txHash), linkAriaLabel: 'Open in Stellar Expert' }
+                setLoadingText(btn, 'Proving…');
+                const hashes = await ctx.client.executeTransact(
+                    ctx.poolContractId,
+                    ctx.userAddress,
+                    ctx.membershipBlinding,
+                    extRecipient,
+                    extAmountStroops,
+                    inputNoteIds,
+                    outputAmounts,
+                    noteKeys,
+                    encKeys,
+                    ctx.submitFn,
+                    ctx.onStatus,
                 );
-                App.events.dispatchEvent(new CustomEvent('tx:submitted', { detail: { txHash } }));
+                showExecuteResult(hashes);
             } catch (e) {
                 Toast.show(e?.message || 'Transact failed', 'error', 7000);
             } finally {


### PR DESCRIPTION
Efforts on refactoring the main API, renaming `prove*` methods to a more suitable `execute*`.
Improves harmony with the new tx-planning.
Dedups some logic into a unified transact worker path.