### PR TITLE
Defer signing in CLI to Stellar CLI

### DIFF
--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -1,9 +1,9 @@
 //! Account identity resolved from a `stellar keys` alias.
 //!
 //! The account is
-//! named by an alias and resolved to an address through the Stellar CLI. The
-//! secret is never read here — only at transaction-signing time (see
-//! [`crate::signer::AliasSigner`]).
+//! named by an alias and resolved to an address through the Stellar CLI.
+//! Transaction signing is delegated to `stellar tx sign` via
+//! [`crate::signer::AliasSigner`].
 
 use std::path::Path;
 

--- a/cli/src/cmd/register.rs
+++ b/cli/src/cmd/register.rs
@@ -6,12 +6,13 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 use stellar_private_payments_sdk::{
     blocking::{confirm_tx, prepare_register, submit_tx},
-    chain::{LocalSigner, StateFetcher},
+    chain::StateFetcher,
     state::SqliteStorage,
 };
 
 use crate::{
-    account::Account, config::CliConfig, onboard, output, stellar_cli, stellar_cli::StellarNetwork,
+    account::Account, config::CliConfig, onboard, output, signer::AliasSigner,
+    stellar_cli::StellarNetwork,
 };
 
 pub fn run(config: &CliConfig, json: bool) -> Result<()> {
@@ -61,10 +62,14 @@ pub fn register_account(
     log::info!("Preparing address registration for {}", account.address);
     let prepared = prepare_register(&fetcher, &account.address, note_key, encryption_key)?;
 
-    let secret = stellar_cli::secret(&account.alias, config.stellar_config_dir.as_deref())?;
-    let signer = LocalSigner::from_secret(&secret).context("build signer for registration")?;
+    let signer = AliasSigner {
+        alias: account.alias.clone(),
+        rpc_url: network.rpc_url.clone(),
+        network_passphrase: network.passphrase.clone(),
+        config_dir: config.stellar_config_dir.clone(),
+    };
     let envelope = signer
-        .sign_prepared_transaction(&prepared, &network.passphrase, &account.address)
+        .sign_prepared_transaction(&prepared)
         .context("sign registration transaction")?;
 
     log::info!("Submitting registration…");

--- a/cli/src/session.rs
+++ b/cli/src/session.rs
@@ -60,8 +60,8 @@ impl PoolSession {
     ) -> Result<Self> {
         let signer: Box<dyn Signer> = Box::new(AliasSigner {
             alias: account.alias.clone(),
+            rpc_url: network.rpc_url.clone(),
             network_passphrase: network.passphrase.clone(),
-            user_address: account.address.clone(),
             config_dir: config.stellar_config_dir.clone(),
         });
 

--- a/cli/src/signer.rs
+++ b/cli/src/signer.rs
@@ -1,15 +1,15 @@
 //! Transaction signer backed by a `stellar keys` alias.
 //!
-//! The pool's `transact` call requires Soroban authorization-entry signatures,
-//! which the `stellar` binary cannot produce on its own. So we keep the SDK's
-//! in-process signing (`LocalSigner`) but source the secret from the alias via
-//! `stellar keys secret` **only when a transaction is actually signed** — read
-//! operations (balance, notes) never trigger this.
+//! Pool transacts delegate signing to `stellar tx sign --sign-with-key`, so
+//! keys in the OS secure store work without exporting secrets into this
+//! process.
 
 use std::path::PathBuf;
 
 use stellar_private_payments_sdk::{
-    LocalSigner, PoolError, PreparedTransaction, Signer, types::SignedTransaction,
+    PoolError, PreparedTransaction, Signer,
+    chain::{Limits, PreparedSorobanTx, ReadXdr, TransactionEnvelope, WriteXdr},
+    types::SignedTransaction,
 };
 
 use crate::stellar_cli;
@@ -17,22 +17,41 @@ use crate::stellar_cli;
 /// Signs pool transactions using an alias resolved through the Stellar CLI.
 pub struct AliasSigner {
     pub alias: String,
+    pub rpc_url: String,
     pub network_passphrase: String,
-    pub user_address: String,
     pub config_dir: Option<PathBuf>,
+}
+
+impl AliasSigner {
+    pub fn sign_prepared_transaction(
+        &self,
+        prepared: &PreparedSorobanTx,
+    ) -> Result<TransactionEnvelope, PoolError> {
+        let signed_xdr = stellar_cli::sign_tx(
+            &self.alias,
+            &prepared.tx_xdr,
+            &self.rpc_url,
+            &self.network_passphrase,
+            self.config_dir.as_deref(),
+        )
+        .map_err(|e| {
+            PoolError::Other(format!(
+                "sign transaction for alias `{}`: {e:#}",
+                self.alias
+            ))
+        })?;
+        TransactionEnvelope::from_xdr_base64(&signed_xdr, Limits::none())
+            .map_err(|e| PoolError::Other(format!("decode signed transaction xdr: {e}")))
+    }
 }
 
 #[async_trait::async_trait(?Send)]
 impl Signer for AliasSigner {
     async fn sign(&self, prepared: &PreparedTransaction) -> Result<SignedTransaction, PoolError> {
-        let secret = stellar_cli::secret(&self.alias, self.config_dir.as_deref()).map_err(|e| {
-            PoolError::Other(format!("fetch secret for alias `{}`: {e:#}", self.alias))
-        })?;
-        let inner = LocalSigner::new(
-            &secret,
-            self.network_passphrase.clone(),
-            self.user_address.clone(),
-        )?;
-        inner.sign(prepared).await
+        let envelope = self.sign_prepared_transaction(&prepared.soroban_tx)?;
+        let signed_xdr = envelope
+            .to_xdr_base64(Limits::none())
+            .map_err(|e| PoolError::Other(format!("encode signed transaction xdr: {e}")))?;
+        Ok(SignedTransaction { signed_xdr })
     }
 }

--- a/cli/src/stellar_cli.rs
+++ b/cli/src/stellar_cli.rs
@@ -2,16 +2,20 @@
 //!
 //! Account operations are delegated to the official Stellar CLI so the private
 //! payments CLI never handles a raw mnemonic or secret key: identities live in
-//! the Stellar CLI's alias store (`stellar keys …`). We shell out for three
-//! things:
+//! the Stellar CLI's alias store (`stellar keys …`). We shell out for:
 //!
 //! * resolve an alias to its address ([`public_key`]),
 //! * produce the SEP-53 key-derivation signature ([`sign_message`]), and
-//! * fetch the secret key just-in-time for transaction signing ([`secret`]).
+//! * sign transaction envelopes ([`sign_tx`]), including OS secure-store keys.
 
-use std::{path::Path, process::Command};
+use std::{
+    io::Write,
+    path::Path,
+    process::{Command, Stdio},
+};
 
 use anyhow::{Context, Result, bail};
+
 use stellar_private_payments_sdk::{chain::Signature, types::KeyDerivationSignature};
 
 /// Env var to override the `stellar` binary path (default: `stellar` on PATH).
@@ -84,11 +88,67 @@ pub fn sign_message(
     Ok(KeyDerivationSignature(signature.as_bytes().to_vec()))
 }
 
-/// Fetch an alias's secret key via `stellar keys secret` (transaction signing
-/// only). Not available for ledger identities.
-pub fn secret(alias: &str, config_dir: Option<&Path>) -> Result<String> {
-    let args = vec!["keys".to_string(), "secret".to_string(), alias.to_string()];
-    run(&args, config_dir)
+/// Sign an unsigned transaction envelope via `stellar tx sign`.
+///
+/// Works for identities stored in the config file or OS secure store. The
+/// unsigned envelope XDR is passed on stdin; signed envelope XDR is returned
+/// from stdout.
+pub fn sign_tx(
+    alias: &str,
+    tx_xdr: &str,
+    rpc_url: &str,
+    network_passphrase: &str,
+    config_dir: Option<&Path>,
+) -> Result<String> {
+    let bin = stellar_bin();
+    let mut cmd = Command::new(&bin);
+    cmd.args([
+        "tx",
+        "sign",
+        "--sign-with-key",
+        alias,
+        "--auto-sign",
+        "--rpc-url",
+        rpc_url,
+        "--network-passphrase",
+        network_passphrase,
+    ]);
+    if let Some(dir) = config_dir {
+        cmd.arg("--config-dir").arg(dir);
+    }
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().with_context(|| {
+        format!(
+            "failed to run `{bin} tx sign`; install the Stellar CLI (https://stellar.org/cli) \
+             or set {STELLAR_BIN_ENV} to its path"
+        )
+    })?;
+
+    child
+        .stdin
+        .take()
+        .context("stellar tx sign stdin")?
+        .write_all(tx_xdr.as_bytes())
+        .context("write transaction XDR to stellar tx sign")?;
+
+    let output = child
+        .wait_with_output()
+        .context("wait for stellar tx sign")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "`{bin} tx sign --sign-with-key {alias}` failed: {}",
+            stderr.trim()
+        );
+    }
+
+    let stdout =
+        String::from_utf8(output.stdout).context("stellar CLI produced non-UTF-8 output")?;
+    Ok(stdout.trim().to_string())
 }
 
 /// A network's connection parameters, resolved from the Stellar CLI.


### PR DESCRIPTION
Uses the Stellar CLI to sign txs instead of importing the secret and creating a local `LocalSigner`.

Also fixes the cause of the error in https://github.com/NethermindEth/stellar-private-payments/pull/334#issuecomment-4892807457 (account added to the Stellar CLI using the `--secure-store` flag). cc @Fantoni0 