### PR TITLE
CI unused deps check

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -10,6 +10,12 @@ if ! cargo sort --workspace --check; then
     exit 1
 fi
 
+# Unused dependencies
+if ! cargo shear; then
+    echo "❌ Unused dependencies detected (run 'cargo shear --fix')"
+    exit 7
+fi
+
 # Dependency audit
 if ! cargo deny check; then
     echo "❌ Critical: Vulnerable dependencies detected (run 'cargo deny check')"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,6 +25,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+    
+      - name: Install cargo-shear
+        uses: taiki-e/install-action@541dbe11e2898b05bb65bedbd1d0c4e3092b5bdd # v2
+        with:
+          tool: cargo-shear@1.11.2
+      - name: Check for unused dependencies
+        run: cargo shear
+
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
         with:
           toolchain: stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,16 +818,12 @@ dependencies = [
  "anyhow",
  "ark-bn254 0.6.0",
  "ark-circom",
- "ark-ff 0.6.0",
  "ark-groth16",
  "ark-serialize 0.6.0",
  "circuit-keys",
  "clap",
  "getrandom 0.2.17",
  "glob",
- "num-bigint",
- "serde",
- "serde_json",
  "shlex",
  "zeroize",
 ]
@@ -942,7 +938,6 @@ dependencies = [
  "parser",
  "program_structure",
  "regex",
- "serde_json",
  "type_analysis",
  "wast",
  "zkhash",
@@ -1778,7 +1773,6 @@ dependencies = [
  "anyhow",
  "hex",
  "prover",
- "serde_json",
  "sha2 0.11.0",
  "types",
 ]
@@ -1826,9 +1820,6 @@ name = "e2e-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ark-bn254 0.6.0",
- "ark-ff 0.6.0",
- "ark-groth16",
  "asp-membership",
  "asp-non-membership",
  "circom-groth16-verifier",
@@ -4262,16 +4253,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4638,7 +4619,6 @@ name = "soroban-utils"
 version = "0.1.0"
 dependencies = [
  "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
  "ark-ff 0.6.0",
  "ark-groth16",
  "contract-types",
@@ -4719,7 +4699,6 @@ dependencies = [
  "prover",
  "rusqlite",
  "rusqlite_migration",
- "serde",
  "sha2 0.11.0",
  "stellar",
  "types",
@@ -5245,7 +5224,6 @@ dependencies = [
  "hex",
  "rusqlite",
  "serde",
- "serde_bytes",
  "serde_json",
  "uint",
 ]
@@ -6128,9 +6106,6 @@ dependencies = [
  "anyhow",
  "ark-bn254 0.6.0",
  "ark-circom",
- "ark-ff 0.6.0",
- "ark-std 0.6.0",
- "getrandom 0.2.17",
  "num-bigint",
  "serde_json",
  "wasmer",
@@ -6284,13 +6259,10 @@ name = "zkhash"
 version = "0.2.0"
 dependencies = [
  "ark-ff 0.6.0",
- "ark-std 0.6.0",
  "cfg-if",
- "getrandom 0.2.17",
  "hex",
  "lazy_static",
  "rand",
- "sha2 0.11.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,8 @@ publish = false
 anyhow = { version = "1", default-features = false }
 ark-bn254 = { version = "0.6.0", default-features = false, features = ["curve"] }
 ark-circom = { git = "https://github.com/NethermindEth/circom-compat.git", default-features = false, branch = "wasm-no-parallel" }
-ark-crypto-primitives = { version = "0.6.0", default-features = false }
-ark-ec = { version = "0.6.0", default-features = false }
 ark-ff = { version = "0.6.0", default-features = false }
 ark-groth16 = { version = "0.6.0", default-features = false }
-ark-poly = { version = "0.6.0", default-features = false }
 ark-relations = { version = "0.6.0", default-features = false }
 ark-serialize = { version = "0.6.0", default-features = false }
 ark-snark = { version = "0.6.0", default-features = false }
@@ -54,13 +51,11 @@ hex = { version = "0.4", default-features = false, features = ["alloc"] }
 log = { version = "0.4", default-features = false }
 num-bigint = { version = "0.4.6", default-features = false, features = ["serde"] }
 num-integer = { version = "0.1.46", default-features = false }
-num-traits = { version = "0.2", default-features = false }
 pool = { path = "contracts/pool" }
 prover = { path = "app/crates/core/prover" }
 rusqlite = { version = "0.39.0", default-features = false, features = ["buildtime_bindgen"] }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 serde-wasm-bindgen = { version = "0.6", default-features = false }
-serde_bytes = { version = "0.11", default-features = false }
 serde_json = { version = "1", default-features = false }
 sha2 = { version = "0.11.0", default-features = false }
 soroban-sdk = { version = "26", default-features = false, features = ["hazmat"] }
@@ -76,7 +71,6 @@ wasm-bindgen-test = { version = "0.3", default-features = false, features = ["st
 wasm-log = { version = "0.3", default-features = false }
 # see also https://github.com/NethermindEth/stellar-private-payments/issues/192
 wasmer = { git = "https://github.com/wasmerio/wasmer", rev = "763e9f2800644f51ce27f6f5c1752776da16ddd1", shallow = true, default-features = false }
-web = { path = "app/crates/platforms/web" }
 witness = { path = "app/crates/core/witness" }
 zkhash = { path = "poseidon2" }
 

--- a/app/crates/core/disclosure/Cargo.toml
+++ b/app/crates/core/disclosure/Cargo.toml
@@ -14,8 +14,5 @@ prover = { workspace = true }
 sha2 = { workspace = true }
 types = { workspace = true }
 
-[dev-dependencies]
-serde_json = { workspace = true, features = ["alloc"] }
-
 [lints]
 workspace = true

--- a/app/crates/core/state/Cargo.toml
+++ b/app/crates/core/state/Cargo.toml
@@ -14,7 +14,6 @@ hex = { workspace = true }
 log = { workspace = true }
 rusqlite = { workspace = true }
 rusqlite_migration = { version = "2.5.0", default-features = false }
-serde = { workspace = true }
 stellar = { workspace = true }
 types = { workspace = true, features = ["rusqlite"] }
 

--- a/app/crates/core/types/Cargo.toml
+++ b/app/crates/core/types/Cargo.toml
@@ -15,7 +15,6 @@ anyhow = { workspace = true }
 hex = { workspace = true }
 rusqlite = { workspace = true, optional = true }
 serde = { workspace = true }
-serde_bytes = { workspace = true }
 uint = { workspace = true }
 
 [dev-dependencies]

--- a/app/crates/core/witness/Cargo.toml
+++ b/app/crates/core/witness/Cargo.toml
@@ -13,9 +13,6 @@ anyhow = { workspace = true }
 # Arkworks
 ark-bn254 = { workspace = true }
 ark-circom = { workspace = true }
-ark-ff = { workspace = true }
-ark-std = { workspace = true }
-getrandom = { workspace = true }
 
 # BigInt support for input parsing
 num-bigint = { workspace = true }

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -61,7 +61,6 @@ num-bigint = { workspace = true }
 parser = { git = "https://github.com/iden3/circom", tag = "v2.2.3" }
 program_structure = { git = "https://github.com/iden3/circom", tag = "v2.2.3" }
 regex = "1"
-serde_json = "1.0"
 type_analysis = { git = "https://github.com/iden3/circom", tag = "v2.2.3" }
 wast = "248.0.0"
 

--- a/contracts/soroban-utils/Cargo.toml
+++ b/contracts/soroban-utils/Cargo.toml
@@ -12,7 +12,6 @@ doctest = false
 
 [dependencies]
 ark-bn254 = { workspace = true }
-ark-ec = { workspace = true }
 ark-ff = { workspace = true }
 ark-groth16 = { workspace = true }
 contract-types = { workspace = true }

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -8,9 +8,6 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-ark-bn254 = { workspace = true }
-ark-ff = { workspace = true }
-ark-groth16 = { workspace = true }
 asp-membership = { workspace = true }
 asp-non-membership = { workspace = true }
 circom-groth16-verifier = { workspace = true }

--- a/poseidon2/Cargo.toml
+++ b/poseidon2/Cargo.toml
@@ -15,16 +15,10 @@ asm = ["ark-ff/asm"]
 
 [dependencies]
 ark-ff = { workspace = true }
-ark-std = { workspace = true }
 cfg-if = { workspace = true }
 hex = { workspace = true }
 lazy_static = "1.5"
 rand = "0.8"
-sha2 = { workspace = true }
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-getrandom = { workspace = true, features = ["std"] }
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { workspace = true, features = ["js"] }
 
 [profile.release]
 # Enable link-time optimization, eliminates more code and inlines across crate boundaries.

--- a/tools/ceremony-cli/Cargo.toml
+++ b/tools/ceremony-cli/Cargo.toml
@@ -14,16 +14,12 @@ path = "src/main.rs"
 anyhow.workspace = true
 ark-bn254.workspace = true
 ark-circom.workspace = true
-ark-ff.workspace = true
 ark-groth16.workspace = true
 ark-serialize.workspace = true
 circuit-keys.workspace = true
 clap = { version = "4.6.1", features = ["derive"] }
 getrandom.workspace = true
 glob = "0.3.3"
-num-bigint.workspace = true
-serde.workspace = true
-serde_json = { workspace = true, features = ["std"] }
 shlex = "1.3.0"
 zeroize = "1.8.2"
 


### PR DESCRIPTION
Checks for unused dependencies using [cargo shear](https://github.com/Boshen/cargo-shear). Seems to be a bit better than machete, [see the claims](https://github.com/Boshen/cargo-shear#prior-art).
This PR also removes the current unused deps.