### PR TITLE
Auto release notes

### DIFF
--- a/.github/workflows/bootnode-release.yml
+++ b/.github/workflows/bootnode-release.yml
@@ -64,6 +64,7 @@ jobs:
       - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: out/*
+          generate_release_notes: true
 
   docker:
     name: Docker (multi-arch)

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -195,4 +195,11 @@ jobs:
         with:
           files: out/*
           prerelease: ${{ steps.pre.outputs.prerelease }}
+          generate_release_notes: true
+          body: |
+            ## Install CLI
+
+            ```bash
+            curl -fsSL https://nethermindeth.github.io/stellar-private-payments/install.sh | sh -s -- --version ${{ github.ref_name }}
+            ```
           fail_on_unmatched_files: true


### PR DESCRIPTION
Output in releases page should become something like this; giving it some additional info:



# Release v1.2.3

## Install CLI

```bash
curl -fsSL https://nethermindeth.github.io/stellar-private-payments/install.sh | sh -s -- --version v1.2.3
```
## What's Changed
(Automatically generated by GitHub based on merged PRs, commits, and contributors since the previous release.)
Example:
Add encrypted wallet export by @alice in #42
Improve transaction batching by @bob in #45
Fix Windows installer by @carol in #47
Full Changelog: v1.2.2...v1.2.3
## Assets
...