### PR TITLE
Fix admin leaf derivation hex encoding

### DIFF
--- a/app/js/admin.js
+++ b/app/js/admin.js
@@ -302,16 +302,15 @@ async function computeMembershipLeaf() {
       throw new Error('Blinding is required');
     }
 
-    const publicOverride = parseBigIntInput(publicKeyInput.value, 'Public key');
-    if (publicOverride === null) {
+    const notePublicKey = parseBigIntInput(publicKeyInput.value, 'Public key');
+    if (notePublicKey === null) {
       throw new Error('User note public key is required');
     }
 
-    const pubKey = '0x' + publicOverride.toString(16).padStart(64, '0');
-    const leafHex = await client().deriveAspUserLeaf(blindingValue, pubKey);
+    const leafHex = await client().deriveAspUserLeaf(blindingValue, notePublicKey);
     const leafDec = BigInt(leafHex).toString();
 
-    derivedPubKeyEl.textContent = pubKey;
+    derivedPubKeyEl.textContent = `0x${notePublicKey.toString(16).padStart(64, '0')}`;
     computedMembershipLeafHexEl.textContent = leafHex;
     computedMembershipLeafDecEl.textContent = leafDec;
 
@@ -444,7 +443,7 @@ async function computeNonMembershipLeaf() {
     if (valueValue === null) {
       throw new Error('Value is required');
     }
-    const leafBytes = await client().deriveAspUserLeaf(valueValue, keyValue.toString(16).padStart(64, '0'));
+    const leafBytes = await client().deriveAspUserLeaf(valueValue, keyValue);
     computedNonMembershipLeafHexEl.textContent = leafBytes;
     log('Computed non-membership leaf hash');
   } catch (err) {

--- a/app/js/wasm-facade.js
+++ b/app/js/wasm-facade.js
@@ -25,6 +25,11 @@ export async function ensureWasmInit() {
     }
 }
 
+function toScalarHex(value) {
+    const n = typeof value === 'bigint' ? value : BigInt(value);
+    return `0x${n.toString(16).padStart(64, '0')}`;
+}
+
 function bindAppStorage(sdkStorage) {
     appStorageInstance = new AppStorage(sdkStorage);
 }
@@ -112,11 +117,11 @@ function wrapSdkClient(sdk, sdkStorage) {
             const response = await storageCall(sdkStorage, { UserNotes: [address, limit] });
             return response.UserNotes ?? [];
         },
-        async deriveAspUserLeaf(membershipBlinding, pubkeyHex) {
+        async deriveAspUserLeaf(membershipBlinding, notePublicKey) {
             const response = await storageCall(sdkStorage, {
                 DeriveASPleaf: {
-                    membershipBlinding: membershipBlinding.toString(),
-                    pubkey: pubkeyHex,
+                    membershipBlinding: toScalarHex(membershipBlinding),
+                    pubkey: toScalarHex(notePublicKey),
                 },
             });
             const leaf = response.DeriveASPleaf;


### PR DESCRIPTION
`deriveAspUserLeaf` was sending decimal blinding/key strings to the storage worker, which expects hex instead.