### PR TITLE
Group Cargo.toml deps, local vs external

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,8 +5,8 @@ echo "⚠️ Some tests are ignored because they take a long time"
 echo "⚠️ you can run them with ('BUILD_TESTS=1 cargo test -p circuits -- --ignored') "
 
 # Dependency sorting
-if ! cargo sort --workspace --check; then
-    echo "❌ Dependencies should be sorted (run 'cargo sort --workspace')"
+if ! cargo sort --workspace -g --check; then
+    echo "❌ Dependencies should be sorted (run 'cargo sort --workspace -g')"
     exit 1
 fi
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,26 @@ license = "Apache-2.0"
 publish = false
 
 [workspace.dependencies]
+# workspace
+asp-membership = { path = "contracts/asp-membership" }
+asp-non-membership = { path = "contracts/asp-non-membership" }
+circom-groth16-verifier = { path = "contracts/circom-groth16-verifier" }
+circuit-keys = { path = "circuit-keys" }
+circuits = { path = "circuits", default-features = false }
+contract-types = { path = "contracts/types" }
+disclosure = { path = "app/crates/core/disclosure" }
+pool = { path = "contracts/pool" }
+prover = { path = "app/crates/core/prover" }
+public-key-registry = { path = "contracts/public-key-registry" }
+soroban-utils = { path = "contracts/soroban-utils" }
+state = { path = "app/crates/core/state" }
+stellar = { path = "app/crates/core/stellar" }
+tx-planner = { path = "app/crates/core/tx-planner" }
+types = { path = "app/crates/core/types" }
+witness = { path = "app/crates/core/witness" }
+zkhash = { path = "poseidon2" }
+
+# external
 anyhow = { version = "1", default-features = false }
 ark-bn254 = { version = "0.6.0", default-features = false, features = ["curve"] }
 ark-circom = { git = "https://github.com/NethermindEth/circom-compat.git", default-features = false, branch = "wasm-no-parallel" }
@@ -35,16 +55,9 @@ ark-relations = { version = "0.6.0", default-features = false }
 ark-serialize = { version = "0.6.0", default-features = false }
 ark-snark = { version = "0.6.0", default-features = false }
 ark-std = { version = "0.6.0", default-features = false, features = ["std"] }
-asp-membership = { path = "contracts/asp-membership" }
-asp-non-membership = { path = "contracts/asp-non-membership" }
 async-trait = { version = "0.1.89", default-features = false }
 cfg-if = { version = "1", default-features = false }
-circom-groth16-verifier = { path = "contracts/circom-groth16-verifier" }
-circuit-keys = { path = "circuit-keys" }
-circuits = { path = "circuits", default-features = false }
 console_error_panic_hook = { version = "0.1.7", default-features = false }
-contract-types = { path = "contracts/types" }
-disclosure = { path = "app/crates/core/disclosure" }
 futures = { version = "0.3.32", default-features = false, features = ["async-await"] }
 getrandom = { version = "0.2", default-features = false }
 gloo-timers = { version = "0.4", default-features = false, features = ["futures"] }
@@ -52,9 +65,6 @@ hex = { version = "0.4", default-features = false, features = ["alloc"] }
 log = { version = "0.4", default-features = false }
 num-bigint = { version = "0.4.6", default-features = false, features = ["serde"] }
 num-integer = { version = "0.1.46", default-features = false }
-pool = { path = "contracts/pool" }
-prover = { path = "app/crates/core/prover" }
-public-key-registry = { path = "contracts/public-key-registry" }
 reqwest = { version = "0.13", default-features = false, features = ["json"] }
 rusqlite = { version = "0.39.0", default-features = false, features = ["buildtime_bindgen"] }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
@@ -62,20 +72,13 @@ serde-wasm-bindgen = { version = "0.6", default-features = false }
 serde_json = { version = "1", default-features = false }
 sha2 = { version = "0.11.0", default-features = false }
 soroban-sdk = { version = "26", default-features = false, features = ["hazmat"] }
-soroban-utils = { path = "contracts/soroban-utils" }
-state = { path = "app/crates/core/state" }
-stellar = { path = "app/crates/core/stellar" }
 thiserror = { version = "2", default-features = false }
-tx-planner = { path = "app/crates/core/tx-planner" }
-types = { path = "app/crates/core/types" }
 uint = { version = "0.10", default-features = false }
 wasm-bindgen = { version = "0.2", default-features = false, features = ["serde-serialize"] }
 wasm-bindgen-test = { version = "0.3", default-features = false, features = ["std"] }
 wasm-log = { version = "0.3", default-features = false }
 # see also https://github.com/NethermindEth/stellar-private-payments/issues/192
 wasmer = { git = "https://github.com/wasmerio/wasmer", rev = "763e9f2800644f51ce27f6f5c1752776da16ddd1", shallow = true, default-features = false }
-witness = { path = "app/crates/core/witness" }
-zkhash = { path = "poseidon2" }
 
 [workspace.lints.rust]
 missing_docs = "allow"

--- a/app/crates/core/disclosure/Cargo.toml
+++ b/app/crates/core/disclosure/Cargo.toml
@@ -8,11 +8,14 @@ publish.workspace = true
 description = "Selective disclosure receipt validation and circuit metadata"
 
 [dependencies]
+# workspace
+prover = { workspace = true }
+types = { workspace = true }
+
+# external
 anyhow = { workspace = true }
 hex = { workspace = true }
-prover = { workspace = true }
 sha2 = { workspace = true }
-types = { workspace = true }
 
 [lints]
 workspace = true

--- a/app/crates/core/prover/Cargo.toml
+++ b/app/crates/core/prover/Cargo.toml
@@ -8,6 +8,14 @@ publish.workspace = true
 description = "Browser WASM module for ZK proof generation using Groth16"
 
 [dependencies]
+# workspace
+# Circuit utilities (core module only, no_std compatible)
+circuits = { workspace = true, default-features = false }
+types = { workspace = true }
+# Poseidon2 hash
+zkhash = { workspace = true }
+
+# external
 anyhow = { workspace = true }
 # Arkworks ZK proving
 ark-bn254 = { workspace = true }
@@ -18,18 +26,17 @@ ark-relations = { workspace = true }
 ark-serialize = { workspace = true }
 ark-snark = { workspace = true }
 ark-std = { workspace = true }
-# Circuit utilities (core module only, no_std compatible)
-circuits = { workspace = true, default-features = false }
 crypto_secretbox = { version = "0.1.1", default-features = false, features = ["alloc", "salsa20"] }
 serde = { workspace = true }
 sha2 = { workspace = true }
-types = { workspace = true }
 x25519-dalek = { version = "2.0", default-features = false, features = ["static_secrets"] }
-# Poseidon2 hash
-zkhash = { workspace = true }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# external
 getrandom = { workspace = true, features = ["std"] }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+# external
 getrandom = { workspace = true, features = ["js"] }
 
 [lints]

--- a/app/crates/core/state/Cargo.toml
+++ b/app/crates/core/state/Cargo.toml
@@ -9,19 +9,24 @@ description = "SQLite-backed application state"
 build = "build.rs"
 
 [dependencies]
+# workspace
+stellar = { workspace = true }
+types = { workspace = true, features = ["rusqlite"] }
+
+# external
 anyhow = { workspace = true }
 hex = { workspace = true }
 log = { workspace = true }
 rusqlite = { workspace = true }
 rusqlite_migration = { version = "2.5.0", default-features = false }
-stellar = { workspace = true }
-types = { workspace = true, features = ["rusqlite"] }
 
 [build-dependencies]
+# external
 hex = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
+# workspace
 prover = { workspace = true }
 
 [lints]

--- a/app/crates/core/stellar/Cargo.toml
+++ b/app/crates/core/stellar/Cargo.toml
@@ -7,6 +7,10 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
+# workspace
+types = { workspace = true }
+
+# external
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = "0.22"
@@ -23,9 +27,9 @@ sha3 = { version = "0.11", default-features = false }
 stellar-strkey = "0.0.16"
 stellar-xdr = { version = "26.0.0", features = ["curr", "serde", "base64", "std", "alloc"] }
 thiserror = { workspace = true }
-types = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+# external
 gloo-timers = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/app/crates/core/tx-planner/Cargo.toml
+++ b/app/crates/core/tx-planner/Cargo.toml
@@ -8,8 +8,11 @@ publish.workspace = true
 description = "Transaction planning for private pool operations"
 
 [dependencies]
-thiserror = { workspace = true }
+# workspace
 types = { workspace = true }
+
+# external
+thiserror = { workspace = true }
 
 [lints]
 workspace = true

--- a/app/crates/core/types/Cargo.toml
+++ b/app/crates/core/types/Cargo.toml
@@ -11,6 +11,7 @@ default = []
 rusqlite = ["dep:rusqlite"]
 
 [dependencies]
+# external
 anyhow = { workspace = true }
 hex = { workspace = true }
 rusqlite = { workspace = true, optional = true }
@@ -18,6 +19,7 @@ serde = { workspace = true }
 uint = { workspace = true }
 
 [dev-dependencies]
+# external
 rusqlite = { workspace = true, features = ["buildtime_bindgen", "bundled"] }
 serde_json = { workspace = true, features = ["alloc"] }
 

--- a/app/crates/core/witness/Cargo.toml
+++ b/app/crates/core/witness/Cargo.toml
@@ -8,24 +8,24 @@ publish.workspace = true
 description = "Browser WASM module for Circom witness generation using ark-circom"
 
 [dependencies]
+# external
 anyhow = { workspace = true }
-
 # Arkworks
 ark-bn254 = { workspace = true }
 ark-circom = { workspace = true }
-
 # BigInt support for input parsing
 num-bigint = { workspace = true }
-
 # JSON parsing
 serde_json = { workspace = true, default-features = false, features = ["alloc", "std"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# external
 ark-circom = { workspace = true, features = ["parallel"] }
 # see https://github.com/NethermindEth/stellar-private-payments/issues/192
 wasmer = { workspace = true, features = ["cranelift"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+# external
 ark-circom = { workspace = true }
 wasmer = { workspace = true, features = ["js", "js-default"] }
 

--- a/app/crates/platforms/web/Cargo.toml
+++ b/app/crates/platforms/web/Cargo.toml
@@ -19,35 +19,40 @@ name = "prover-worker"
 path = "src/bin/prover_worker.rs"
 
 [dependencies]
+# workspace
+disclosure = { workspace = true }
+prover = { workspace = true }
+state = { workspace = true }
+stellar = { workspace = true }
+tx-planner = { workspace = true }
+types = { workspace = true }
+witness = { workspace = true }
+
+# external
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 console_error_panic_hook = { workspace = true }
-disclosure = { workspace = true }
 futures = { workspace = true }
 gloo-timers = { workspace = true, features = ["futures"] }
 gloo-worker = { version = "0.6", default-features = false, features = ["futures"] }
 js-sys = "0.3"
 log = { workspace = true }
-prover = { workspace = true }
 serde = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }
 sha2 = { workspace = true }
-state = { workspace = true }
-stellar = { workspace = true }
-tx-planner = { workspace = true }
-types = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
 wasm-log = { workspace = true }
 web-sys = { version = "0.3", features = ["console", "WorkerGlobalScope", "Response", "Request", "RequestInit", "RequestMode", "Window"] }
-witness = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies] # only to please clippy, this crate is intended only for WASM
+# external
 sqlite-wasm-rs = { version = "0.5.3", default-features = false }
 sqlite-wasm-vfs = { version = "0.2.0", default-features = false }
 
 [build-dependencies]
+# external
 sha2 = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/circuit-keys/Cargo.toml
+++ b/circuit-keys/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
+# external
 anyhow = { workspace = true }
 ark-bn254 = { workspace = true }
 ark-ff = { workspace = true }
@@ -17,4 +18,3 @@ serde_json = { workspace = true, features = ["std"] }
 
 [lints]
 workspace = true
-

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -22,7 +22,11 @@ std = [
 ]
 
 [dependencies]
+# workspace
+# Core dependencies (no_std compatible)
+zkhash = { workspace = true }
 
+# external
 # Test utilities dependencies (std only — used by the `test` module)
 anyhow = { workspace = true, optional = true }
 ark-bn254 = { workspace = true, optional = true }
@@ -35,16 +39,19 @@ ark-std = { workspace = true, optional = true }
 num-bigint = { workspace = true, optional = true }
 num-integer = { workspace = true, optional = true }
 
-# Core dependencies (no_std compatible)
-zkhash = { workspace = true }
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# external
 ark-circom = { workspace = true, features = ["parallel"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+# external
 ark-circom = { workspace = true, optional = true }
 
 [build-dependencies]
+# workspace
+circuit-keys = { workspace = true }
+
+# external
 anyhow = { workspace = true }
 ark-bn254 = { workspace = true }
 ark-circom = { workspace = true }
@@ -53,7 +60,6 @@ ark-groth16 = { workspace = true }
 ark-serialize = "0.6.0"
 ark-snark = { workspace = true }
 ark-std = { workspace = true }
-circuit-keys = { workspace = true }
 compiler = { git = "https://github.com/iden3/circom", tag = "v2.2.3" }
 constraint_generation = { git = "https://github.com/iden3/circom", tag = "v2.2.3" }
 constraint_writers = { git = "https://github.com/iden3/circom", tag = "v2.2.3" }

--- a/contracts/asp-membership/Cargo.toml
+++ b/contracts/asp-membership/Cargo.toml
@@ -11,13 +11,19 @@ crate-type = ["lib", "cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { workspace = true }
+# workspace
 soroban-utils = { workspace = true }
 
+# external
+soroban-sdk = { workspace = true }
+
 [dev-dependencies]
+# workspace
+zkhash = { workspace = true }
+
+# external
 num-bigint = { workspace = true }
 soroban-sdk = { workspace = true, features = ["testutils"] }
-zkhash = { workspace = true }
 
 [lints]
 workspace = true

--- a/contracts/asp-non-membership/Cargo.toml
+++ b/contracts/asp-non-membership/Cargo.toml
@@ -11,10 +11,14 @@ crate-type = ["lib", "cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { workspace = true }
+# workspace
 soroban-utils = { workspace = true }
 
+# external
+soroban-sdk = { workspace = true }
+
 [dev-dependencies]
+# external
 soroban-sdk = { workspace = true, features = ["testutils"] }
 
 [lints]

--- a/contracts/circom-groth16-verifier/Cargo.toml
+++ b/contracts/circom-groth16-verifier/Cargo.toml
@@ -10,15 +10,25 @@ crate-type = ["lib", "cdylib"]
 doctest = false
 
 [dependencies]
+# workspace
 contract-types = { workspace = true }
+
+# external
 soroban-sdk = { workspace = true, features = ["alloc"] }
 
 [build-dependencies]
-ark-bn254 = { workspace = true }
+# workspace
 circuit-keys = { workspace = true }
+
+# external
+ark-bn254 = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
+# workspace
+soroban-utils = { workspace = true }
+
+# external
 ark-bn254 = { workspace = true }
 ark-circom = { workspace = true }
 ark-ff = { workspace = true }
@@ -26,7 +36,6 @@ ark-groth16 = { workspace = true }
 ark-relations = { workspace = true }
 ark-std = { workspace = true }
 soroban-sdk = { workspace = true, features = ["testutils"] }
-soroban-utils = { workspace = true }
 
 [lints]
 workspace = true

--- a/contracts/pool/Cargo.toml
+++ b/contracts/pool/Cargo.toml
@@ -11,15 +11,20 @@ crate-type = ["lib", "cdylib"]
 doctest = false
 
 [dependencies]
-
+# workspace
 contract-types.workspace = true
-soroban-sdk.workspace = true
 soroban-utils.workspace = true
 
+# external
+soroban-sdk.workspace = true
+
 [dev-dependencies]
+# workspace
 asp-membership = { workspace = true }
 asp-non-membership = { workspace = true }
 circom-groth16-verifier = { workspace = true }
+
+# external
 soroban-sdk = { workspace = true, features = ["testutils"] }
 
 [lints]

--- a/contracts/public-key-registry/Cargo.toml
+++ b/contracts/public-key-registry/Cargo.toml
@@ -11,9 +11,11 @@ crate-type = ["lib", "cdylib"]
 doctest = false
 
 [dependencies]
+# external
 soroban-sdk.workspace = true
 
 [dev-dependencies]
+# external
 soroban-sdk = { workspace = true, features = ["testutils"] }
 
 [lints]

--- a/contracts/soroban-utils/Cargo.toml
+++ b/contracts/soroban-utils/Cargo.toml
@@ -11,10 +11,13 @@ crate-type = ["lib"]
 doctest = false
 
 [dependencies]
+# workspace
+contract-types = { workspace = true }
+
+# external
 ark-bn254 = { workspace = true }
 ark-ff = { workspace = true }
 ark-groth16 = { workspace = true }
-contract-types = { workspace = true }
 soroban-sdk = { workspace = true }
 
 [lints]

--- a/contracts/types/Cargo.toml
+++ b/contracts/types/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["lib"]
 doctest = false
 
 [dependencies]
+# external
 soroban-sdk = { workspace = true, features = ["alloc"] }
 
 [lints]

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -7,23 +7,24 @@ license.workspace = true
 publish = false
 
 [dependencies]
-anyhow = { workspace = true }
+# workspace
 asp-membership = { workspace = true }
 asp-non-membership = { workspace = true }
 circom-groth16-verifier = { workspace = true }
 # Circuit dependencies
 circuits = { workspace = true, features = ["std"] }
-num-bigint = { workspace = true }
-
 # Contract dependencies
 pool = { workspace = true }
-soroban-sdk = { workspace = true, features = ["testutils"] }
 soroban-utils = { workspace = true }
-
 # Shared deps
 tx-planner = { workspace = true }
 types = { workspace = true }
 zkhash = { workspace = true }
+
+# external
+anyhow = { workspace = true }
+num-bigint = { workspace = true }
+soroban-sdk = { workspace = true, features = ["testutils"] }
 
 [lints]
 workspace = true

--- a/poseidon2/Cargo.toml
+++ b/poseidon2/Cargo.toml
@@ -14,6 +14,7 @@ default = []
 asm = ["ark-ff/asm"]
 
 [dependencies]
+# external
 ark-ff = { workspace = true }
 cfg-if = { workspace = true }
 hex = { workspace = true }

--- a/tomlfmt.toml
+++ b/tomlfmt.toml
@@ -1,0 +1,1 @@
+key_value_newlines = true

--- a/tools/bootnode/Cargo.toml
+++ b/tools/bootnode/Cargo.toml
@@ -15,6 +15,10 @@ name = "bootnode"
 path = "bin/bootnode.rs"
 
 [dependencies]
+# workspace
+types = { path = "../../app/crates/core/types", version = "0.1.0" }
+
+# external
 anyhow = { version = "1", default-features = false }
 async-trait = { version = "0.1.89", default-features = false }
 axum = { version = "0.8.9", default-features = false, features = ["tokio", "http1", "json"] }
@@ -40,13 +44,15 @@ tower_governor = "0.7.0"
 tracing = "0.1.44"
 tracing-opentelemetry = { version = "0.29.0", default-features = false }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt"] }
-types = { path = "../../app/crates/core/types", version = "0.1.0" }
 url = "2.5.8"
 
 [dev-dependencies]
+# workspace
+types = { path = "../../app/crates/core/types", version = "0.1.0" }
+
+# external
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false }
-types = { path = "../../app/crates/core/types", version = "0.1.0" }
 
 [lints.rust]
 missing_docs = "allow"

--- a/tools/ceremony-cli/Cargo.toml
+++ b/tools/ceremony-cli/Cargo.toml
@@ -11,12 +11,15 @@ name = "ceremony-cli"
 path = "src/main.rs"
 
 [dependencies]
+# workspace
+circuit-keys.workspace = true
+
+# external
 anyhow.workspace = true
 ark-bn254.workspace = true
 ark-circom.workspace = true
 ark-groth16.workspace = true
 ark-serialize.workspace = true
-circuit-keys.workspace = true
 clap = { version = "4.6.1", features = ["derive"] }
 getrandom.workspace = true
 glob = "0.3.3"

--- a/vendor/cranelift-control/Cargo.toml
+++ b/vendor/cranelift-control/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2024"
 rust-version = "1.92.0"
 
 [dependencies]
+# external
 arbitrary = { version = "~1.3.0", optional = true }
 
 [features]


### PR DESCRIPTION
Puts local crates/dependencies at the top of `Cargo.toml`s. A bit cleaner, avoids mixing since some are maintained by us.