### PR TITLE
bootnode local Docker setup

### DIFF
--- a/tools/bootnode/README.md
+++ b/tools/bootnode/README.md
@@ -7,13 +7,32 @@ Bootnode is a narrow HTTPS JSON-RPC service that supports only:
 
 It caches historical `getEvents` pages into Postgres (starting at the compiled-in deployment ledger). Once a request is safely within the retention window buffer (tip − 5 days by default), it returns a JSON-RPC handoff error (`-32002` with `fromLedger`) so the app indexer resumes on the user's configured main RPC.
 
-## Local development (HTTP, loopback only)
+## Local development
 
 ```bash
 cargo build --manifest-path tools/bootnode/Cargo.toml
 export DATABASE_URL='postgres://postgres:postgres@127.0.0.1:5432/bootnode'
 ./tools/bootnode/target/debug/bootnode --dev --insecure-http --bind 127.0.0.1:8080 --upstream-rpc-url https://soroban-testnet.stellar.org --database-url "$DATABASE_URL"
 ```
+
+### Docker
+
+Use the `docker-compose.no-https.yml` override with the base compose file:
+
+```bash
+cd tools/bootnode
+docker compose -f docker-compose.yml -f docker-compose.no-https.yml up --build
+```
+
+Bootnode URL for the app: `http://127.0.0.1:8080`
+
+```bash
+curl http://127.0.0.1:8080/healthz
+```
+
+The override binds `0.0.0.0:8080` inside the container (required for Docker port
+publishing) and skips ACME/TLS. Use the base `docker-compose.yml` alone for
+production HTTPS on `:443`.
 
 ## Production (HTTPS + ACME)
 

--- a/tools/bootnode/bin/bootnode.rs
+++ b/tools/bootnode/bin/bootnode.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use bootnode::{
     Bootnode, Postgres,
     config::{Config, OtelConfig, TlsConfig},
@@ -33,9 +33,7 @@ struct Cli {
     #[arg(long, env = "BOOTNODE_DEV", default_value_t = false)]
     dev: bool,
 
-    /// Serve plain HTTP (debug only).
-    ///
-    /// This is only allowed when binding to loopback (127.0.0.1 / ::1).
+    /// Serve plain HTTP.
     #[arg(long, env = "BOOTNODE_INSECURE_HTTP", default_value_t = false)]
     insecure_http: bool,
 
@@ -106,24 +104,23 @@ struct Cli {
 
 impl Cli {
     fn validate(&self) -> Result<()> {
-        if self.insecure_http {
-            if !self.dev {
-                bail!("--insecure-http requires --dev");
+        if self.insecure_http && !self.dev {
+            bail!("--insecure-http requires --dev");
+        } else if !self.insecure_http {
+            if self
+                .domain
+                .as_deref()
+                .is_none_or(|domain| domain.trim().is_empty())
+            {
+                bail!("--domain is required for HTTPS/ACME mode");
             }
-            let ip = self.bind.ip();
-            if !ip.is_loopback() {
-                bail!(
-                    "--insecure-http is only allowed on loopback binds (got {})",
-                    self.bind
-                );
+            if self
+                .acme_email
+                .as_deref()
+                .is_none_or(|email| email.trim().is_empty())
+            {
+                bail!("--acme-email is required for HTTPS/ACME mode");
             }
-        } else {
-            self.domain
-                .as_ref()
-                .context("--domain is required for HTTPS/ACME mode")?;
-            self.acme_email
-                .as_ref()
-                .context("--acme-email is required for HTTPS/ACME mode")?;
         }
 
         if self.otel_enabled && !(0.0..=1.0).contains(&self.otel_sample_ratio) {

--- a/tools/bootnode/docker-compose.no-https.yml
+++ b/tools/bootnode/docker-compose.no-https.yml
@@ -1,0 +1,16 @@
+# Local dev: plain HTTP on port 8080 (no TLS / ACME).
+#
+#   docker compose -f docker-compose.yml -f docker-compose.no-https.yml up --build
+#
+# Bootnode URL for the app: http://127.0.0.1:8080
+
+services:
+  bootnode:
+    environment:
+      BOOTNODE_DEV: "true"
+      BOOTNODE_INSECURE_HTTP: "true"
+      BOOTNODE_BIND: 0.0.0.0:8080
+      BOOTNODE_DOMAIN: ""
+      BOOTNODE_ACME_EMAIL: ""
+    ports: !override
+      - "8080:8080"


### PR DESCRIPTION
Adds a local Docker setup and support for it in the code. Drops `localhost`/`0.0.0.0` restrictions to support insecure-http mode binded via `0.0.0.0` so Docker can forward to it inside.