### PR TITLE
Install  wasm-bindgen-cli in deployment CI

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Install mdBook
         run: cargo install mdbook --no-default-features
 
+      - name: Install wasm build prerequisites
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo install wasm-bindgen-cli --version 0.2.126 --locked --force
+
       - name: Build app (Trunk)
         run: |
           rm -rf site


### PR DESCRIPTION
We need that now to make the web SDK (WASM separate from Trunk now).