### PR TITLE
ci(bootnode): add JFrog dev push workflow, scope Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,33 @@
+# Deny everything by default: the only Dockerfile in this repo (tools/bootnode)
+# only needs its own crate + sdk/types (its one path dependency, per
+# tools/bootnode/Cargo.toml) + the compiled-in testnet deployment config.
+# Everything else at the repo root (circuits, contracts, app, cli, e2e-tests,
+# ceremony keys, docs, vendor, root Cargo workspace, ...) is unrelated to its
+# build (tools/bootnode is excluded from the root Cargo workspace).
+*
+
+!Cargo.toml
+!Cargo.lock
+
+!tools
+tools/*
+!tools/bootnode
+
+!sdk
+sdk/*
+!sdk/types
+
+!deployments
+deployments/*
+!deployments/testnet
+deployments/testnet/*
+!deployments/testnet/deployments.json
+
+# Re-exclude local junk/build artifacts that may exist inside the allowed trees
 .git
 .github
 **/.env
-.env
-.env.*
-
+**/.env.*
 **/target
 **/node_modules
 **/dist

--- a/.github/workflows/bootnode-push-jfrog-dev.yml
+++ b/.github/workflows/bootnode-push-jfrog-dev.yml
@@ -1,0 +1,40 @@
+name: Bootnode push to JFrog (dev)
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "tools/bootnode/**"
+      - "sdk/types/**"
+      - "deployments/testnet/deployments.json"
+      - ".github/workflows/bootnode-push-jfrog-dev.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "tools/bootnode/**"
+      - "sdk/types/**"
+      - "deployments/testnet/deployments.json"
+      - ".github/workflows/bootnode-push-jfrog-dev.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  attestations: write
+  artifact-metadata: write
+  contents: read
+
+jobs:
+  push-bootnode:
+    uses: NethermindEth/github-workflows/.github/workflows/docker-build-push-jfrog.yaml@77a6b36410ca0a5e9ae2cb5d387e5b34d6f639ef
+    with:
+      repo_name: research-oci-local-dev
+      image_name: bootnode
+      runner: ubuntu-24.04-arm
+      platforms: "linux/arm64"
+      context: .
+      dockerfile_path: ./tools/bootnode/Dockerfile
+      push: ${{ github.event_name != 'pull_request' }}

--- a/tools/bootnode/Dockerfile
+++ b/tools/bootnode/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.87-bookworm AS builder
+FROM rust:1.92-bookworm AS builder
 
 WORKDIR /workspace
 COPY . .


### PR DESCRIPTION
### Description

This PR adds a CI workflow to automatically build and push the Bootnode Docker image to JFrog Artifactory when changes are merged into `main`. It also optimizes the Docker build context by updating `.dockerignore` so that only the files required by Bootnode are included during the build.

### Changes

**CI Workflow (`bootnode-push-jfrog-dev.yml`)**
* Builds the image from `tools/bootnode/Dockerfile` for the `linux/arm64` platform using a native ARM runner.
* Pushes the image to `nethermind.jfrog.io/research-oci-local-dev/bootnode` using OIDC authentication.
* Runs only when relevant files change under:
  * `tools/bootnode/**`
  * `sdk/types/**`
  * `deployments/testnet/deployments.json`
* For pull requests, the workflow performs a build and Trivy scan but does not push the image.
**Docker Build Context Optimization (`.dockerignore`)**
* Switched to a deny-by-default allowlist approach.
* Includes only:
  * `tools/bootnode`
  * `sdk/types` (Bootnode's only path dependency)
  * Root `Cargo.toml`
  * Root `Cargo.lock`
  * `deployments/testnet/deployments.json`
* Excludes unrelated directories such as `circuits`, `contracts`, `app`, `cli`, `e2e-tests`, `circuit-keys`, `vendor`, and `docs`, which are not required for the Bootnode build.

