### PR TITLE
fix(bootnode): exempt /healthz and /metrics from RPC rate limiting

### DIFF
--- a/tools/bootnode/src/http_server.rs
+++ b/tools/bootnode/src/http_server.rs
@@ -60,7 +60,12 @@ impl HttpServer {
         let router = Router::new()
             .route("/healthz", get(healthz))
             .route("/metrics", get(metrics))
-            .route("/", post(handle_rpc))
+            .route(
+                "/",
+                post(handle_rpc).layer(GovernorLayer {
+                    config: Arc::new(governor_conf),
+                }),
+            )
             .with_state(RpcState {
                 app: state.clone(),
                 rpc: rpc_svc,
@@ -68,9 +73,6 @@ impl HttpServer {
             .layer(axum::extract::DefaultBodyLimit::max(1024 * 1024))
             .layer(cors)
             .layer(TraceLayer::new_for_http())
-            .layer(GovernorLayer {
-                config: Arc::new(governor_conf),
-            })
             .layer(SetResponseHeaderLayer::overriding(
                 header::X_CONTENT_TYPE_OPTIONS,
                 HeaderValue::from_static("nosniff"),


### PR DESCRIPTION
## Description
`GovernorLayer` was applied router-wide, so `/healthz` and `/metrics`shared the same rate-limit budget as the public `/` RPC route. Any burst of real RPC traffic (or even a modest test loop) could exhaust the shared bucket and start 429ing kubelet's probes, causing CrashLoopBackOff.

## Changes
- Scope `GovernorLayer` to only the `/` route instead of the whole router
- `/healthz` and `/metrics` are now never subject to rate limiting, regardless of RPC load