### PR TITLE
Display spent and unspent notes when generating selective disclosures

### DIFF
--- a/app/js/disclosure.js
+++ b/app/js/disclosure.js
@@ -7,6 +7,7 @@ import {
 } from './wallet.js';
 import { isDbLockedError, showDbLockedModal } from './db-locked.js';
 import { getActivePoolContractId } from './ui/pool.js';
+import { filterNotes, createNoteRow } from './ui/notes-view.js';
 
 // ---------------------------------------------------------------------------
 // Canonical constants
@@ -37,6 +38,8 @@ const state = {
   notes: [],
   pools: [],
   selectedNotes: [],
+  noteStatusFilter: 'all',
+  notePoolFilter: null,
   notesLoading: false,
   notesError: null,
   generating: false,
@@ -176,14 +179,14 @@ async function loadNotes() {
     const query = parseQueryParams();
     if (query.commitments && query.commitments.length > 0) {
       const targets = query.commitments.map(normalizeCommitment);
-      const matches = state.notes.filter(
-        (n) => targets.includes(normalizeCommitment(n.id)) && !n.spent
+      const matches = state.notes.filter((n) =>
+        targets.includes(normalizeCommitment(n.id))
       );
       if (matches.length > 0) {
         state.selectedNotes = matches.slice(0, 4);
       } else {
         state.notesError =
-          'Preselected notes not found, already spent, or not owned by this account.';
+          'Preselected notes not found or not owned by this account.';
       }
     }
   } catch (e) {
@@ -322,6 +325,61 @@ function normalizeCommitment(s) {
   return t;
 }
 
+// Filter controls for the Generate selector: spent-status buttons plus a
+// token/pool select (shown only when the account holds notes across more than
+// one pool). Mutating a control updates state and re-renders in place.
+function buildGenerateFilters(container) {
+  const wrap = el('div', 'flex flex-wrap items-center gap-2 mb-3');
+
+  const statusGroup = el('div', 'inline-flex rounded-lg border border-dark-700 bg-dark-800 p-0.5');
+  const statuses = [
+    { key: 'all', label: 'All' },
+    { key: 'unspent', label: 'Available' },
+    { key: 'spent', label: 'Spent' },
+  ];
+  statuses.forEach(({ key, label }) => {
+    const active = state.noteStatusFilter === key;
+    const btn = el(
+      'button',
+      `px-3 py-1 text-xs rounded-md transition-colors ${
+        active ? 'bg-brand-500/20 text-brand-300' : 'text-dark-400 hover:text-dark-200'
+      }`,
+      label,
+    );
+    btn.type = 'button';
+    btn.addEventListener('click', () => {
+      state.noteStatusFilter = key;
+      mountGenerate(container);
+    });
+    statusGroup.appendChild(btn);
+  });
+  wrap.appendChild(statusGroup);
+
+  const poolIds = [...new Set(state.notes.map((n) => n.poolContractId))];
+  if (poolIds.length > 1) {
+    const select = el(
+      'select',
+      'text-xs bg-dark-800 border border-dark-700 rounded-lg px-2 py-1 text-dark-200',
+    );
+    const optAll = el('option', null, 'All tokens');
+    optAll.value = '';
+    select.appendChild(optAll);
+    poolIds.forEach((pid) => {
+      const opt = el('option', null, tokenLabelForPool(pid));
+      opt.value = pid;
+      select.appendChild(opt);
+    });
+    select.value = state.notePoolFilter || '';
+    select.addEventListener('change', () => {
+      state.notePoolFilter = select.value || null;
+      mountGenerate(container);
+    });
+    wrap.appendChild(select);
+  }
+
+  return wrap;
+}
+
 export function mountGenerate(container) {
   container.replaceChildren();
 
@@ -335,7 +393,7 @@ export function mountGenerate(container) {
     const msg = document.createElement('div');
     msg.className = 'text-sm text-dark-400';
     msg.textContent =
-      'Connect your Freighter wallet to generate disclosure receipts for your unspent notes.';
+      'Connect your Freighter wallet to generate disclosure receipts for your notes.';
     container.appendChild(msg);
     return;
   }
@@ -360,74 +418,59 @@ export function mountGenerate(container) {
     return;
   }
 
-  const unspent = state.notes.filter((n) => !n.spent);
-
-  if (unspent.length === 0) {
+  if (state.notes.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'text-sm text-dark-400';
-    empty.textContent = 'No unspent notes found for this account.';
+    empty.textContent = 'No notes found for this account.';
     container.appendChild(empty);
     return;
   }
 
+  container.appendChild(buildGenerateFilters(container));
+
+  const notes = filterNotes(state.notes, {
+    status: state.noteStatusFilter,
+    poolId: state.notePoolFilter,
+  });
+
   // Note picker
   const pickerLabel = document.createElement('label');
   pickerLabel.className = 'block text-xs font-medium text-dark-400 uppercase tracking-wide mb-2';
-  pickerLabel.textContent = `Select up to 4 unspent notes (${unspent.length})`;
+  pickerLabel.textContent = `Select up to 4 notes (${notes.length})`;
   container.appendChild(pickerLabel);
 
   const list = document.createElement('div');
   list.className = 'space-y-2 mb-4';
   list.setAttribute('role', 'group');
-  list.setAttribute('aria-label', 'Unspent notes');
+  list.setAttribute('aria-label', 'Notes');
 
   const isSelected = (note) => state.selectedNotes.some((n) => n.id === note.id);
   const atMaxSelection = () => state.selectedNotes.length >= 4;
 
-  unspent.forEach((note) => {
-    const selected = isSelected(note);
-
-    const row = document.createElement('label');
-    row.className = `w-full text-left p-3 rounded-lg border transition-all duration-200 flex items-center justify-between gap-3 cursor-pointer ${
-      selected
-        ? 'bg-brand-500/10 border-brand-500/40 text-brand-300'
-        : 'bg-dark-800 border-dark-700 hover:border-dark-600 text-dark-200'
-    }`;
-
-    const noteLabel = tokenLabelForPool(note.poolContractId);
-    const rowInner = el('div', 'flex items-center gap-3 min-w-0');
-    const checkbox = el('input', 'accent-brand-500');
-    checkbox.type = 'checkbox';
-    checkbox.checked = selected;
-    if (!selected && atMaxSelection()) checkbox.disabled = true;
-    rowInner.appendChild(checkbox);
-
-    const rowInfo = el('div', 'min-w-0');
-    rowInfo.append(
-      el('div', 'font-mono text-xs truncate', shortCommitment(note.id)),
-      el('div', 'text-[10px] text-dark-500 mt-0.5', `${noteLabel} · Leaf ${note.leafIndex} · Ledger ${note.createdAtLedger}`),
+  if (notes.length === 0) {
+    list.appendChild(
+      el('div', 'text-sm text-dark-400 p-3', 'No notes match this filter.'),
     );
-    rowInner.appendChild(rowInfo);
-
-    row.append(
-      rowInner,
-      el('div', `text-xs font-medium whitespace-nowrap ${selected ? 'text-brand-300' : 'text-dark-300'}`, formatAmount(note.amount, noteLabel)),
-    );
-
-    const rowCheckbox = row.querySelector('input');
-    rowCheckbox.addEventListener('change', () => {
-      if (rowCheckbox.checked) {
-        if (!isSelected(note)) {
-          state.selectedNotes.push(note);
-        }
-      } else {
-        state.selectedNotes = state.selectedNotes.filter((n) => n.id !== note.id);
-      }
-      mountGenerate(container);
+  } else {
+    notes.forEach((note) => {
+      const selected = isSelected(note);
+      const row = createNoteRow(note, {
+        symbol: tokenLabelForPool(note.poolContractId),
+        selectable: true,
+        selected,
+        disabled: !selected && atMaxSelection(),
+        onToggle: (n, checked) => {
+          if (checked) {
+            if (!isSelected(n)) state.selectedNotes.push(n);
+          } else {
+            state.selectedNotes = state.selectedNotes.filter((x) => x.id !== n.id);
+          }
+          mountGenerate(container);
+        },
+      });
+      list.appendChild(row);
     });
-
-    list.appendChild(row);
-  });
+  }
 
   container.appendChild(list);
 

--- a/app/js/ui/notes-table.js
+++ b/app/js/ui/notes-table.js
@@ -1,6 +1,7 @@
 import { client } from '../wasm-facade.js';
 import { App, Toast, Utils } from './core.js';
 import { Templates } from './templates.js';
+import { filterNotes } from './notes-view.js';
 
 function noteWithLabels(note) {
     const pool = App.state.pools.find(item => item.poolContractId === note.poolContractId);
@@ -80,10 +81,10 @@ export const NotesTable = {
         if (!tbody || !empty) return;
 
         tbody.replaceChildren();
-        const filtered = App.state.notes
-            .filter(note => this.filter === 'all' ? true : this.filter === 'unspent' ? !note.spent : note.spent)
-            .filter(note => !App.state.selectedPoolId || note.poolContractId === App.state.selectedPoolId)
-            .map(noteWithLabels);
+        const filtered = filterNotes(App.state.notes, {
+            status: this.filter,
+            poolId: App.state.selectedPoolId,
+        }).map(noteWithLabels);
 
         if (!filtered.length) {
             empty.classList.remove('hidden');

--- a/app/js/ui/notes-view.js
+++ b/app/js/ui/notes-view.js
@@ -1,0 +1,202 @@
+// Reusable, presentational note helpers shared by the Advanced notes table
+// (app/js/ui/notes-table.js) and the Selective Disclosure selector
+// (app/js/disclosure.js).
+//
+// This module is intentionally PURE and STATELESS: it has no dependency on
+// App.state, App.events, polling, or DOM <template> tags. Every element is
+// built with el()/elc(), so the module works on any page (index.html and
+// disclosure.html). Callers own their state/lifecycle and pass in data +
+// callbacks; the module returns DOM and derived values.
+//
+// Reuse boundary (by design): the table view keeps its own <tr>/<td> row
+// (it is a real HTML table) but reuses filterNotes(), the statusBadge spec,
+// and the formatting helpers below. createNoteRow() is an el()-based CARD row
+// for non-table note lists (the disclosure selector and any future surface).
+
+// ---------------------------------------------------------------------------
+// Minimal DOM builders (signature-compatible with disclosure.js el()/elc()).
+// ---------------------------------------------------------------------------
+
+export function el(tag, className, text) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text != null) node.textContent = String(text);
+  return node;
+}
+
+// Create an element and append DOM-node children. `children` only ever contains
+// Nodes (or null) — never raw strings — so nothing untrusted reaches the DOM as
+// markup.
+export function elc(tag, className, children) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  for (const child of children) {
+    if (child instanceof Node) node.appendChild(child);
+  }
+  return node;
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+// Format a token amount in base units (stroops) to a decimal string with symbol.
+// Mirrors both Utils.formatTokenAmount (core.js) and disclosure.js formatAmount.
+export function formatAmount(amount, symbol = 'XLM', decimals = 7) {
+  try {
+    let value = typeof amount === 'bigint' ? amount : BigInt(amount ?? 0);
+    const negative = value < 0n;
+    if (negative) value = -value;
+    const abs = value.toString().padStart(decimals + 1, '0');
+    const intPart = abs.slice(0, -decimals);
+    const frac = abs.slice(-decimals).replace(/0+$/, '');
+    const out = frac ? `${intPart}.${frac}` : intPart;
+    return `${negative ? '-' : ''}${out} ${symbol}`;
+  } catch {
+    return `0 ${symbol}`;
+  }
+}
+
+// Token symbol for a pool, derived from the deployment config's asset descriptor.
+// Takes the pool object (mirrors Utils.poolLabel).
+export function tokenLabel(pool) {
+  const asset = pool?.asset || {};
+  if (asset.kind === 'native') return 'XLM';
+  if (asset.kind === 'classic') return asset.code || 'Asset';
+  if (asset.kind === 'contract') return asset.symbol || 'Token';
+  return 'Token';
+}
+
+// Convenience for callers that hold a pool contract id + the pools list
+// (mirrors disclosure.js tokenLabelForPool).
+export function tokenLabelFor(poolContractId, pools) {
+  const pool = (pools || []).find((p) => p.poolContractId === poolContractId);
+  return tokenLabel(pool);
+}
+
+// Shorten a hex string for display (mirrors disclosure.js shortCommitment).
+export function shortHex(hex, start = 8, end = 4, ellipsis = '…') {
+  if (!hex || hex.length < start + end + 2) return hex || '--';
+  return `${hex.slice(0, start)}${ellipsis}${hex.slice(-end)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Filtering (pure) — mirrors notes-table.js render() filter semantics.
+// ---------------------------------------------------------------------------
+
+// Filter notes by spent status ('all' | 'unspent' | 'spent') and optional pool.
+export function filterNotes(notes, { status = 'all', poolId = null } = {}) {
+  return (notes || []).filter((note) => {
+    const statusOk =
+      status === 'all' ? true : status === 'unspent' ? !note.spent : note.spent;
+    const poolOk = !poolId || note.poolContractId === poolId;
+    return statusOk && poolOk;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Status badge — one source of truth for the Spent/Available pill.
+// ---------------------------------------------------------------------------
+
+// Returns { text, className } so callers can either build a fresh element
+// (createStatusBadge) or apply the styling to an existing span (the table view,
+// which keeps its `.note-status` hook class).
+export function statusBadgeSpec(spent) {
+  return spent
+    ? {
+        text: 'Spent',
+        className:
+          'inline-flex rounded-full border border-rose-400/30 bg-rose-400/10 px-2 py-1 text-[11px] font-medium text-rose-200',
+      }
+    : {
+        text: 'Available',
+        className:
+          'inline-flex rounded-full border border-cyan-400/30 bg-cyan-400/10 px-2 py-1 text-[11px] font-medium text-cyan-100',
+      };
+}
+
+export function createStatusBadge(spent) {
+  const { text, className } = statusBadgeSpec(spent);
+  return el('span', className, text);
+}
+
+// ---------------------------------------------------------------------------
+// Card row (el()-based) for non-table note lists.
+// ---------------------------------------------------------------------------
+
+// Build a note card row.
+//
+// note: { id, poolContractId, amount, spent, leafIndex?, createdAtLedger? }
+// opts:
+//   symbol      — token label to display (falls back to note.tokenLabel/'Token')
+//   selectable  — render a leading checkbox
+//   selected    — checkbox checked + highlighted row
+//   disabled    — checkbox disabled (e.g. max selection reached)
+//   onToggle    — (note, checked) => void, fired on checkbox change
+//   showBadge   — include the Spent/Available badge (default true)
+//   actions     — array of trailing DOM nodes (e.g. buttons); nulls ignored
+export function createNoteRow(note, opts = {}) {
+  const {
+    symbol: symbolOpt,
+    selectable = false,
+    selected = false,
+    disabled = false,
+    onToggle,
+    showBadge = true,
+    actions = [],
+  } = opts;
+
+  const symbol = symbolOpt || note.tokenLabel || 'Token';
+
+  const rowTag = selectable ? 'label' : 'div';
+  const row = el(
+    rowTag,
+    `w-full text-left p-3 rounded-lg border transition-all duration-200 flex items-center justify-between gap-3 ${
+      selectable ? 'cursor-pointer ' : ''
+    }${
+      selected
+        ? 'bg-brand-500/10 border-brand-500/40 text-brand-300'
+        : 'bg-dark-800 border-dark-700 hover:border-dark-600 text-dark-200'
+    }`,
+  );
+  if (note.id) row.dataset.noteId = note.id;
+
+  // Left cluster: optional checkbox + commitment / meta line.
+  const leftItems = [];
+  if (selectable) {
+    const checkbox = el('input', 'accent-brand-500');
+    checkbox.type = 'checkbox';
+    checkbox.checked = selected;
+    if (disabled) checkbox.disabled = true;
+    checkbox.addEventListener('change', () => onToggle?.(note, checkbox.checked));
+    leftItems.push(checkbox);
+  }
+
+  const metaParts = [symbol];
+  if (note.leafIndex != null) metaParts.push(`Leaf ${note.leafIndex}`);
+  metaParts.push(`Ledger ${note.createdAtLedger ?? 0}`);
+
+  leftItems.push(
+    elc('div', 'min-w-0', [
+      el('div', 'font-mono text-xs truncate', shortHex(note.id)),
+      el('div', 'text-[10px] text-dark-500 mt-0.5', metaParts.join(' · ')),
+    ]),
+  );
+  const left = elc('div', 'flex items-center gap-3 min-w-0', leftItems);
+
+  // Right cluster: status badge + amount + any caller actions.
+  const rightItems = [];
+  if (showBadge) rightItems.push(createStatusBadge(note.spent));
+  rightItems.push(
+    el(
+      'div',
+      `text-xs font-medium whitespace-nowrap ${selected ? 'text-brand-300' : 'text-dark-300'}`,
+      formatAmount(note.amount, symbol),
+    ),
+  );
+  for (const action of actions) if (action) rightItems.push(action);
+  const right = elc('div', 'flex items-center gap-3 whitespace-nowrap', rightItems);
+
+  row.append(left, right);
+  return row;
+}

--- a/app/js/ui/templates.js
+++ b/app/js/ui/templates.js
@@ -1,4 +1,5 @@
 import { App, Utils } from './core.js';
+import { statusBadgeSpec } from './notes-view.js';
 
 export const Templates = {
     init() {
@@ -66,13 +67,9 @@ export const Templates = {
         row.querySelector('.note-pool').textContent = Utils.shortAddress(note.poolContractId, 6, 4);
 
         const status = row.querySelector('.note-status');
-        if (note.spent) {
-            status.textContent = 'Spent';
-            status.className = 'note-status inline-flex rounded-full border border-rose-400/30 bg-rose-400/10 px-2 py-1 text-[11px] font-medium text-rose-200';
-        } else {
-            status.textContent = 'Available';
-            status.className = 'note-status inline-flex rounded-full border border-cyan-400/30 bg-cyan-400/10 px-2 py-1 text-[11px] font-medium text-cyan-100';
-        }
+        const badge = statusBadgeSpec(note.spent);
+        status.textContent = badge.text;
+        status.className = `note-status ${badge.className}`;
 
         // A spent note can't be used as a transact input — hide its Use button.
         const useBtn = row.querySelector('.note-use');

--- a/sdk/pool/src/disclosure.rs
+++ b/sdk/pool/src/disclosure.rs
@@ -94,10 +94,10 @@ pub fn build_disclosure_inputs(
     let mut notes = Vec::with_capacity(req.selected_commitments.len());
     for commitment in &req.selected_commitments {
         let (amount, blinding, leaf_index) = storage
-            .get_unspent_user_note_by_commitment(&req.pool_address, &req.user_address, commitment)?
+            .get_user_note_by_commitment(&req.pool_address, &req.user_address, commitment)?
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "unspent note not found for commitment {commitment} in pool {}",
+                    "note not found for commitment {commitment} in pool {}",
                     req.pool_address
                 )
             })?;

--- a/sdk/state/src/storage.rs
+++ b/sdk/state/src/storage.rs
@@ -840,6 +840,51 @@ impl Storage {
         Ok(row)
     }
 
+    /// Like [`Self::get_unspent_user_note_by_commitment`], but returns the note
+    /// regardless of spent status.
+    ///
+    /// Selective disclosure proves Merkle membership of a commitment; spending
+    /// a note publishes a nullifier but does not remove its commitment leaf
+    /// from the tree, so a spent note can still be disclosed. Use this
+    /// lookup on the disclosure input-building path. The transact path must
+    /// keep using [`Self::get_unspent_user_note_by_commitment`], which
+    /// excludes spent notes.
+    pub fn get_user_note_by_commitment(
+        &self,
+        pool_contract_id: &str,
+        account_address: &str,
+        commitment: &Field,
+    ) -> Result<Option<(NoteAmount, Field, u32)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT n.amount, n.blinding, pc.leaf_index
+             FROM user_notes n
+             JOIN accounts a ON a.id = n.account_id
+             JOIN pool_commitments pc ON pc.id = n.commitment_id
+             JOIN raw_contract_events r ON r.id = pc.event_id
+             JOIN contracts c ON c.contract_id = r.contract_id
+             WHERE a.address = ?2
+               AND c.address = ?1
+               AND pc.commitment = ?3
+             LIMIT 1",
+        )?;
+
+        let row = stmt
+            .query_row(
+                params![pool_contract_id, account_address, commitment],
+                |row| {
+                    let amount: NoteAmount = row.get(0)?;
+                    let blinding: Field = row.get(1)?;
+                    let leaf_index_i64: i64 = row.get(2)?;
+                    let leaf_index = col_u32(leaf_index_i64, 2)?;
+                    Ok((amount, blinding, leaf_index))
+                },
+            )
+            .optional()
+            .context("Failed to query user note by commitment")?;
+
+        Ok(row)
+    }
+
     /// Batch upsert for spent nullifiers
     pub fn save_nullifier_events_batch(&mut self, events: &Vec<NewNullifierEvent>) -> Result<()> {
         let tx = self.conn.transaction()?;
@@ -2330,6 +2375,189 @@ mod tests {
             &wrong_commitment,
         )?;
         assert!(result.is_none(), "wrong commitment should not match");
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_user_note_by_commitment_finds_unspent_note() -> Result<()> {
+        let mut storage = Storage::connect_in_memory()?;
+
+        let sig = KeyDerivationSignature(vec![1u8; 64]);
+        let (note_keypair, enc_keypair) =
+            encryption::derive_encryption_and_note_keypairs(sig.clone())?;
+        let membership_blinding = encryption::derive_membership_blinding(&sig, "testnet")?;
+        storage.save_encryption_and_note_keypairs(
+            "GTESTACCOUNT",
+            &note_keypair,
+            &enc_keypair,
+            &membership_blinding,
+        )?;
+
+        let amount = NoteAmount::from(5);
+        let mut blinding_le = [0u8; 32];
+        blinding_le[0] = 7;
+        let blinding = Field::try_from_le_bytes(blinding_le)?;
+
+        let amount_field_le = Field::from(amount).to_le_bytes();
+        let commitment_le = crypto::compute_commitment(
+            &amount_field_le,
+            note_keypair.public.as_ref(),
+            &blinding.to_le_bytes(),
+        )?;
+        let commitment_le: [u8; 32] = commitment_le.try_into().map_err(|v: Vec<u8>| {
+            anyhow::anyhow!("commitment: expected 32 bytes, got {}", v.len())
+        })?;
+        let commitment = Field::try_from_le_bytes(commitment_le)?;
+
+        let encrypted_output =
+            encryption::encrypt_output_note(&enc_keypair.public, amount, &blinding)?;
+
+        storage.save_events_batch(&ContractsEventData {
+            events: vec![dummy_event("evt-commit")],
+            cursor: "cur".to_string(),
+            latest_ledger: 1,
+        })?;
+        storage.save_commitment_events_batch(&vec![NewCommitmentEvent {
+            id: "evt-commit".to_string(),
+            commitment,
+            index: 3,
+            encrypted_output: encrypted_output.clone(),
+        }])?;
+
+        let mut derive = |account: &AccountKeys,
+                          row: &PoolCommitmentRow|
+         -> Result<Option<DerivedUserNoteRow>> {
+            let opt = prover::notes::try_decrypt_and_derive_user_note(
+                &account.note_keypair,
+                &account.encryption_keypair.private,
+                &row.commitment,
+                row.leaf_index,
+                &row.encrypted_output,
+            )?;
+            Ok(opt.map(|d| DerivedUserNoteRow {
+                amount: d.amount,
+                blinding: d.blinding,
+                expected_nullifier: d.expected_nullifier,
+            }))
+        };
+        assert!(storage.scan_commitments_for_user_notes(100, &mut derive)?);
+
+        let result = storage.get_user_note_by_commitment("CPOOL", "GTESTACCOUNT", &commitment)?;
+        assert!(result.is_some());
+        let (got_amount, got_blinding, got_leaf_index) = result.expect("just checked is_some");
+        assert_eq!(got_amount, amount);
+        assert_eq!(got_blinding, blinding);
+        assert_eq!(got_leaf_index, 3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_user_note_by_commitment_finds_spent_note() -> Result<()> {
+        let mut storage = Storage::connect_in_memory()?;
+
+        let sig = KeyDerivationSignature(vec![1u8; 64]);
+        let (note_keypair, enc_keypair) =
+            encryption::derive_encryption_and_note_keypairs(sig.clone())?;
+        let membership_blinding = encryption::derive_membership_blinding(&sig, "testnet")?;
+        storage.save_encryption_and_note_keypairs(
+            "GTESTACCOUNT",
+            &note_keypair,
+            &enc_keypair,
+            &membership_blinding,
+        )?;
+
+        let amount = NoteAmount::from(5);
+        let mut blinding_le = [0u8; 32];
+        blinding_le[0] = 7;
+        let blinding = Field::try_from_le_bytes(blinding_le)?;
+
+        let amount_field_le = Field::from(amount).to_le_bytes();
+        let commitment_le = crypto::compute_commitment(
+            &amount_field_le,
+            note_keypair.public.as_ref(),
+            &blinding.to_le_bytes(),
+        )?;
+        let commitment_le: [u8; 32] = commitment_le.try_into().map_err(|v: Vec<u8>| {
+            anyhow::anyhow!("commitment: expected 32 bytes, got {}", v.len())
+        })?;
+        let commitment = Field::try_from_le_bytes(commitment_le)?;
+
+        let encrypted_output =
+            encryption::encrypt_output_note(&enc_keypair.public, amount, &blinding)?;
+
+        storage.save_events_batch(&ContractsEventData {
+            events: vec![dummy_event("evt-commit")],
+            cursor: "cur".to_string(),
+            latest_ledger: 1,
+        })?;
+        storage.save_commitment_events_batch(&vec![NewCommitmentEvent {
+            id: "evt-commit".to_string(),
+            commitment,
+            index: 3,
+            encrypted_output: encrypted_output.clone(),
+        }])?;
+
+        let mut derive = |account: &AccountKeys,
+                          row: &PoolCommitmentRow|
+         -> Result<Option<DerivedUserNoteRow>> {
+            let opt = prover::notes::try_decrypt_and_derive_user_note(
+                &account.note_keypair,
+                &account.encryption_keypair.private,
+                &row.commitment,
+                row.leaf_index,
+                &row.encrypted_output,
+            )?;
+            Ok(opt.map(|d| DerivedUserNoteRow {
+                amount: d.amount,
+                blinding: d.blinding,
+                expected_nullifier: d.expected_nullifier,
+            }))
+        };
+        storage.scan_commitments_for_user_notes(100, &mut derive)?;
+
+        // Spend the note via nullifier.
+        let leaf_index: u32 = 3;
+        let mut path_indices_le = [0u8; 32];
+        path_indices_le[..8].copy_from_slice(&(u64::from(leaf_index)).to_le_bytes());
+        let signature = crypto::compute_signature(
+            &note_keypair.private.0,
+            &commitment.to_le_bytes(),
+            &path_indices_le,
+        )?;
+        let nullifier_le =
+            crypto::compute_nullifier(&commitment.to_le_bytes(), &path_indices_le, &signature)?;
+        let nullifier_le: [u8; 32] = nullifier_le.try_into().map_err(|v: Vec<u8>| {
+            anyhow::anyhow!("nullifier: expected 32 bytes, got {}", v.len())
+        })?;
+        let nullifier = Field::try_from_le_bytes(nullifier_le)?;
+
+        storage.save_events_batch(&ContractsEventData {
+            events: vec![dummy_event("evt-null")],
+            cursor: "cur2".to_string(),
+            latest_ledger: 1,
+        })?;
+        storage.save_nullifier_events_batch(&vec![NewNullifierEvent {
+            id: "evt-null".to_string(),
+            nullifier,
+        }])?;
+        storage.reconcile_nullifiers(100)?;
+
+        // The unspent-only lookup rejects it, but the spent-tolerant lookup returns it.
+        assert!(
+            storage
+                .get_unspent_user_note_by_commitment("CPOOL", "GTESTACCOUNT", &commitment)?
+                .is_none(),
+            "sanity: note is spent"
+        );
+
+        let result = storage.get_user_note_by_commitment("CPOOL", "GTESTACCOUNT", &commitment)?;
+        assert!(result.is_some(), "spent note should still be returned");
+        let (got_amount, got_blinding, got_leaf_index) = result.expect("just checked is_some");
+        assert_eq!(got_amount, amount);
+        assert_eq!(got_blinding, blinding);
+        assert_eq!(got_leaf_index, 3);
 
         Ok(())
     }


### PR DESCRIPTION
# Display spent and unspent notes when generating selective disclosures

## Description
This PR enables generating selective disclosures for both **spent** and **unspent (available)** notes. 

In private transaction systems based on commitments and nullifiers, spending a note publishes its nullifier to prevent double-spending, but does not remove the note's commitment leaf from the Merkle tree. As a result, the note still exists in the tree and can still be proven to be part of the pool. This change allows users to generate disclosure receipts for spent notes, which is useful for historical audits and proof-of-payment receipts.

Additionally, this PR refactors the frontend to introduce note filtering (by spent status and token/pool) on the disclosure generation screen and standardizes note styling across the application.

