### PR TITLE
feat: add remove non-membership leaf functionality to admin UI

### DIFF
--- a/app/admin.html
+++ b/app/admin.html
@@ -204,6 +204,18 @@
         Insert Non-Membership Leaf
       </button>
       <p class="text-xs text-dark-400">Leaf hash uses Poseidon2(key, value, domain=1).</p>
+
+      <div class="border-t border-dark-700 pt-4 space-y-4">
+        <h3 class="text-sm uppercase tracking-[0.25em] text-rose-400">Remove Non-Membership Leaf</h3>
+        <p class="text-xs text-dark-400">Unblock a user by removing their key from the non-membership tree. Requires admin authorization.</p>
+        <div class="space-y-3">
+          <label class="block text-xs font-medium text-dark-400 uppercase tracking-wide" for="removeNonMembershipKey">Key (public key to unblock)</label>
+          <input class="w-full px-3 py-2 bg-dark-800 border border-dark-700 rounded-lg text-xs font-mono focus:outline-none focus:border-rose-500 focus:ring-1 focus:ring-rose-500" id="removeNonMembershipKey" type="text" placeholder="0x..." />
+        </div>
+        <button class="w-full px-4 py-2 bg-rose-600 text-white rounded-lg text-sm font-semibold shadow-lg shadow-rose-600/20 hover:bg-rose-500 transition" id="removeNonMembershipLeafBtn" type="button">
+          Remove Non-Membership Leaf
+        </button>
+      </div>
     </section>
 
     <section class="xl:col-span-3 bg-dark-900/80 backdrop-blur-sm border border-dark-800 rounded-xl p-4 sm:p-6" aria-labelledby="activity-heading">

--- a/app/js/admin.js
+++ b/app/js/admin.js
@@ -45,6 +45,10 @@ const computeNonMembershipLeafBtn = document.getElementById('computeNonMembershi
 const computedNonMembershipLeafHexEl = document.getElementById('computedNonMembershipLeafHex');
 const insertNonMembershipLeafBtn = document.getElementById('insertNonMembershipLeafBtn');
 
+// Non-membership leaf removal inputs
+const removeNonMembershipKeyInput = document.getElementById('removeNonMembershipKey');
+const removeNonMembershipLeafBtn = document.getElementById('removeNonMembershipLeafBtn');
+
 const state = {
   address: null,
   networkPassphrase: null,
@@ -453,6 +457,34 @@ async function computeNonMembershipLeaf() {
   }
 }
 
+async function removeNonMembershipLeaf() {
+  try {
+    ensureWalletConnected();
+    const contractId = nonMembershipContractInput.value.trim();
+    if (!contractId) {
+      throw new Error('Non-membership contract ID is required');
+    }
+
+    const keyValue = parseBigIntInput(reverseHexWithPrefix(removeNonMembershipKeyInput.value), 'Key');
+    if (keyValue === null) {
+      throw new Error('Key is required');
+    }
+
+    setStatus('Removing non-membership leaf...', 'info');
+    const client = await getNonMembershipClient(contractId);
+    const tx = await client.delete_leaf({ key: keyValue });
+    const sent = await tx.signAndSend();
+    log(`Non-membership leaf removed: ${sent.sendTransactionResponse?.hash || 'ok'}`);
+    setStatus('Non-membership leaf removed', 'ok');
+    showToast('Non-membership leaf removed successfully', 'success');
+    await refreshState();
+  } catch (err) {
+    setStatus('Non-membership removal failed', 'error');
+    log(`Non-membership removal error: ${err.message}`);
+    showToast('Failed to remove non-membership leaf', 'error');
+  }
+}
+
 async function insertNonMembershipLeaf() {
   try {
     ensureWalletConnected();
@@ -503,6 +535,9 @@ computeNonMembershipLeafBtn.addEventListener('click', () => {
 });
 insertNonMembershipLeafBtn.addEventListener('click', () => {
   insertNonMembershipLeaf();
+});
+removeNonMembershipLeafBtn.addEventListener('click', () => {
+  removeNonMembershipLeaf();
 });
 valueSameCheckbox.addEventListener('change', () => {
   syncNonMembershipValue();


### PR DESCRIPTION
## Summary

Closes #131

- Adds a **Remove Non-Membership Leaf** sub-section to the Non-Membership panel in `admin.html`, with a key input and a rose-styled button to signal the destructive action
- Adds `removeNonMembershipLeaf()` in `admin.js` that calls `client.delete_leaf({ key })` on the non-membership contract, matching the existing admin-gated contract function signature
- Follows the same error-handling pattern as `insertNonMembershipLeaf()` — wallet guard, contract ID validation, status/log/toast feedback, and `refreshState()` on success