### PR TITLE
Web SDK `Client::aspState()`

### DIFF
--- a/app/js/wasm-facade.js
+++ b/app/js/wasm-facade.js
@@ -136,19 +136,11 @@ function wrapSdkClient(sdk, sdkStorage) {
             };
         },
         async aspState() {
-            try {
-                const data = await this.allContractsData();
-                return {
-                    aspMembership: data.aspMembership,
-                    aspNonMembership: data.aspNonMembership,
-                };
-            } catch (error) {
-                const message = error?.message || '';
-                if (!message.includes('initialize')) {
-                    throw error;
-                }
-                throw new Error('ASP state requires an initialized wallet session');
-            }
+            const data = await sdk.aspState();
+            return {
+                aspMembership: data.aspMembership,
+                aspNonMembership: data.aspNonMembership,
+            };
         },
     };
 }

--- a/sdk/web/js/index.js
+++ b/sdk/web/js/index.js
@@ -42,6 +42,7 @@ function wrapClient(wasmClient) {
     registerPublicKeys: (options) => wasmClient.registerPublicKeys(options),
     lookupRegisteredPublicKey: (address) => wasmClient.lookupRegisteredPublicKey(address),
     allContractsData: () => wasmClient.allContractsData(),
+    aspState: () => wasmClient.aspState(),
     verifySelectiveDisclosure: (receiptJson, expectedVkHash, options = {}) =>
       wasmClient.verifySelectiveDisclosure(receiptJson, expectedVkHash, {
         proverWorkerUrl,

--- a/sdk/web/js/types/index.d.ts
+++ b/sdk/web/js/types/index.d.ts
@@ -46,6 +46,7 @@ export interface AccountClient {
   registerPublicKeys(options?: RegisterPublicKeysOptions | null): Promise<string>;
   lookupRegisteredPublicKey(address: string): Promise<unknown>;
   allContractsData(): Promise<unknown>;
+  aspState(): Promise<unknown>;
   verifySelectiveDisclosure(
     receiptJson: string,
     expectedVkHash: string,

--- a/sdk/web/src/client/core.rs
+++ b/sdk/web/src/client/core.rs
@@ -106,6 +106,15 @@ impl ClientCore {
         Ok(serde_wasm_bindgen::to_value(&data)?)
     }
 
+    pub(crate) async fn asp_state(&self) -> Result<JsValue, JsError> {
+        let data = self
+            .fetcher
+            .asp_state()
+            .await
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(serde_wasm_bindgen::to_value(&data)?)
+    }
+
     pub(crate) async fn lookup_registered_public_key(
         &self,
         address: String,

--- a/sdk/web/src/client/mod.rs
+++ b/sdk/web/src/client/mod.rs
@@ -8,7 +8,7 @@ mod transact;
 use std::rc::Rc;
 
 use serde::Deserialize;
-use stellar_private_payments_sdk::{PoolError, types::DisclosureReceipt};
+use stellar_private_payments_sdk::{PoolError, chain::StateFetcher, types::DisclosureReceipt};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
@@ -195,6 +195,23 @@ impl Client {
     #[wasm_bindgen(js_name = allContractsData)]
     pub async fn all_contracts_data(&self) -> Result<JsValue, JsError> {
         self.initialized()?.0.all_contracts_data().await
+    }
+
+    /// On-chain ASP membership and non-membership state.
+    #[wasm_bindgen(js_name = aspState)]
+    pub async fn asp_state(&self) -> Result<JsValue, JsError> {
+        if let Some(core) = &self.core {
+            return core.asp_state().await;
+        }
+
+        let config = deployment_config()?;
+        let fetcher = StateFetcher::new(&self.rpc_url, (*config).clone())
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        let data = fetcher
+            .asp_state()
+            .await
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(serde_wasm_bindgen::to_value(&data)?)
     }
 
     /// Register this account's public keys on the deployment-wide registry.


### PR DESCRIPTION
Adds a wallet-less method to get current ASP state -- useful and currently required (matching pre-SDK logic) in the admin page.