### PR TITLE
Rename app `Pool` to `PrivatePool`

### DIFF
--- a/app/crates/platforms/web/src/client/disclosure.rs
+++ b/app/crates/platforms/web/src/client/disclosure.rs
@@ -1,12 +1,14 @@
-//! WASM selective-disclosure methods on [`Pool`].
+//! WASM selective-disclosure methods on [`PrivatePool`].
 
-use super::{emit_progress, parse_field_bigint_numeric, parse_field_hex_str, pool::Pool, pool_err};
+use super::{
+    emit_progress, parse_field_bigint_numeric, parse_field_hex_str, pool::PrivatePool, pool_err,
+};
 use js_sys::{BigInt, Function};
 use stellar_private_payments_sdk::DisclosureRequest;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-impl Pool {
+impl PrivatePool {
     #[wasm_bindgen(js_name = disclose)]
     #[allow(clippy::too_many_arguments)]
     pub async fn disclose_wasm(
@@ -51,7 +53,7 @@ impl Pool {
     }
 }
 
-impl Pool {
+impl PrivatePool {
     async fn disclose_inner(
         &self,
         selected_commitment_hex: String,

--- a/app/crates/platforms/web/src/client/pool.rs
+++ b/app/crates/platforms/web/src/client/pool.rs
@@ -23,12 +23,12 @@ pub struct PoolCreateConfig {
 }
 
 /// Per-pool session for deposits, transfers, and withdrawals.
-#[wasm_bindgen(js_name = PrivatePool)]
-pub struct Pool {
+#[wasm_bindgen]
+pub struct PrivatePool {
     inner: Rc<SdkPrivatePool<StorageBridge>>,
 }
 
-impl Pool {
+impl PrivatePool {
     pub(crate) fn new(inner: Rc<SdkPrivatePool<StorageBridge>>) -> Self {
         Self { inner }
     }
@@ -39,7 +39,7 @@ impl Pool {
 }
 
 #[wasm_bindgen]
-impl Pool {
+impl PrivatePool {
     /// Warm prover worker (idempotent). `createPool` already pings once.
     pub async fn initialize(&self) -> Result<(), JsError> {
         Ok(())
@@ -80,7 +80,7 @@ impl WebClient {
 #[wasm_bindgen]
 impl WebClient {
     #[wasm_bindgen(js_name = createPool)]
-    pub async fn create_pool(&self, config: JsValue) -> Result<Pool, JsError> {
+    pub async fn create_pool(&self, config: JsValue) -> Result<PrivatePool, JsError> {
         let cfg: PoolCreateConfig = serde_wasm_bindgen::from_value(config)?;
 
         self.ping_prover()
@@ -96,6 +96,6 @@ impl WebClient {
             SdkPrivatePool::init(pool_config, self.storage(), signer, prover)
                 .map_err(super::pool_err)?,
         );
-        Ok(Pool::new(inner))
+        Ok(PrivatePool::new(inner))
     }
 }

--- a/app/crates/platforms/web/src/client/transact.rs
+++ b/app/crates/platforms/web/src/client/transact.rs
@@ -3,7 +3,8 @@
 
 use super::{
     emit_progress, parse_ext_amount_decimal, parse_input_note_ids, parse_note_amount_decimal,
-    parse_output_amounts, parse_output_recipient_keys, pool::Pool, pool_err, pool_err_message,
+    parse_output_amounts, parse_output_recipient_keys, pool::PrivatePool, pool_err,
+    pool_err_message,
 };
 use gloo_timers::future::TimeoutFuture;
 use js_sys::{Array, BigInt, Function};
@@ -66,7 +67,7 @@ impl ExecuteJsResponse {
     }
 }
 
-impl Pool {
+impl PrivatePool {
     async fn execute_plan(
         &self,
         plan: &mut PreparedTransactionPlan,
@@ -321,7 +322,7 @@ impl Pool {
 }
 
 #[wasm_bindgen]
-impl Pool {
+impl PrivatePool {
     #[wasm_bindgen(js_name = estimate)]
     pub async fn estimate(&self, amount: BigInt) -> Result<wasm_bindgen::JsValue, JsError> {
         let estimate = self.estimate_inner(amount).await?;


### PR DESCRIPTION
A wasm-binden-cli update changed some behavior, causing the current pool app Rust abstraction over the Rust SDK to error out with:
```
2026-07-03T13:41:55.873740Z  INFO downloading wasm-bindgen version="0.2.126"
2026-07-03T13:41:56.017148Z  INFO installing wasm-bindgen
error: class `Pool` referenced by an impl block does not match any exported struct
error: class `Pool` referenced by an impl block does not match any exported struct
error: class `Pool` referenced by an impl block does not match any exported struct
2026-07-03T13:41:56.967607Z ERROR ❌ error
error from build pipeline
```
Site deployment failing because of this.