### PR TITLE
Increase prover worker init timeout to 20s

### DIFF
--- a/sdk/web/src/workers/prover.rs
+++ b/sdk/web/src/workers/prover.rs
@@ -531,7 +531,7 @@ impl ProverBridge {
     }
 
     pub(crate) async fn ping(&self) -> anyhow::Result<()> {
-        match self.call(ProverWorkerRequest::Ping, 5_000).await? {
+        match self.call(ProverWorkerRequest::Ping, 20_000).await? {
             ProverWorkerResponse::Pong => Ok(()),
             other => Err(anyhow!("unexpected response: {other:?}")),
         }


### PR DESCRIPTION
Selective disclosure circuits were added, causing the prover initialization to timeout frequently.
More context: https://github.com/NethermindEth/stellar-private-payments/issues/333#issuecomment-4877826244