### PR TITLE
Update `crossbeam-epoch` dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Run `cargo update -p crossbeam-epoch` to relax deny:
```
error[vulnerability]: Invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid
    ┌─ /Users/v0/nm/repos/stellar-private-payments/Cargo.lock:114:1
    │
114 │ crossbeam-epoch 0.9.18 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ security vulnerability detected
    │
    ├ ID: RUSTSEC-2026-0204
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0204
    ├ Affected versions of `fmt::Display` dereference the underlying pointer. This causes a invalid pointer dereference e.g., when a pointer created with `Atomic::null` or `Shared::null`. `fmt::Debug` impls and pre-0.9 `fmt::Display` impls, which do not dereference pointers, are not affected by this issue.
    ├ Announcement: https://github.com/crossbeam-rs/crossbeam/pull/1276
    ├ Solution: Upgrade to >=0.9.20 (try `cargo update -p crossbeam-epoch`)
    ├ crossbeam-epoch v0.9.18
```