### PR TITLE
Store generated disclosures in persistent storage

### DIFF
--- a/app/disclosure.html
+++ b/app/disclosure.html
@@ -51,6 +51,12 @@
     <!-- Rendered by disclosure.js -->
   </section>
 
+  <!-- History Section (encrypted, opt-in local storage of generated receipts) -->
+  <section id="disclosure-history" class="bg-dark-900/80 backdrop-blur-sm border border-dark-800 rounded-xl p-4 sm:p-6" aria-labelledby="history-heading">
+    <h2 id="history-heading" class="text-sm uppercase tracking-[0.25em] text-brand-400 mb-4">Disclosure History</h2>
+    <!-- Rendered by disclosure.js -->
+  </section>
+
   <!-- Verify Section -->
   <section id="disclosure-verify" class="bg-dark-900/80 backdrop-blur-sm border border-dark-800 rounded-xl p-4 sm:p-6" aria-labelledby="verify-heading">
     <h2 id="verify-heading" class="text-sm uppercase tracking-[0.25em] text-brand-400 mb-4">Verify Disclosure Receipt</h2>

--- a/app/js/disclosure.js
+++ b/app/js/disclosure.js
@@ -7,6 +7,7 @@ import {
 } from './wallet.js';
 import { isDbLockedError, showDbLockedModal } from './db-locked.js';
 import { getActivePoolContractId } from './ui/pool.js';
+import { filterNotes, createNoteRow } from './ui/notes-view.js';
 
 // ---------------------------------------------------------------------------
 // Canonical constants
@@ -37,6 +38,8 @@ const state = {
   notes: [],
   pools: [],
   selectedNotes: [],
+  noteStatusFilter: 'all',
+  notePoolFilter: null,
   notesLoading: false,
   notesError: null,
   generating: false,
@@ -176,14 +179,14 @@ async function loadNotes() {
     const query = parseQueryParams();
     if (query.commitments && query.commitments.length > 0) {
       const targets = query.commitments.map(normalizeCommitment);
-      const matches = state.notes.filter(
-        (n) => targets.includes(normalizeCommitment(n.id)) && !n.spent
+      const matches = state.notes.filter((n) =>
+        targets.includes(normalizeCommitment(n.id))
       );
       if (matches.length > 0) {
         state.selectedNotes = matches.slice(0, 4);
       } else {
         state.notesError =
-          'Preselected notes not found, already spent, or not owned by this account.';
+          'Preselected notes not found or not owned by this account.';
       }
     }
   } catch (e) {
@@ -322,6 +325,61 @@ function normalizeCommitment(s) {
   return t;
 }
 
+// Filter controls for the Generate selector: spent-status buttons plus a
+// token/pool select (shown only when the account holds notes across more than
+// one pool). Mutating a control updates state and re-renders in place.
+function buildGenerateFilters(container) {
+  const wrap = el('div', 'flex flex-wrap items-center gap-2 mb-3');
+
+  const statusGroup = el('div', 'inline-flex rounded-lg border border-dark-700 bg-dark-800 p-0.5');
+  const statuses = [
+    { key: 'all', label: 'All' },
+    { key: 'unspent', label: 'Available' },
+    { key: 'spent', label: 'Spent' },
+  ];
+  statuses.forEach(({ key, label }) => {
+    const active = state.noteStatusFilter === key;
+    const btn = el(
+      'button',
+      `px-3 py-1 text-xs rounded-md transition-colors ${
+        active ? 'bg-brand-500/20 text-brand-300' : 'text-dark-400 hover:text-dark-200'
+      }`,
+      label,
+    );
+    btn.type = 'button';
+    btn.addEventListener('click', () => {
+      state.noteStatusFilter = key;
+      mountGenerate(container);
+    });
+    statusGroup.appendChild(btn);
+  });
+  wrap.appendChild(statusGroup);
+
+  const poolIds = [...new Set(state.notes.map((n) => n.poolContractId))];
+  if (poolIds.length > 1) {
+    const select = el(
+      'select',
+      'text-xs bg-dark-800 border border-dark-700 rounded-lg px-2 py-1 text-dark-200',
+    );
+    const optAll = el('option', null, 'All tokens');
+    optAll.value = '';
+    select.appendChild(optAll);
+    poolIds.forEach((pid) => {
+      const opt = el('option', null, tokenLabelForPool(pid));
+      opt.value = pid;
+      select.appendChild(opt);
+    });
+    select.value = state.notePoolFilter || '';
+    select.addEventListener('change', () => {
+      state.notePoolFilter = select.value || null;
+      mountGenerate(container);
+    });
+    wrap.appendChild(select);
+  }
+
+  return wrap;
+}
+
 export function mountGenerate(container) {
   container.replaceChildren();
 
@@ -335,7 +393,7 @@ export function mountGenerate(container) {
     const msg = document.createElement('div');
     msg.className = 'text-sm text-dark-400';
     msg.textContent =
-      'Connect your Freighter wallet to generate disclosure receipts for your unspent notes.';
+      'Connect your Freighter wallet to generate disclosure receipts for your notes.';
     container.appendChild(msg);
     return;
   }
@@ -360,74 +418,59 @@ export function mountGenerate(container) {
     return;
   }
 
-  const unspent = state.notes.filter((n) => !n.spent);
-
-  if (unspent.length === 0) {
+  if (state.notes.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'text-sm text-dark-400';
-    empty.textContent = 'No unspent notes found for this account.';
+    empty.textContent = 'No notes found for this account.';
     container.appendChild(empty);
     return;
   }
 
+  container.appendChild(buildGenerateFilters(container));
+
+  const notes = filterNotes(state.notes, {
+    status: state.noteStatusFilter,
+    poolId: state.notePoolFilter,
+  });
+
   // Note picker
   const pickerLabel = document.createElement('label');
   pickerLabel.className = 'block text-xs font-medium text-dark-400 uppercase tracking-wide mb-2';
-  pickerLabel.textContent = `Select up to 4 unspent notes (${unspent.length})`;
+  pickerLabel.textContent = `Select up to 4 notes (${notes.length})`;
   container.appendChild(pickerLabel);
 
   const list = document.createElement('div');
   list.className = 'space-y-2 mb-4';
   list.setAttribute('role', 'group');
-  list.setAttribute('aria-label', 'Unspent notes');
+  list.setAttribute('aria-label', 'Notes');
 
   const isSelected = (note) => state.selectedNotes.some((n) => n.id === note.id);
   const atMaxSelection = () => state.selectedNotes.length >= 4;
 
-  unspent.forEach((note) => {
-    const selected = isSelected(note);
-
-    const row = document.createElement('label');
-    row.className = `w-full text-left p-3 rounded-lg border transition-all duration-200 flex items-center justify-between gap-3 cursor-pointer ${
-      selected
-        ? 'bg-brand-500/10 border-brand-500/40 text-brand-300'
-        : 'bg-dark-800 border-dark-700 hover:border-dark-600 text-dark-200'
-    }`;
-
-    const noteLabel = tokenLabelForPool(note.poolContractId);
-    const rowInner = el('div', 'flex items-center gap-3 min-w-0');
-    const checkbox = el('input', 'accent-brand-500');
-    checkbox.type = 'checkbox';
-    checkbox.checked = selected;
-    if (!selected && atMaxSelection()) checkbox.disabled = true;
-    rowInner.appendChild(checkbox);
-
-    const rowInfo = el('div', 'min-w-0');
-    rowInfo.append(
-      el('div', 'font-mono text-xs truncate', shortCommitment(note.id)),
-      el('div', 'text-[10px] text-dark-500 mt-0.5', `${noteLabel} · Leaf ${note.leafIndex} · Ledger ${note.createdAtLedger}`),
+  if (notes.length === 0) {
+    list.appendChild(
+      el('div', 'text-sm text-dark-400 p-3', 'No notes match this filter.'),
     );
-    rowInner.appendChild(rowInfo);
-
-    row.append(
-      rowInner,
-      el('div', `text-xs font-medium whitespace-nowrap ${selected ? 'text-brand-300' : 'text-dark-300'}`, formatAmount(note.amount, noteLabel)),
-    );
-
-    const rowCheckbox = row.querySelector('input');
-    rowCheckbox.addEventListener('change', () => {
-      if (rowCheckbox.checked) {
-        if (!isSelected(note)) {
-          state.selectedNotes.push(note);
-        }
-      } else {
-        state.selectedNotes = state.selectedNotes.filter((n) => n.id !== note.id);
-      }
-      mountGenerate(container);
+  } else {
+    notes.forEach((note) => {
+      const selected = isSelected(note);
+      const row = createNoteRow(note, {
+        symbol: tokenLabelForPool(note.poolContractId),
+        selectable: true,
+        selected,
+        disabled: !selected && atMaxSelection(),
+        onToggle: (n, checked) => {
+          if (checked) {
+            if (!isSelected(n)) state.selectedNotes.push(n);
+          } else {
+            state.selectedNotes = state.selectedNotes.filter((x) => x.id !== n.id);
+          }
+          mountGenerate(container);
+        },
+      });
+      list.appendChild(row);
     });
-
-    list.appendChild(row);
-  });
+  }
 
   container.appendChild(list);
 

--- a/app/js/disclosure.js
+++ b/app/js/disclosure.js
@@ -47,6 +47,9 @@ const state = {
   generateStage: null,
   generateStageMessage: null,
   lastReceipt: null,
+  storeReceipts: false,
+  receiptsHistory: [],
+  historyLoading: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -250,6 +253,10 @@ async function connect() {
 
     // Load notes and render generate section
     await loadNotes();
+
+    // Load the opt-in setting and (if any) the encrypted receipt history.
+    await loadStoreReceiptsSetting();
+    await loadReceiptsHistory();
   } catch (err) {
     if (err.code === 'USER_REJECTED') {
       showToast('Connection cancelled', 'info');
@@ -402,6 +409,30 @@ export function mountGenerate(container) {
   const statusLine = el('div', 'text-xs text-dark-500 mb-4');
   statusLine.append('Connected: ', el('span', 'font-mono text-dark-300', shortAddress(state.address)));
   container.appendChild(statusLine);
+
+  // Opt-in: store generated receipts locally (encrypted). Default off.
+  const optRow = el('label', 'flex items-start gap-2 mb-4 cursor-pointer select-none');
+  const optBox = el('input', 'accent-brand-500 mt-0.5');
+  optBox.type = 'checkbox';
+  optBox.checked = !!state.storeReceipts;
+  optBox.addEventListener('change', async () => {
+    try {
+      const enabled = await client().setStoreReceiptsSetting(optBox.checked);
+      state.storeReceipts = !!enabled;
+    } catch (e) {
+      console.warn('[Disclosure] failed to update store-receipts setting:', e);
+      optBox.checked = !!state.storeReceipts; // revert on failure
+      showToast('Could not update setting', 'error');
+    }
+  });
+  optRow.append(
+    optBox,
+    elc('div', 'min-w-0', [
+      el('div', 'text-xs text-dark-200', 'Store generated receipts locally (encrypted)'),
+      el('div', 'text-[10px] text-dark-500', 'Kept only on this device, encrypted with your keys. Clear anytime from Disclosure History.'),
+    ]),
+  );
+  container.appendChild(optRow);
 
   if (state.notesLoading) {
     const spinner = el('div', 'text-sm text-dark-400 flex items-center gap-2');
@@ -705,6 +736,23 @@ export function mountGenerate(container) {
     state.lastReceipt = receipt;
     resultArea.classList.remove('hidden');
     const json = JSON.stringify(receipt, null, 2);
+
+    // Persist (encrypted) when the opt-in is enabled. Non-blocking: storage
+    // failures must not break the generate flow.
+    let savedNote = null;
+    if (state.storeReceipts && state.address) {
+      savedNote = el('div', 'text-xs text-dark-500', 'Saving to history…');
+      client()
+        .saveDisclosureReceipt(state.address, JSON.stringify(receipt), new Date().toISOString())
+        .then(() => {
+          if (savedNote) savedNote.textContent = 'Saved to history (encrypted).';
+          return loadReceiptsHistory();
+        })
+        .catch((e) => {
+          console.warn('[Disclosure] failed to store receipt:', e);
+          if (savedNote) savedNote.textContent = 'Could not save to history.';
+        });
+    }
     const commitmentPrefix = state.selectedNotes.length
       ? `${state.selectedNotes.length}-note`
       : 'receipt';
@@ -717,6 +765,7 @@ export function mountGenerate(container) {
 
     const box = el('div', 'space-y-3');
     box.appendChild(el('div', 'text-sm text-emerald-300 bg-emerald-500/10 border border-emerald-500/40 rounded-lg p-3', 'Disclosure receipt generated successfully.'));
+    if (savedNote) box.appendChild(savedNote);
     if (receipt.publicInputs) {
       box.appendChild(renderDisclosedNotes(receipt.publicInputs, selectedNotesForSymbol));
     }
@@ -1372,6 +1421,279 @@ export function mountVerify(container) {
 // Init
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Disclosure history (encrypted, opt-in local storage of generated receipts)
+// ---------------------------------------------------------------------------
+
+async function loadStoreReceiptsSetting() {
+  try {
+    state.storeReceipts = await client().getStoreReceiptsSetting();
+  } catch (e) {
+    console.warn('[Disclosure] failed to read store-receipts setting:', e);
+    state.storeReceipts = false;
+  }
+}
+
+async function loadReceiptsHistory() {
+  const container = document.getElementById('disclosure-history');
+  if (!state.address) {
+    state.receiptsHistory = [];
+    if (container) mountHistory(container);
+    return;
+  }
+  state.historyLoading = true;
+  if (container) mountHistory(container);
+  try {
+    const list = await client().listDisclosureReceipts(state.address);
+    state.receiptsHistory = Array.isArray(list) ? list : [];
+  } catch (e) {
+    console.warn('[Disclosure] failed to load receipt history:', e);
+    state.receiptsHistory = [];
+  } finally {
+    state.historyLoading = false;
+    if (container) mountHistory(container);
+  }
+}
+
+// Compact, LIVE re-verification summary. Never a cached verdict — recomputed
+// against current chain state each time.
+function reverifyResultEl(report) {
+  const proofOk = !!report.proofVerified;
+  const contextOk = !!report.contextVerified;
+  const rootOk = !!report.knownRootStatus;
+  const unspentOk = !!report.nullifiersUnspent;
+  const spent = Array.isArray(report.spentNullifierIndices)
+    ? report.spentNullifierIndices.map((i) => Number(i))
+    : [];
+
+  const line = (ok, text) =>
+    elc('div', `flex items-center gap-2 ${ok ? 'text-emerald-300' : 'text-rose-300'}`, [
+      el('span', 'font-mono', ok ? '✓' : '✗'),
+      el('span', '', text),
+    ]);
+
+  const wrap = el('div', 'mt-2 text-xs space-y-1');
+  wrap.append(line(proofOk, 'Proof'), line(contextOk, 'Context'), line(rootOk, 'Root fresh'));
+  if (spent.length) {
+    wrap.appendChild(
+      el('div', 'text-amber-300', `Note(s) ${spent.map((i) => i + 1).join(', ')} already spent on-chain`),
+    );
+  } else {
+    wrap.appendChild(
+      el('div', unspentOk ? 'text-emerald-300' : 'text-amber-300', unspentOk ? 'Nullifiers unspent' : 'Spent status unavailable'),
+    );
+  }
+  return wrap;
+}
+
+// Two-step inline confirm for destructive actions (no modal): the first click
+// arms the button (label -> confirmText, rose styling) and starts a revert
+// timer; a second click within the window runs onConfirm; otherwise it reverts.
+function armConfirm(btn, { confirmText, confirmClass, onConfirm, timeoutMs = 3000 }) {
+  const originalText = btn.textContent;
+  const originalClass = btn.className;
+  let armed = false;
+  let timer = null;
+  const reset = () => {
+    armed = false;
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    btn.textContent = originalText;
+    btn.className = originalClass;
+  };
+  btn.addEventListener('click', async () => {
+    if (!armed) {
+      armed = true;
+      btn.textContent = confirmText;
+      if (confirmClass) btn.className = confirmClass;
+      timer = setTimeout(reset, timeoutMs);
+      return;
+    }
+    reset();
+    await onConfirm();
+  });
+}
+
+function renderHistoryRow(item) {
+  let receipt = null;
+  try {
+    receipt = JSON.parse(item.receiptJson);
+  } catch {
+    /* leave receipt null; row still shows id + date */
+  }
+  const ctx = receipt?.context || {};
+  const pub = receipt?.publicInputs || {};
+  const symbol = tokenLabelForPool(ctx.poolAddress || '');
+  const amounts = Array.isArray(pub.amounts) ? pub.amounts : [];
+  let total = 0n;
+  for (const a of amounts) {
+    try {
+      total += BigInt(a);
+    } catch {
+      /* skip unparseable */
+    }
+  }
+  const amountText = amounts.length ? formatAmount(total, symbol) : '';
+  const noteCount = Array.isArray(pub.nullifiers) ? pub.nullifiers.length : amounts.length;
+
+  const row = el('div', 'p-3 bg-dark-800 border border-dark-700 rounded-lg');
+
+  const top = el('div', 'flex items-start justify-between gap-3');
+  top.append(
+    elc('div', 'min-w-0 space-y-0.5', [
+      el('div', 'text-sm text-dark-100 truncate', ctx.authorityLabel || 'Unknown authority'),
+      el('div', 'text-xs text-dark-400 truncate', ctx.purpose || ''),
+      el(
+        'div',
+        'text-[10px] text-dark-500',
+        `${noteCount} note${noteCount === 1 ? '' : 's'}${amountText ? ` · ${amountText}` : ''} · ${item.createdAt}`,
+      ),
+    ]),
+    el('div', 'text-xs font-medium text-brand-300 whitespace-nowrap', amountText),
+  );
+  row.appendChild(top);
+
+  const statusArea = el('div');
+  row.appendChild(statusArea);
+
+  const actions = el('div', 'flex flex-wrap gap-2 mt-2');
+  const btnClass =
+    'px-3 py-1 text-xs bg-dark-900 border border-dark-700 rounded-lg hover:border-brand-500 hover:text-brand-400 transition';
+
+  const dl = el('button', btnClass, 'Download');
+  dl.type = 'button';
+  dl.addEventListener('click', () => {
+    const blob = new Blob([item.receiptJson], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `disclosure-receipt-${(item.id || 'receipt').slice(0, 8)}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+
+  const copy = el('button', btnClass, 'Copy');
+  copy.type = 'button';
+  copy.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(item.receiptJson);
+      showToast('Copied to clipboard', 'success');
+    } catch {
+      showToast('Failed to copy', 'error');
+    }
+  });
+
+  const rv = el('button', btnClass, 'Re-verify');
+  rv.type = 'button';
+  rv.addEventListener('click', async () => {
+    statusArea.replaceChildren();
+    const loading = el('div', 'mt-2 text-xs text-dark-400 flex items-center gap-2');
+    loading.append(spinnerEl(), 'Verifying against chain…');
+    statusArea.appendChild(loading);
+    try {
+      const name = receipt?.circuit?.name;
+      const vk =
+        (name && CANONICAL_SELECTIVE_DISCLOSURE_VK_HASHES[name]) ||
+        CANONICAL_SELECTIVE_DISCLOSURE_VK_HASHES.selectiveDisclosure_1;
+      const report = await client().verifySelectiveDisclosure(item.receiptJson, vk);
+      statusArea.replaceChildren(reverifyResultEl(report));
+    } catch (e) {
+      console.warn('[Disclosure] re-verify failed:', e);
+      statusArea.replaceChildren(el('div', 'mt-2 text-xs text-rose-300', 'Re-verify failed.'));
+    }
+  });
+
+  const del = el(
+    'button',
+    'px-3 py-1 text-xs bg-dark-900 border border-dark-700 rounded-lg hover:border-rose-500 hover:text-rose-300 transition',
+    'Delete',
+  );
+  del.type = 'button';
+  armConfirm(del, {
+    confirmText: 'Confirm?',
+    confirmClass:
+      'px-3 py-1 text-xs bg-rose-500/20 border border-rose-500/50 rounded-lg text-rose-200 transition',
+    onConfirm: async () => {
+      try {
+        await client().deleteDisclosureReceipt(state.address, item.id);
+        await loadReceiptsHistory();
+      } catch (e) {
+        console.warn('[Disclosure] delete failed:', e);
+        showToast('Failed to delete', 'error');
+      }
+    },
+  });
+
+  actions.append(dl, copy, rv, del);
+  row.appendChild(actions);
+  return row;
+}
+
+export function mountHistory(container) {
+  container.replaceChildren();
+
+  const heading = el('h2', 'text-sm uppercase tracking-[0.25em] text-brand-400 mb-4', 'Disclosure History');
+  heading.id = 'history-heading';
+  container.appendChild(heading);
+
+  if (!state.address || !state.derivedKeys) {
+    container.appendChild(
+      el('div', 'text-sm text-dark-400', 'Connect your wallet to view stored disclosure receipts.'),
+    );
+    return;
+  }
+
+  if (state.historyLoading) {
+    const spinner = el('div', 'text-sm text-dark-400 flex items-center gap-2');
+    spinner.append(spinnerEl(), 'Loading history…');
+    container.appendChild(spinner);
+    return;
+  }
+
+  const items = state.receiptsHistory || [];
+  if (items.length === 0) {
+    container.appendChild(
+      el(
+        'div',
+        'text-sm text-dark-400',
+        state.storeReceipts
+          ? 'No stored receipts yet. Generated receipts will appear here.'
+          : 'Receipt storage is off. Enable “Store generated receipts locally” in the Generate section to keep a history.',
+      ),
+    );
+    return;
+  }
+
+  const topRow = el('div', 'flex items-center justify-between mb-3');
+  topRow.appendChild(
+    el('div', 'text-xs text-dark-500', `${items.length} stored receipt${items.length === 1 ? '' : 's'}`),
+  );
+  const clearBtn = el('button', 'text-xs text-rose-300 hover:text-rose-200 transition', 'Clear all');
+  clearBtn.type = 'button';
+  armConfirm(clearBtn, {
+    confirmText: 'Confirm clear all?',
+    confirmClass: 'text-xs font-semibold text-rose-200 hover:text-rose-100 transition',
+    onConfirm: async () => {
+      try {
+        await client().clearDisclosureReceipts(state.address);
+        await loadReceiptsHistory();
+        showToast('History cleared', 'success');
+      } catch (e) {
+        console.warn('[Disclosure] clear failed:', e);
+        showToast('Failed to clear history', 'error');
+      }
+    },
+  });
+  topRow.appendChild(clearBtn);
+  container.appendChild(topRow);
+
+  const list = el('div', 'space-y-2');
+  items.forEach((item) => list.appendChild(renderHistoryRow(item)));
+  container.appendChild(list);
+}
+
 async function init() {
   networkChip = document.getElementById('networkChip');
   walletChip = document.getElementById('walletChip');
@@ -1401,8 +1723,11 @@ async function init() {
   const generateContainer = document.getElementById('disclosure-generate');
   const verifyContainer = document.getElementById('disclosure-verify');
 
+  const historyContainer = document.getElementById('disclosure-history');
+
   if (generateContainer) mountGenerate(generateContainer);
   if (verifyContainer) mountVerify(verifyContainer);
+  if (historyContainer) mountHistory(historyContainer);
 
   if (query.verify && verifyContainer) {
     verifyContainer.scrollIntoView({ behavior: 'smooth', block: 'start' });

--- a/app/js/ui/notes-table.js
+++ b/app/js/ui/notes-table.js
@@ -1,6 +1,7 @@
 import { client } from '../wasm-facade.js';
 import { App, Toast, Utils } from './core.js';
 import { Templates } from './templates.js';
+import { filterNotes } from './notes-view.js';
 
 function noteWithLabels(note) {
     const pool = App.state.pools.find(item => item.poolContractId === note.poolContractId);
@@ -80,10 +81,10 @@ export const NotesTable = {
         if (!tbody || !empty) return;
 
         tbody.replaceChildren();
-        const filtered = App.state.notes
-            .filter(note => this.filter === 'all' ? true : this.filter === 'unspent' ? !note.spent : note.spent)
-            .filter(note => !App.state.selectedPoolId || note.poolContractId === App.state.selectedPoolId)
-            .map(noteWithLabels);
+        const filtered = filterNotes(App.state.notes, {
+            status: this.filter,
+            poolId: App.state.selectedPoolId,
+        }).map(noteWithLabels);
 
         if (!filtered.length) {
             empty.classList.remove('hidden');

--- a/app/js/ui/notes-view.js
+++ b/app/js/ui/notes-view.js
@@ -1,0 +1,202 @@
+// Reusable, presentational note helpers shared by the Advanced notes table
+// (app/js/ui/notes-table.js) and the Selective Disclosure selector
+// (app/js/disclosure.js).
+//
+// This module is intentionally PURE and STATELESS: it has no dependency on
+// App.state, App.events, polling, or DOM <template> tags. Every element is
+// built with el()/elc(), so the module works on any page (index.html and
+// disclosure.html). Callers own their state/lifecycle and pass in data +
+// callbacks; the module returns DOM and derived values.
+//
+// Reuse boundary (by design): the table view keeps its own <tr>/<td> row
+// (it is a real HTML table) but reuses filterNotes(), the statusBadge spec,
+// and the formatting helpers below. createNoteRow() is an el()-based CARD row
+// for non-table note lists (the disclosure selector and any future surface).
+
+// ---------------------------------------------------------------------------
+// Minimal DOM builders (signature-compatible with disclosure.js el()/elc()).
+// ---------------------------------------------------------------------------
+
+export function el(tag, className, text) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text != null) node.textContent = String(text);
+  return node;
+}
+
+// Create an element and append DOM-node children. `children` only ever contains
+// Nodes (or null) — never raw strings — so nothing untrusted reaches the DOM as
+// markup.
+export function elc(tag, className, children) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  for (const child of children) {
+    if (child instanceof Node) node.appendChild(child);
+  }
+  return node;
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+// Format a token amount in base units (stroops) to a decimal string with symbol.
+// Mirrors both Utils.formatTokenAmount (core.js) and disclosure.js formatAmount.
+export function formatAmount(amount, symbol = 'XLM', decimals = 7) {
+  try {
+    let value = typeof amount === 'bigint' ? amount : BigInt(amount ?? 0);
+    const negative = value < 0n;
+    if (negative) value = -value;
+    const abs = value.toString().padStart(decimals + 1, '0');
+    const intPart = abs.slice(0, -decimals);
+    const frac = abs.slice(-decimals).replace(/0+$/, '');
+    const out = frac ? `${intPart}.${frac}` : intPart;
+    return `${negative ? '-' : ''}${out} ${symbol}`;
+  } catch {
+    return `0 ${symbol}`;
+  }
+}
+
+// Token symbol for a pool, derived from the deployment config's asset descriptor.
+// Takes the pool object (mirrors Utils.poolLabel).
+export function tokenLabel(pool) {
+  const asset = pool?.asset || {};
+  if (asset.kind === 'native') return 'XLM';
+  if (asset.kind === 'classic') return asset.code || 'Asset';
+  if (asset.kind === 'contract') return asset.symbol || 'Token';
+  return 'Token';
+}
+
+// Convenience for callers that hold a pool contract id + the pools list
+// (mirrors disclosure.js tokenLabelForPool).
+export function tokenLabelFor(poolContractId, pools) {
+  const pool = (pools || []).find((p) => p.poolContractId === poolContractId);
+  return tokenLabel(pool);
+}
+
+// Shorten a hex string for display (mirrors disclosure.js shortCommitment).
+export function shortHex(hex, start = 8, end = 4, ellipsis = '…') {
+  if (!hex || hex.length < start + end + 2) return hex || '--';
+  return `${hex.slice(0, start)}${ellipsis}${hex.slice(-end)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Filtering (pure) — mirrors notes-table.js render() filter semantics.
+// ---------------------------------------------------------------------------
+
+// Filter notes by spent status ('all' | 'unspent' | 'spent') and optional pool.
+export function filterNotes(notes, { status = 'all', poolId = null } = {}) {
+  return (notes || []).filter((note) => {
+    const statusOk =
+      status === 'all' ? true : status === 'unspent' ? !note.spent : note.spent;
+    const poolOk = !poolId || note.poolContractId === poolId;
+    return statusOk && poolOk;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Status badge — one source of truth for the Spent/Available pill.
+// ---------------------------------------------------------------------------
+
+// Returns { text, className } so callers can either build a fresh element
+// (createStatusBadge) or apply the styling to an existing span (the table view,
+// which keeps its `.note-status` hook class).
+export function statusBadgeSpec(spent) {
+  return spent
+    ? {
+        text: 'Spent',
+        className:
+          'inline-flex rounded-full border border-rose-400/30 bg-rose-400/10 px-2 py-1 text-[11px] font-medium text-rose-200',
+      }
+    : {
+        text: 'Available',
+        className:
+          'inline-flex rounded-full border border-cyan-400/30 bg-cyan-400/10 px-2 py-1 text-[11px] font-medium text-cyan-100',
+      };
+}
+
+export function createStatusBadge(spent) {
+  const { text, className } = statusBadgeSpec(spent);
+  return el('span', className, text);
+}
+
+// ---------------------------------------------------------------------------
+// Card row (el()-based) for non-table note lists.
+// ---------------------------------------------------------------------------
+
+// Build a note card row.
+//
+// note: { id, poolContractId, amount, spent, leafIndex?, createdAtLedger? }
+// opts:
+//   symbol      — token label to display (falls back to note.tokenLabel/'Token')
+//   selectable  — render a leading checkbox
+//   selected    — checkbox checked + highlighted row
+//   disabled    — checkbox disabled (e.g. max selection reached)
+//   onToggle    — (note, checked) => void, fired on checkbox change
+//   showBadge   — include the Spent/Available badge (default true)
+//   actions     — array of trailing DOM nodes (e.g. buttons); nulls ignored
+export function createNoteRow(note, opts = {}) {
+  const {
+    symbol: symbolOpt,
+    selectable = false,
+    selected = false,
+    disabled = false,
+    onToggle,
+    showBadge = true,
+    actions = [],
+  } = opts;
+
+  const symbol = symbolOpt || note.tokenLabel || 'Token';
+
+  const rowTag = selectable ? 'label' : 'div';
+  const row = el(
+    rowTag,
+    `w-full text-left p-3 rounded-lg border transition-all duration-200 flex items-center justify-between gap-3 ${
+      selectable ? 'cursor-pointer ' : ''
+    }${
+      selected
+        ? 'bg-brand-500/10 border-brand-500/40 text-brand-300'
+        : 'bg-dark-800 border-dark-700 hover:border-dark-600 text-dark-200'
+    }`,
+  );
+  if (note.id) row.dataset.noteId = note.id;
+
+  // Left cluster: optional checkbox + commitment / meta line.
+  const leftItems = [];
+  if (selectable) {
+    const checkbox = el('input', 'accent-brand-500');
+    checkbox.type = 'checkbox';
+    checkbox.checked = selected;
+    if (disabled) checkbox.disabled = true;
+    checkbox.addEventListener('change', () => onToggle?.(note, checkbox.checked));
+    leftItems.push(checkbox);
+  }
+
+  const metaParts = [symbol];
+  if (note.leafIndex != null) metaParts.push(`Leaf ${note.leafIndex}`);
+  metaParts.push(`Ledger ${note.createdAtLedger ?? 0}`);
+
+  leftItems.push(
+    elc('div', 'min-w-0', [
+      el('div', 'font-mono text-xs truncate', shortHex(note.id)),
+      el('div', 'text-[10px] text-dark-500 mt-0.5', metaParts.join(' · ')),
+    ]),
+  );
+  const left = elc('div', 'flex items-center gap-3 min-w-0', leftItems);
+
+  // Right cluster: status badge + amount + any caller actions.
+  const rightItems = [];
+  if (showBadge) rightItems.push(createStatusBadge(note.spent));
+  rightItems.push(
+    el(
+      'div',
+      `text-xs font-medium whitespace-nowrap ${selected ? 'text-brand-300' : 'text-dark-300'}`,
+      formatAmount(note.amount, symbol),
+    ),
+  );
+  for (const action of actions) if (action) rightItems.push(action);
+  const right = elc('div', 'flex items-center gap-3 whitespace-nowrap', rightItems);
+
+  row.append(left, right);
+  return row;
+}

--- a/app/js/ui/templates.js
+++ b/app/js/ui/templates.js
@@ -1,4 +1,5 @@
 import { App, Utils } from './core.js';
+import { statusBadgeSpec } from './notes-view.js';
 
 export const Templates = {
     init() {
@@ -66,13 +67,9 @@ export const Templates = {
         row.querySelector('.note-pool').textContent = Utils.shortAddress(note.poolContractId, 6, 4);
 
         const status = row.querySelector('.note-status');
-        if (note.spent) {
-            status.textContent = 'Spent';
-            status.className = 'note-status inline-flex rounded-full border border-rose-400/30 bg-rose-400/10 px-2 py-1 text-[11px] font-medium text-rose-200';
-        } else {
-            status.textContent = 'Available';
-            status.className = 'note-status inline-flex rounded-full border border-cyan-400/30 bg-cyan-400/10 px-2 py-1 text-[11px] font-medium text-cyan-100';
-        }
+        const badge = statusBadgeSpec(note.spent);
+        status.textContent = badge.text;
+        status.className = `note-status ${badge.className}`;
 
         // A spent note can't be used as a transact input — hide its Use button.
         const useBtn = row.querySelector('.note-use');

--- a/app/js/wasm-facade.js
+++ b/app/js/wasm-facade.js
@@ -117,6 +117,38 @@ function wrapSdkClient(sdk, sdkStorage) {
             const response = await storageCall(sdkStorage, { UserNotes: [address, limit] });
             return response.UserNotes ?? [];
         },
+        // Encrypted, opt-in local storage of generated disclosure receipts.
+        // The worker encrypts/decrypts under the account's own encryption keypair;
+        // returned receipts carry camelCase fields { id, createdAt, receiptJson }.
+        async saveDisclosureReceipt(address, receiptJson, createdAt) {
+            const response = await storageCall(sdkStorage, {
+                SaveDisclosureReceipt: {
+                    address,
+                    receipt_json: receiptJson,
+                    created_at: createdAt,
+                },
+            });
+            return response.DisclosureReceiptSaved ?? null;
+        },
+        async listDisclosureReceipts(address) {
+            const response = await storageCall(sdkStorage, { ListDisclosureReceipts: address });
+            return response.DisclosureReceipts ?? [];
+        },
+        async deleteDisclosureReceipt(address, id) {
+            await storageCall(sdkStorage, { DeleteDisclosureReceipt: { address, id } });
+        },
+        async clearDisclosureReceipts(address) {
+            await storageCall(sdkStorage, { ClearDisclosureReceipts: address });
+        },
+        async getStoreReceiptsSetting() {
+            // Unit request variant -> externally-tagged bare string.
+            const response = await storageCall(sdkStorage, 'GetStoreReceiptsSetting');
+            return response.StoreReceiptsSetting ?? false;
+        },
+        async setStoreReceiptsSetting(enabled) {
+            const response = await storageCall(sdkStorage, { SetStoreReceiptsSetting: enabled });
+            return response.StoreReceiptsSetting ?? enabled;
+        },
         async deriveAspUserLeaf(membershipBlinding, notePublicKey) {
             const response = await storageCall(sdkStorage, {
                 DeriveASPleaf: {

--- a/sdk/pool/src/disclosure.rs
+++ b/sdk/pool/src/disclosure.rs
@@ -94,10 +94,10 @@ pub fn build_disclosure_inputs(
     let mut notes = Vec::with_capacity(req.selected_commitments.len());
     for commitment in &req.selected_commitments {
         let (amount, blinding, leaf_index) = storage
-            .get_unspent_user_note_by_commitment(&req.pool_address, &req.user_address, commitment)?
+            .get_user_note_by_commitment(&req.pool_address, &req.user_address, commitment)?
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "unspent note not found for commitment {commitment} in pool {}",
+                    "note not found for commitment {commitment} in pool {}",
                     req.pool_address
                 )
             })?;

--- a/sdk/prover/src/encryption.rs
+++ b/sdk/prover/src/encryption.rs
@@ -295,14 +295,39 @@ pub fn decrypt_output_note(
 ///
 /// # Returns
 /// Encrypted data (120 bytes)
+/// Encrypt arbitrary-length `plaintext` to `recipient_pubkey` using the same
+/// scheme as note encryption (ephemeral X25519 + XSalsa20Poly1305). Intended
+/// for self-encryption of local artifacts (e.g. disclosure receipts) under the
+/// account's own encryption public key.
+pub fn encrypt_blob(recipient_pubkey: &EncryptionPublicKey, plaintext: &[u8]) -> Result<Vec<u8>> {
+    encrypt_ecies(&recipient_pubkey.0, plaintext)
+}
+
+/// Decrypt bytes produced by [`encrypt_blob`]. Unlike [`decrypt_note_data`]
+/// (which returns an empty vec when a scanned note is not ours), this errors on
+/// failure because the caller expects the blob to be its own.
+pub fn decrypt_blob(
+    recipient_privkey: &EncryptionPrivateKey,
+    ciphertext: &[u8],
+) -> Result<Vec<u8>> {
+    ecies_open(&recipient_privkey.0, ciphertext)
+}
+
 fn encrypt_note_data(recipient_pubkey_bytes: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {
-    if recipient_pubkey_bytes.len() != 32 {
-        return Err(anyhow!("Recipient public key must be 32 bytes"));
-    }
     if plaintext.len() != 48 {
         return Err(anyhow!(
             "Plaintext must be 48 bytes (16 amount + 32 blinding)"
         ));
+    }
+    encrypt_ecies(recipient_pubkey_bytes, plaintext)
+}
+
+/// Core ECIES seal over arbitrary-length plaintext:
+/// ephemeral X25519 + ECDH + XSalsa20Poly1305, packed as
+/// `[ephemeral_pubkey(32)][nonce(24)][ciphertext+tag]`.
+fn encrypt_ecies(recipient_pubkey_bytes: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {
+    if recipient_pubkey_bytes.len() != 32 {
+        return Err(anyhow!("Recipient public key must be 32 bytes"));
     }
 
     // Generate ephemeral secret key using getrandom directly
@@ -406,6 +431,40 @@ fn decrypt_note_data(private_key_bytes: &[u8], encrypted_data: &[u8]) -> Result<
     }
 }
 
+/// Core ECIES open matching [`encrypt_ecies`], returning the plaintext or an
+/// error. Mirrors [`decrypt_note_data`] but treats decryption failure as an
+/// error (the caller owns the ciphertext), and imposes no fixed plaintext size.
+fn ecies_open(private_key_bytes: &[u8], encrypted_data: &[u8]) -> Result<Vec<u8>> {
+    if private_key_bytes.len() != 32 {
+        return Err(anyhow!("Private key must be 32 bytes"));
+    }
+    if encrypted_data.len() < 56 {
+        return Err(anyhow!("Encrypted data too short"));
+    }
+
+    let ephemeral_pubkey = &encrypted_data[0..32];
+    let nonce_bytes = &encrypted_data[32..56];
+    let ciphertext_with_tag = &encrypted_data[56..];
+
+    let our_secret = StaticSecret::from(
+        *<&[u8; 32]>::try_from(private_key_bytes).map_err(|_| anyhow!("Invalid private key"))?,
+    );
+    let ephemeral_public = PublicKey::from(
+        *<&[u8; 32]>::try_from(ephemeral_pubkey)
+            .map_err(|_| anyhow!("Invalid ephemeral public key"))?,
+    );
+    let shared_secret = our_secret.diffie_hellman(&ephemeral_public);
+    let cipher = XSalsa20Poly1305::new(shared_secret.as_bytes().into());
+
+    let mut nonce_array = [0u8; 24];
+    nonce_array.copy_from_slice(nonce_bytes);
+    let nonce = Nonce::from(nonce_array);
+
+    cipher
+        .decrypt(&nonce, ciphertext_with_tag)
+        .map_err(|_| anyhow!("blob decryption failed"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -475,6 +534,41 @@ mod tests {
 
         let decrypted = decrypt_note_data(priv_key, &encrypted).expect("Decryption failed");
         assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn test_encrypt_blob_roundtrip_arbitrary_length() {
+        let (_note, enc) =
+            derive_encryption_and_note_keypairs(KeyDerivationSignature(vec![9u8; 64]))
+                .expect("derivation failed");
+
+        // Arbitrary-length payload (not the 48-byte note framing).
+        let plaintext = br#"{"version":1,"purpose":"KYC for Exchange X","amounts":["550000000"]}"#;
+
+        let ciphertext = encrypt_blob(&enc.public, plaintext).expect("encrypt_blob failed");
+        assert_ne!(
+            &ciphertext[..],
+            &plaintext[..],
+            "ciphertext must differ from plaintext"
+        );
+
+        let recovered = decrypt_blob(&enc.private, &ciphertext).expect("decrypt_blob failed");
+        assert_eq!(recovered, plaintext);
+    }
+
+    #[test]
+    fn test_decrypt_blob_wrong_key_errors() {
+        let (_a_note, alice) =
+            derive_encryption_and_note_keypairs(KeyDerivationSignature(vec![3u8; 64]))
+                .expect("derivation failed");
+        let (_b_note, bob) =
+            derive_encryption_and_note_keypairs(KeyDerivationSignature(vec![4u8; 64]))
+                .expect("derivation failed");
+
+        let ciphertext =
+            encrypt_blob(&alice.public, b"secret receipt bytes").expect("encrypt_blob failed");
+        // Unlike note scanning, a blob addressed to us must ERROR on the wrong key.
+        assert!(decrypt_blob(&bob.private, &ciphertext).is_err());
     }
 
     #[test]

--- a/sdk/state/src/storage.rs
+++ b/sdk/state/src/storage.rs
@@ -16,12 +16,34 @@ use types::{
 const DB_NAME: &str = "poolstellar.sqlite";
 pub const APP_SETTING_BOOTNODE_CONFIG: &str = "bootnode_config";
 pub const APP_SETTING_EXPLORER: &str = "explorer";
+pub const APP_SETTING_STORE_RECEIPTS: &str = "store_receipts";
 
-const MIGRATION_ARRAY: &[M] = &[M::up(include_str!("schema.sql"))];
+const MIGRATION_ARRAY: &[M] = &[
+    M::up(include_str!("schema.sql")),
+    M::up(
+        "CREATE TABLE disclosure_receipts (
+            id TEXT PRIMARY KEY,
+            account_id INTEGER NOT NULL REFERENCES accounts(id),
+            ciphertext BLOB NOT NULL,
+            created_at TEXT NOT NULL
+        );
+        CREATE INDEX idx_disclosure_receipts_account
+            ON disclosure_receipts(account_id, created_at);",
+    ),
+];
 const MIGRATIONS: Migrations = Migrations::from_slice(MIGRATION_ARRAY);
 
 pub struct Storage {
     conn: Connection,
+}
+
+/// A stored disclosure receipt row. `ciphertext` is opaque to this layer — the
+/// storage worker encrypts/decrypts it under the account's encryption keypair.
+#[derive(Debug, Clone)]
+pub struct StoredReceiptRow {
+    pub id: String,
+    pub ciphertext: Vec<u8>,
+    pub created_at: String,
 }
 
 #[derive(Debug, Clone)]
@@ -380,6 +402,84 @@ impl Storage {
                 url: url.to_string(),
             },
         )
+    }
+
+    /// Whether generated disclosure receipts should be persisted locally.
+    /// Opt-in: defaults to false when the setting has never been written.
+    pub fn get_store_receipts_setting(&self) -> Result<bool> {
+        Ok(self
+            .get_setting_json(APP_SETTING_STORE_RECEIPTS)?
+            .unwrap_or(false))
+    }
+
+    pub fn set_store_receipts_setting(&mut self, enabled: bool) -> Result<()> {
+        self.set_setting_json(APP_SETTING_STORE_RECEIPTS, &enabled)
+    }
+
+    /// Persist an already-encrypted disclosure receipt for `address`.
+    /// `id` is an opaque content hash; `ciphertext` is opaque to this layer.
+    pub fn save_disclosure_receipt(
+        &mut self,
+        address: &str,
+        id: &str,
+        ciphertext: &[u8],
+        created_at: &str,
+    ) -> Result<()> {
+        let tx = self.conn.transaction()?;
+        let account_id = Self::get_or_create_account(&tx, address)?;
+        tx.execute(
+            "INSERT OR REPLACE INTO disclosure_receipts (id, account_id, ciphertext, created_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![id, account_id, ciphertext, created_at],
+        )
+        .context("failed to insert disclosure receipt")?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// List stored (encrypted) disclosure receipts for `address`, newest first.
+    pub fn list_disclosure_receipts(&self, address: &str) -> Result<Vec<StoredReceiptRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT r.id, r.ciphertext, r.created_at
+             FROM disclosure_receipts r
+             JOIN accounts a ON a.id = r.account_id
+             WHERE a.address = ?1
+             ORDER BY r.created_at DESC, r.id DESC",
+        )?;
+        let rows = stmt
+            .query_map(params![address], |row| {
+                Ok(StoredReceiptRow {
+                    id: row.get(0)?,
+                    ciphertext: row.get(1)?,
+                    created_at: row.get(2)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .context("failed to read disclosure receipts")?;
+        Ok(rows)
+    }
+
+    pub fn delete_disclosure_receipt(&mut self, address: &str, id: &str) -> Result<()> {
+        self.conn
+            .execute(
+                "DELETE FROM disclosure_receipts
+                 WHERE id = ?1
+                   AND account_id = (SELECT id FROM accounts WHERE address = ?2)",
+                params![id, address],
+            )
+            .context("failed to delete disclosure receipt")?;
+        Ok(())
+    }
+
+    pub fn clear_disclosure_receipts(&mut self, address: &str) -> Result<()> {
+        self.conn
+            .execute(
+                "DELETE FROM disclosure_receipts
+                 WHERE account_id = (SELECT id FROM accounts WHERE address = ?1)",
+                params![address],
+            )
+            .context("failed to clear disclosure receipts")?;
+        Ok(())
     }
 
     /// Internal helper to handle the "Get or Create" logic for accounts
@@ -2640,6 +2740,41 @@ mod tests {
             .get_pool_commitment_leaves_ordered("CPOOL")
             .expect_err("gap should error");
         assert!(err.to_string().contains("gap/out-of-order"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn disclosure_receipts_persist_list_delete_clear() -> Result<()> {
+        let mut storage = Storage::connect_in_memory()?;
+
+        // Opt-in defaults to false, then round-trips.
+        assert!(!storage.get_store_receipts_setting()?);
+        storage.set_store_receipts_setting(true)?;
+        assert!(storage.get_store_receipts_setting()?);
+
+        storage.save_disclosure_receipt("GA", "id1", b"ct1", "2026-07-10T00:00:01Z")?;
+        storage.save_disclosure_receipt("GA", "id2", b"ct2", "2026-07-10T00:00:02Z")?;
+        storage.save_disclosure_receipt("GB", "id3", b"ct3", "2026-07-10T00:00:03Z")?;
+
+        // Newest-first, opaque ciphertext preserved, per-account isolation.
+        let ga = storage.list_disclosure_receipts("GA")?;
+        assert_eq!(ga.len(), 2);
+        assert_eq!(ga[0].id, "id2");
+        assert_eq!(ga[0].ciphertext, b"ct2");
+        assert_eq!(ga[1].id, "id1");
+        assert_eq!(storage.list_disclosure_receipts("GB")?.len(), 1);
+
+        // Delete is scoped by account.
+        storage.delete_disclosure_receipt("GA", "id3")?; // wrong account => no-op
+        assert_eq!(storage.list_disclosure_receipts("GB")?.len(), 1);
+        storage.delete_disclosure_receipt("GA", "id1")?;
+        assert_eq!(storage.list_disclosure_receipts("GA")?.len(), 1);
+
+        // Clear only affects the target account.
+        storage.clear_disclosure_receipts("GA")?;
+        assert!(storage.list_disclosure_receipts("GA")?.is_empty());
+        assert_eq!(storage.list_disclosure_receipts("GB")?.len(), 1);
 
         Ok(())
     }

--- a/sdk/state/src/storage.rs
+++ b/sdk/state/src/storage.rs
@@ -840,6 +840,51 @@ impl Storage {
         Ok(row)
     }
 
+    /// Like [`Self::get_unspent_user_note_by_commitment`], but returns the note
+    /// regardless of spent status.
+    ///
+    /// Selective disclosure proves Merkle membership of a commitment; spending
+    /// a note publishes a nullifier but does not remove its commitment leaf
+    /// from the tree, so a spent note can still be disclosed. Use this
+    /// lookup on the disclosure input-building path. The transact path must
+    /// keep using [`Self::get_unspent_user_note_by_commitment`], which
+    /// excludes spent notes.
+    pub fn get_user_note_by_commitment(
+        &self,
+        pool_contract_id: &str,
+        account_address: &str,
+        commitment: &Field,
+    ) -> Result<Option<(NoteAmount, Field, u32)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT n.amount, n.blinding, pc.leaf_index
+             FROM user_notes n
+             JOIN accounts a ON a.id = n.account_id
+             JOIN pool_commitments pc ON pc.id = n.commitment_id
+             JOIN raw_contract_events r ON r.id = pc.event_id
+             JOIN contracts c ON c.contract_id = r.contract_id
+             WHERE a.address = ?2
+               AND c.address = ?1
+               AND pc.commitment = ?3
+             LIMIT 1",
+        )?;
+
+        let row = stmt
+            .query_row(
+                params![pool_contract_id, account_address, commitment],
+                |row| {
+                    let amount: NoteAmount = row.get(0)?;
+                    let blinding: Field = row.get(1)?;
+                    let leaf_index_i64: i64 = row.get(2)?;
+                    let leaf_index = col_u32(leaf_index_i64, 2)?;
+                    Ok((amount, blinding, leaf_index))
+                },
+            )
+            .optional()
+            .context("Failed to query user note by commitment")?;
+
+        Ok(row)
+    }
+
     /// Batch upsert for spent nullifiers
     pub fn save_nullifier_events_batch(&mut self, events: &Vec<NewNullifierEvent>) -> Result<()> {
         let tx = self.conn.transaction()?;
@@ -2330,6 +2375,189 @@ mod tests {
             &wrong_commitment,
         )?;
         assert!(result.is_none(), "wrong commitment should not match");
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_user_note_by_commitment_finds_unspent_note() -> Result<()> {
+        let mut storage = Storage::connect_in_memory()?;
+
+        let sig = KeyDerivationSignature(vec![1u8; 64]);
+        let (note_keypair, enc_keypair) =
+            encryption::derive_encryption_and_note_keypairs(sig.clone())?;
+        let membership_blinding = encryption::derive_membership_blinding(&sig, "testnet")?;
+        storage.save_encryption_and_note_keypairs(
+            "GTESTACCOUNT",
+            &note_keypair,
+            &enc_keypair,
+            &membership_blinding,
+        )?;
+
+        let amount = NoteAmount::from(5);
+        let mut blinding_le = [0u8; 32];
+        blinding_le[0] = 7;
+        let blinding = Field::try_from_le_bytes(blinding_le)?;
+
+        let amount_field_le = Field::from(amount).to_le_bytes();
+        let commitment_le = crypto::compute_commitment(
+            &amount_field_le,
+            note_keypair.public.as_ref(),
+            &blinding.to_le_bytes(),
+        )?;
+        let commitment_le: [u8; 32] = commitment_le.try_into().map_err(|v: Vec<u8>| {
+            anyhow::anyhow!("commitment: expected 32 bytes, got {}", v.len())
+        })?;
+        let commitment = Field::try_from_le_bytes(commitment_le)?;
+
+        let encrypted_output =
+            encryption::encrypt_output_note(&enc_keypair.public, amount, &blinding)?;
+
+        storage.save_events_batch(&ContractsEventData {
+            events: vec![dummy_event("evt-commit")],
+            cursor: "cur".to_string(),
+            latest_ledger: 1,
+        })?;
+        storage.save_commitment_events_batch(&vec![NewCommitmentEvent {
+            id: "evt-commit".to_string(),
+            commitment,
+            index: 3,
+            encrypted_output: encrypted_output.clone(),
+        }])?;
+
+        let mut derive = |account: &AccountKeys,
+                          row: &PoolCommitmentRow|
+         -> Result<Option<DerivedUserNoteRow>> {
+            let opt = prover::notes::try_decrypt_and_derive_user_note(
+                &account.note_keypair,
+                &account.encryption_keypair.private,
+                &row.commitment,
+                row.leaf_index,
+                &row.encrypted_output,
+            )?;
+            Ok(opt.map(|d| DerivedUserNoteRow {
+                amount: d.amount,
+                blinding: d.blinding,
+                expected_nullifier: d.expected_nullifier,
+            }))
+        };
+        assert!(storage.scan_commitments_for_user_notes(100, &mut derive)?);
+
+        let result = storage.get_user_note_by_commitment("CPOOL", "GTESTACCOUNT", &commitment)?;
+        assert!(result.is_some());
+        let (got_amount, got_blinding, got_leaf_index) = result.expect("just checked is_some");
+        assert_eq!(got_amount, amount);
+        assert_eq!(got_blinding, blinding);
+        assert_eq!(got_leaf_index, 3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_user_note_by_commitment_finds_spent_note() -> Result<()> {
+        let mut storage = Storage::connect_in_memory()?;
+
+        let sig = KeyDerivationSignature(vec![1u8; 64]);
+        let (note_keypair, enc_keypair) =
+            encryption::derive_encryption_and_note_keypairs(sig.clone())?;
+        let membership_blinding = encryption::derive_membership_blinding(&sig, "testnet")?;
+        storage.save_encryption_and_note_keypairs(
+            "GTESTACCOUNT",
+            &note_keypair,
+            &enc_keypair,
+            &membership_blinding,
+        )?;
+
+        let amount = NoteAmount::from(5);
+        let mut blinding_le = [0u8; 32];
+        blinding_le[0] = 7;
+        let blinding = Field::try_from_le_bytes(blinding_le)?;
+
+        let amount_field_le = Field::from(amount).to_le_bytes();
+        let commitment_le = crypto::compute_commitment(
+            &amount_field_le,
+            note_keypair.public.as_ref(),
+            &blinding.to_le_bytes(),
+        )?;
+        let commitment_le: [u8; 32] = commitment_le.try_into().map_err(|v: Vec<u8>| {
+            anyhow::anyhow!("commitment: expected 32 bytes, got {}", v.len())
+        })?;
+        let commitment = Field::try_from_le_bytes(commitment_le)?;
+
+        let encrypted_output =
+            encryption::encrypt_output_note(&enc_keypair.public, amount, &blinding)?;
+
+        storage.save_events_batch(&ContractsEventData {
+            events: vec![dummy_event("evt-commit")],
+            cursor: "cur".to_string(),
+            latest_ledger: 1,
+        })?;
+        storage.save_commitment_events_batch(&vec![NewCommitmentEvent {
+            id: "evt-commit".to_string(),
+            commitment,
+            index: 3,
+            encrypted_output: encrypted_output.clone(),
+        }])?;
+
+        let mut derive = |account: &AccountKeys,
+                          row: &PoolCommitmentRow|
+         -> Result<Option<DerivedUserNoteRow>> {
+            let opt = prover::notes::try_decrypt_and_derive_user_note(
+                &account.note_keypair,
+                &account.encryption_keypair.private,
+                &row.commitment,
+                row.leaf_index,
+                &row.encrypted_output,
+            )?;
+            Ok(opt.map(|d| DerivedUserNoteRow {
+                amount: d.amount,
+                blinding: d.blinding,
+                expected_nullifier: d.expected_nullifier,
+            }))
+        };
+        storage.scan_commitments_for_user_notes(100, &mut derive)?;
+
+        // Spend the note via nullifier.
+        let leaf_index: u32 = 3;
+        let mut path_indices_le = [0u8; 32];
+        path_indices_le[..8].copy_from_slice(&(u64::from(leaf_index)).to_le_bytes());
+        let signature = crypto::compute_signature(
+            &note_keypair.private.0,
+            &commitment.to_le_bytes(),
+            &path_indices_le,
+        )?;
+        let nullifier_le =
+            crypto::compute_nullifier(&commitment.to_le_bytes(), &path_indices_le, &signature)?;
+        let nullifier_le: [u8; 32] = nullifier_le.try_into().map_err(|v: Vec<u8>| {
+            anyhow::anyhow!("nullifier: expected 32 bytes, got {}", v.len())
+        })?;
+        let nullifier = Field::try_from_le_bytes(nullifier_le)?;
+
+        storage.save_events_batch(&ContractsEventData {
+            events: vec![dummy_event("evt-null")],
+            cursor: "cur2".to_string(),
+            latest_ledger: 1,
+        })?;
+        storage.save_nullifier_events_batch(&vec![NewNullifierEvent {
+            id: "evt-null".to_string(),
+            nullifier,
+        }])?;
+        storage.reconcile_nullifiers(100)?;
+
+        // The unspent-only lookup rejects it, but the spent-tolerant lookup returns it.
+        assert!(
+            storage
+                .get_unspent_user_note_by_commitment("CPOOL", "GTESTACCOUNT", &commitment)?
+                .is_none(),
+            "sanity: note is spent"
+        );
+
+        let result = storage.get_user_note_by_commitment("CPOOL", "GTESTACCOUNT", &commitment)?;
+        assert!(result.is_some(), "spent note should still be returned");
+        let (got_amount, got_blinding, got_leaf_index) = result.expect("just checked is_some");
+        assert_eq!(got_amount, amount);
+        assert_eq!(got_blinding, blinding);
+        assert_eq!(got_leaf_index, 3);
 
         Ok(())
     }

--- a/sdk/web/src/protocol.rs
+++ b/sdk/web/src/protocol.rs
@@ -49,6 +49,16 @@ pub struct DisclaimerStatePayload {
     pub accepted: bool,
 }
 
+/// A stored disclosure receipt returned to the UI: opaque `id`, `created_at`,
+/// and the decrypted receipt JSON (decrypted inside the worker).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StoredDisclosureReceipt {
+    pub id: String,
+    pub created_at: String,
+    pub receipt_json: String,
+}
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Serialize, Deserialize)]
 pub enum StorageWorkerRequest {
@@ -106,6 +116,19 @@ pub enum StorageWorkerRequest {
     DisclosureInputs(DisclosureInputsRequest),
     Transact(TransactRequest),
     DeriveASPleaf(AdminASPRequest),
+    SaveDisclosureReceipt {
+        address: Address,
+        receipt_json: String,
+        created_at: String,
+    },
+    ListDisclosureReceipts(Address),
+    DeleteDisclosureReceipt {
+        address: Address,
+        id: String,
+    },
+    ClearDisclosureReceipts(Address),
+    GetStoreReceiptsSetting,
+    SetStoreReceiptsSetting(bool),
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -128,6 +151,9 @@ pub enum StorageWorkerResponse {
     DisclosureNotes(Vec<DisclosureInputs>),
     TransactParams(TransactParams),
     DeriveASPleaf(Field),
+    DisclosureReceiptSaved(String),
+    DisclosureReceipts(Vec<StoredDisclosureReceipt>),
+    StoreReceiptsSetting(bool),
 }
 
 #[allow(clippy::large_enum_variant)]

--- a/sdk/web/src/workers/storage.rs
+++ b/sdk/web/src/workers/storage.rs
@@ -1,7 +1,7 @@
 use crate::protocol::{
     AdminASPRequest, AspSecret, DisclaimerStatePayload, DisclosureInputs, DisclosureInputsRequest,
     PublicEncryptionKeyPair, PublicNoteKeyPair, StorageWorkerRequest, StorageWorkerResponse,
-    UserKeys,
+    StoredDisclosureReceipt, UserKeys,
 };
 use anyhow::{Result, anyhow};
 use futures::{FutureExt, channel::mpsc, stream::StreamExt};
@@ -18,7 +18,10 @@ use stellar_private_payments_sdk::{
     state::{SqliteStorage, StoredUserKeys, process_local_state_batch},
     tx::{
         crypto::asp_membership_leaf,
-        encryption::{derive_encryption_and_note_keypairs, derive_membership_blinding},
+        encryption::{
+            decrypt_blob, derive_encryption_and_note_keypairs, derive_membership_blinding,
+            encrypt_blob,
+        },
         flows::TransactParams,
     },
     types::{
@@ -34,6 +37,18 @@ use wasm_bindgen_futures::spawn_local;
 // wasm threads?
 
 const WORKER_NAME: &str = "WORKER-STORAGE";
+
+/// Content hash used as the opaque primary key for a stored disclosure receipt.
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    use std::fmt::Write as _;
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(64);
+    for b in digest {
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
 
 #[derive(Clone, Debug)]
 enum InitState {
@@ -294,6 +309,52 @@ pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerRes
                 list.len()
             );
             StorageWorkerResponse::UserNotes(list)
+        }
+        StorageWorkerRequest::SaveDisclosureReceipt {
+            address,
+            receipt_json,
+            created_at,
+        } => {
+            let keys = with_storage!(s => s.get_user_keys(&address)?)?
+                .ok_or_else(|| anyhow!("user keys not found for {address}"))?;
+            let id = sha256_hex(receipt_json.as_bytes());
+            let ciphertext =
+                encrypt_blob(&keys.encryption_keypair.public, receipt_json.as_bytes())?;
+            with_storage_mut!(s => s.save_disclosure_receipt(&address, &id, &ciphertext, &created_at)?)?;
+            StorageWorkerResponse::DisclosureReceiptSaved(id)
+        }
+        StorageWorkerRequest::ListDisclosureReceipts(address) => {
+            let keys = with_storage!(s => s.get_user_keys(&address)?)?
+                .ok_or_else(|| anyhow!("user keys not found for {address}"))?;
+            let rows = with_storage!(s => s.list_disclosure_receipts(&address)?)?;
+            let mut out = Vec::with_capacity(rows.len());
+            for row in rows {
+                let bytes = decrypt_blob(&keys.encryption_keypair.private, &row.ciphertext)?;
+                let receipt_json = String::from_utf8(bytes)
+                    .map_err(|e| anyhow!("stored receipt is not valid UTF-8: {e}"))?;
+                out.push(StoredDisclosureReceipt {
+                    id: row.id,
+                    created_at: row.created_at,
+                    receipt_json,
+                });
+            }
+            StorageWorkerResponse::DisclosureReceipts(out)
+        }
+        StorageWorkerRequest::DeleteDisclosureReceipt { address, id } => {
+            with_storage_mut!(s => s.delete_disclosure_receipt(&address, &id)?)?;
+            StorageWorkerResponse::Saved
+        }
+        StorageWorkerRequest::ClearDisclosureReceipts(address) => {
+            with_storage_mut!(s => s.clear_disclosure_receipts(&address)?)?;
+            StorageWorkerResponse::Saved
+        }
+        StorageWorkerRequest::GetStoreReceiptsSetting => {
+            let enabled = with_storage!(s => s.get_store_receipts_setting()?)?;
+            StorageWorkerResponse::StoreReceiptsSetting(enabled)
+        }
+        StorageWorkerRequest::SetStoreReceiptsSetting(enabled) => {
+            with_storage_mut!(s => s.set_store_receipts_setting(enabled)?)?;
+            StorageWorkerResponse::StoreReceiptsSetting(enabled)
         }
         StorageWorkerRequest::PortfolioBalances(address) => {
             log::trace!("[{WORKER_NAME}] list portfolio balances for the account {address}");


### PR DESCRIPTION
# Optionally store generated disclosure receipts

This PR introduces an opt-in history feature allowing users to store and manage their generated selective disclosure receipts locally in the application database. Stored receipts are encrypted under the user's own encryption keypair using ECIES, ensuring that sensitive financial disclosures remain confidential while enabling easy auditing, downloading, and verification.

