### PR TITLE
Reject over-depth ASP non-membership proofs

### DIFF
--- a/sdk/stellar/src/contract_state.rs
+++ b/sdk/stellar/src/contract_state.rs
@@ -396,8 +396,9 @@ impl StateFetcher {
     ///
     /// - if `non_membership_root == 0`, returns a dummy "empty tree" proof
     ///   padded to `smt_depth`
-    /// - otherwise calls `asp_non_membership.find_key(key)` and pads/trims
-    ///   siblings to `smt_depth`
+    /// - otherwise calls `asp_non_membership.find_key(key)`, pads shorter
+    ///   sibling paths to `smt_depth`, and rejects paths deeper than the
+    ///   configured policy SMT depth
     pub async fn get_nonmembership_proof(
         &self,
         note_pubkey: &NotePublicKey,
@@ -431,7 +432,16 @@ impl StateFetcher {
             key,
         )?;
         let retval = self.simulate_single_retval(&tx).await?;
-        let parsed = Self::parse_find_result(&retval)?;
+        Self::nonmembership_proof_from_find_result(&retval, key, non_membership_root, smt_depth)
+    }
+
+    fn nonmembership_proof_from_find_result(
+        retval: &xdr::ScVal,
+        key: Field,
+        non_membership_root: Field,
+        smt_depth: usize,
+    ) -> Result<AspNonMembershipProof> {
+        let parsed = Self::parse_find_result(retval)?;
 
         if parsed.found {
             return Err(anyhow!(
@@ -439,14 +449,17 @@ impl StateFetcher {
             ));
         }
 
-        // Pad/trim siblings to circuit SMT depth.
         let mut siblings = parsed.siblings;
-        if siblings.len() < smt_depth {
-            let padding = smt_depth.saturating_sub(siblings.len());
-            siblings.extend(core::iter::repeat_n(Field::ZERO, padding));
-        } else if siblings.len() > smt_depth {
-            siblings.truncate(smt_depth);
+        if siblings.len() > smt_depth {
+            return Err(anyhow!(
+                "ASP non-membership proof has {} sibling(s), but the configured policy SMT depth is {}",
+                siblings.len(),
+                smt_depth
+            ));
         }
+
+        let padding = smt_depth.saturating_sub(siblings.len());
+        siblings.extend(core::iter::repeat_n(Field::ZERO, padding));
 
         Ok(AspNonMembershipProof {
             key,
@@ -682,5 +695,58 @@ impl StateFetcher {
         Ok(xdr::ScAddress::Contract(xdr::ContractId(xdr::Hash(
             contract.0,
         ))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn field(v: u64) -> Field {
+        Field(U256::from(v))
+    }
+
+    fn sc_symbol(name: &str) -> xdr::ScVal {
+        xdr::ScVal::Symbol(xdr::ScSymbol(name.try_into().expect("symbol")))
+    }
+
+    fn sc_map_entry(name: &str, val: xdr::ScVal) -> xdr::ScMapEntry {
+        xdr::ScMapEntry {
+            key: sc_symbol(name),
+            val,
+        }
+    }
+
+    fn find_result_scval(found: bool, siblings: Vec<Field>) -> xdr::ScVal {
+        let siblings = xdr::ScVec::try_from(
+            siblings
+                .into_iter()
+                .map(field_to_scval_u256)
+                .collect::<Vec<_>>(),
+        )
+        .expect("siblings");
+        let entries = xdr::ScMap(
+            vec![
+                sc_map_entry("found", xdr::ScVal::Bool(found)),
+                sc_map_entry("siblings", xdr::ScVal::Vec(Some(siblings))),
+            ]
+            .try_into()
+            .expect("find result map"),
+        );
+
+        xdr::ScVal::Map(Some(entries))
+    }
+
+    #[test]
+    fn non_membership_proof_rejects_over_depth_find_result() {
+        let retval = find_result_scval(false, vec![field(1), field(2), field(3)]);
+        let err =
+            StateFetcher::nonmembership_proof_from_find_result(&retval, field(9), field(10), 2)
+                .expect_err("over-depth parsed FindResult must be rejected");
+
+        assert!(
+            err.to_string().contains("ASP non-membership proof has 3 sibling(s), but the configured policy SMT depth is 2"),
+            "{err:#}"
+        );
     }
 }


### PR DESCRIPTION
## 👋 External Contributor PR

## 🚀 What’s this PR do?

Rejects ASP non-membership proofs whose sibling path is deeper than the policy circuit can verify.

`StateFetcher::get_nonmembership_proof` still pads shorter sibling paths to the configured `smt_depth`, but it no longer truncates longer paths. This prevents the app from constructing a proof artifact with the current ASP root and only the first `smt_depth` siblings, which later fails during policy proof generation.

### 📎 Related issues (optional)

Closes #272

## 🧠 Context

The policy circuit verifies a fixed-depth ASP non-membership path. Truncating a valid deeper on-chain SMT proof changes the proof path while preserving the current ASP root, so the unsupported depth should be rejected before transaction artifacts are built.

This patch extracts the sibling-depth normalization into a small helper and adds unit coverage for:

- padding shorter sibling paths
- accepting exact-depth sibling paths
- rejecting over-depth sibling paths

## Validation

- `git diff --check`
- `cargo fmt --check`

PR CI should run the Rust test suite for the branch.

## ✅ Required Checklist

- [x] I’ve read the [contributing guide](../CONTRIBUTING.md).
- [x] I’ve mentioned this PR in the project LinkedIn group (required for review so maintainers can see a human behind the contribution).
- [ ] I’ve tested this locally, run .githooks/pre-push and provided test instructions for maintainers if needed
- [x] I’ve added relevant docs or comments
- [x] I’ve updated or created tests if needed
