### PR TITLE
docs+tests: document privacy trade-offs and pin event shapes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -290,3 +290,16 @@ To make a production release of CLI
 git tag v0.1.0 # with a proper new version
 git push origin v0.1.0
 ```
+
+## Instrumentation & Logging Guidelines
+
+All contributions to the SDK must adhere to the following telemetry and instrumentation guidelines to prevent credential/key leaks:
+
+### 1. Instrumentation House Rules
+* Always use `#[tracing::instrument(skip_all, fields(...))]` on public functions or functions processing transaction requests.
+* Do not log parameters by default; instead, explicitly list only **non-sensitive** fields in the `fields(...)` allowlist of the macro.
+* Wrap all **Tier-1** parameters (such as amounts, recipient/sender addresses, note commitments, nullifiers, and public keys) inside the `types::Sensitive(value)` wrapper when logging or recording them inside spans.
+
+### 2. Tier Classification
+* **Tier-0 (Private/Secret)**: Private keys, seeds, signatures, circuit witness arrays, and membership blinding factors. **Strictly forbidden from being formatted or logged.** Do not wrap them; keep them out of logs completely.
+* **Tier-1 (Sensitive/Redactable)**: Stellar addresses, token amounts, commitments, and nullifiers. **Must be wrapped in `types::Sensitive`.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,3 +303,19 @@ All contributions to the SDK must adhere to the following telemetry and instrume
 ### 2. Tier Classification
 * **Tier-0 (Private/Secret)**: Private keys, seeds, signatures, circuit witness arrays, and membership blinding factors. **Strictly forbidden from being formatted or logged.** Do not wrap them; keep them out of logs completely.
 * **Tier-1 (Sensitive/Redactable)**: Stellar addresses, token amounts, commitments, and nullifiers. **Must be wrapped in `types::Sensitive`.**
+
+See [SECURITY.md](SECURITY.md) § "Logging Security & Privacy Model" for the full two-tier model and its invariants.
+
+### 3. Correlation IDs
+* Every instrumented boundary/operation function includes `correlation_id = %types::correlation_id_or_new()` in its `fields(...)`. It inherits the ambient id when nested and mints one at operation roots — never call `new_correlation_id()` directly.
+* CLI commands open a root span (`info_span!("cmd_*", correlation_id = ...)`) so SDK calls inherit the id.
+
+### 4. Timing & Durations
+* SDK crates (must stay wasm-compatible): use `web_time::Instant`. Native-only crates (e.g. `cli`): use `std::time::Instant`.
+* Time genuinely expensive operations only (proving, witness computation, key deserialization, external processes). Emit `elapsed_ms` at `debug!` level, on **both** success and error exits of the expensive section (capture the result, log, then `?`).
+* Use `u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX)` — the workspace denies `clippy::cast_possible_truncation`.
+
+### 5. Levels & Payloads
+* Boundary spans at `info`; internal "started" breadcrumbs and durations at `debug`; verbose detail at `trace`; fallback/degraded paths at `warn`; hard failures at `error`.
+* External process boundaries (e.g. shelling out to `stellar`): an `info!` breadcrumb **before** spawn (this is the hang diagnostic), outcome + duration **after** exit.
+* Large or secret byte payloads (proving keys, witnesses, R1CS, XDR): log **lengths only**, never contents.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,6 +1862,8 @@ dependencies = [
  "hex",
  "prover",
  "sha2 0.11.0",
+ "tracing",
+ "tracing-subscriber",
  "types",
 ]
 
@@ -3309,6 +3311,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3941,6 +3952,8 @@ dependencies = [
  "getrandom 0.2.17",
  "serde",
  "sha2 0.11.0",
+ "tracing",
+ "tracing-subscriber",
  "types",
  "x25519-dalek",
  "zkhash",
@@ -4585,6 +4598,8 @@ dependencies = [
  "rusqlite",
  "serde_json",
  "stellar-private-payments-sdk",
+ "tracing",
+ "tracing-subscriber",
  "types",
 ]
 
@@ -5166,6 +5181,8 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "stellar",
+ "tracing",
+ "tracing-subscriber",
  "types",
 ]
 
@@ -5200,6 +5217,8 @@ dependencies = [
  "stellar-strkey 0.0.16",
  "stellar-xdr",
  "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
  "types",
  "wasm-bindgen-test",
 ]
@@ -5217,6 +5236,8 @@ dependencies = [
  "serde_json",
  "stellar-private-payments-sdk",
  "toml",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5228,8 +5249,8 @@ dependencies = [
  "disclosure",
  "futures",
  "futures-timer",
+ "getrandom 0.2.17",
  "gloo-timers",
- "log",
  "prover",
  "serde",
  "serde_json",
@@ -5237,6 +5258,8 @@ dependencies = [
  "stellar",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "tx-planner",
  "types",
  "wiremock",
@@ -5252,6 +5275,7 @@ dependencies = [
  "base64",
  "console_error_panic_hook",
  "futures",
+ "getrandom 0.2.17",
  "gloo-timers",
  "gloo-worker",
  "js-sys",
@@ -5263,6 +5287,9 @@ dependencies = [
  "sqlite-wasm-rs",
  "sqlite-wasm-vfs",
  "stellar-private-payments-sdk",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
  "types",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -5714,6 +5741,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5762,17 +5790,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -5792,6 +5837,8 @@ name = "tx-planner"
 version = "0.1.0"
 dependencies = [
  "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
  "types",
 ]
 
@@ -5816,11 +5863,15 @@ name = "types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "getrandom 0.2.17",
  "hex",
  "rusqlite",
  "serde",
  "serde_json",
+ "tracing",
+ "tracing-subscriber",
  "uint",
+ "zeroize",
 ]
 
 [[package]]
@@ -6589,6 +6640,8 @@ dependencies = [
  "ark-circom",
  "num-bigint",
  "serde_json",
+ "tracing",
+ "tracing-subscriber",
  "wasmer",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,8 +1863,8 @@ dependencies = [
  "prover",
  "sha2 0.11.0",
  "tracing",
- "tracing-subscriber",
  "types",
+ "web-time",
 ]
 
 [[package]]
@@ -3953,8 +3953,8 @@ dependencies = [
  "serde",
  "sha2 0.11.0",
  "tracing",
- "tracing-subscriber",
  "types",
+ "web-time",
  "x25519-dalek",
  "zkhash",
 ]
@@ -5119,9 +5119,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"
@@ -5173,7 +5173,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "hex",
- "log",
  "prover",
  "rusqlite",
  "rusqlite_migration",
@@ -5182,7 +5181,6 @@ dependencies = [
  "sha2 0.11.0",
  "stellar",
  "tracing",
- "tracing-subscriber",
  "types",
 ]
 
@@ -5204,7 +5202,6 @@ dependencies = [
  "futures",
  "gloo-timers",
  "http",
- "log",
  "pool",
  "public-key-registry",
  "reqwest",
@@ -5218,7 +5215,6 @@ dependencies = [
  "stellar-xdr",
  "thiserror 2.0.18",
  "tracing",
- "tracing-subscriber",
  "types",
  "wasm-bindgen-test",
 ]
@@ -5236,8 +5232,10 @@ dependencies = [
  "serde_json",
  "stellar-private-payments-sdk",
  "toml",
+ "tracing",
  "tracing-log",
  "tracing-subscriber",
+ "types",
 ]
 
 [[package]]
@@ -5249,7 +5247,6 @@ dependencies = [
  "disclosure",
  "futures",
  "futures-timer",
- "getrandom 0.2.17",
  "gloo-timers",
  "prover",
  "serde",
@@ -5259,7 +5256,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "tx-planner",
  "types",
  "wiremock",
@@ -5275,11 +5271,9 @@ dependencies = [
  "base64",
  "console_error_panic_hook",
  "futures",
- "getrandom 0.2.17",
  "gloo-timers",
  "gloo-worker",
  "js-sys",
- "log",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -5287,14 +5281,13 @@ dependencies = [
  "sqlite-wasm-rs",
  "sqlite-wasm-vfs",
  "stellar-private-payments-sdk",
+ "tokio",
  "tracing",
- "tracing-log",
  "tracing-subscriber",
  "types",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
- "wasm-log",
  "web-sys",
 ]
 
@@ -5741,7 +5734,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5838,7 +5830,6 @@ version = "0.1.0"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
- "tracing-subscriber",
  "types",
 ]
 
@@ -6139,17 +6130,6 @@ checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.248.0",
-]
-
-[[package]]
-name = "wasm-log"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def95b2a762924804037f77e3de791f1c177d6ecbe0385a64e519bd7902a5f81"
-dependencies = [
- "log",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -6641,8 +6621,9 @@ dependencies = [
  "num-bigint",
  "serde_json",
  "tracing",
- "tracing-subscriber",
+ "types",
  "wasmer",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ clap = { version = "4.6.1", default-features = false, features = ["std", "color"
   "suggestions", "derive", "env"] }
 console_error_panic_hook = { version = "0.1.7", default-features = false }
 futures = { version = "0.3.32", default-features = false, features = ["async-await"] }
-getrandom = { version = "0.2", default-features = false }
+getrandom = { version = "0.2", default-features = false, features = ["js"] }
 gloo-timers = { version = "0.4", default-features = false, features = ["futures"] }
 gloo-worker = { version = "0.6", default-features = false, features = ["futures"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
@@ -92,13 +92,13 @@ uint = { version = "0.10", default-features = false }
 wasm-bindgen = { version = "0.2", default-features = false, features = ["serde-serialize"] }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
 wasm-bindgen-test = { version = "0.3", default-features = false, features = ["std"] }
-wasm-log = { version = "0.3", default-features = false }
-tracing = { version = "0.1", default-features = false, features = ["log", "std", "release_max_level_info"] }
+tracing = { version = "0.1", default-features = false, features = ["std", "release_max_level_info"] }
 tracing-log = { version = "0.2", default-features = false, features = ["log-tracer", "std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 # see also https://github.com/NethermindEth/stellar-private-payments/issues/192
 wasmer = { git = "https://github.com/wasmerio/wasmer", rev = "763e9f2800644f51ce27f6f5c1752776da16ddd1", shallow = true, default-features = false }
 web-sys = { version = "0.3", features = ["console", "WorkerGlobalScope", "Response", "Request", "RequestInit", "RequestMode", "Window", "Event", "Cache", "CacheStorage"] }
+web-time = "1"
 wiremock = "0.6"
 zeroize = { version = "1.9.0", default-features = false, features = ["alloc", "derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ wasm-bindgen-test = { version = "0.3", default-features = false, features = ["st
 wasm-log = { version = "0.3", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["log", "std", "release_max_level_info"] }
 tracing-log = { version = "0.2", default-features = false, features = ["log-tracer", "std"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "fmt", "env-filter", "std"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 # see also https://github.com/NethermindEth/stellar-private-payments/issues/192
 wasmer = { git = "https://github.com/wasmerio/wasmer", rev = "763e9f2800644f51ce27f6f5c1752776da16ddd1", shallow = true, default-features = false }
 web-sys = { version = "0.3", features = ["console", "WorkerGlobalScope", "Response", "Request", "RequestInit", "RequestMode", "Window", "Event", "Cache", "CacheStorage"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ uint = { version = "0.10", default-features = false }
 wasm-bindgen = { version = "0.2", default-features = false, features = ["serde-serialize"] }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
 wasm-bindgen-test = { version = "0.3", default-features = false, features = ["std"] }
-tracing = { version = "0.1", default-features = false, features = ["std", "release_max_level_info"] }
+tracing = { version = "0.1", default-features = false, features = ["std", "release_max_level_info", "attributes"] }
 tracing-log = { version = "0.2", default-features = false, features = ["log-tracer", "std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 # see also https://github.com/NethermindEth/stellar-private-payments/issues/192

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,10 +93,14 @@ wasm-bindgen = { version = "0.2", default-features = false, features = ["serde-s
 wasm-bindgen-futures = { version = "0.4", default-features = false }
 wasm-bindgen-test = { version = "0.3", default-features = false, features = ["std"] }
 wasm-log = { version = "0.3", default-features = false }
+tracing = { version = "0.1", default-features = false, features = ["log", "std", "release_max_level_info"] }
+tracing-log = { version = "0.2", default-features = false, features = ["log-tracer", "std"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "fmt", "env-filter", "std"] }
 # see also https://github.com/NethermindEth/stellar-private-payments/issues/192
 wasmer = { git = "https://github.com/wasmerio/wasmer", rev = "763e9f2800644f51ce27f6f5c1752776da16ddd1", shallow = true, default-features = false }
 web-sys = { version = "0.3", features = ["console", "WorkerGlobalScope", "Response", "Request", "RequestInit", "RequestMode", "Window", "Event", "Cache", "CacheStorage"] }
 wiremock = "0.6"
+zeroize = { version = "1.9.0", default-features = false, features = ["alloc", "derive"] }
 
 [workspace.lints.rust]
 missing_docs = "allow"

--- a/Makefile
+++ b/Makefile
@@ -4,33 +4,58 @@ DIST_DIR ?= dist
 PUBLIC_URL ?= /
 BUILD_TESTS ?=
 RELEASE ?=
+# LOGS=1 builds the WASM SDK with verbose diagnostic logging enabled
+# (WASM_PROFILE=release-with-logs) instead of the quiet, privacy-first default.
+# e.g. `make serve LOGS=1`, `make build LOGS=1`.
+LOGS ?=
 
 .PHONY: release
 release: RELEASE := 1
 release: build
 
 .PHONY: serve
-serve: install sdk-web-build
+serve: install $(if $(LOGS),sdk-web-build-debug,sdk-web-build)
+	@echo "Serving frontend with trunk$(if $(LOGS), (debug logs enabled),)..."
 	# --dist $(DIST_DIR) overrides the dist_dir set in the trunk.toml
 	# it's useful for generating a different serving path
 	unset NO_COLOR && export PUBLIC_URL=$(PUBLIC_URL) && \
 	trunk serve --dist $(DIST_DIR) --public-url $(PUBLIC_URL)
 
+# Alias: `make serve-debug` == `make serve LOGS=1`.
+.PHONY: serve-debug
+serve-debug:
+	@$(MAKE) serve LOGS=1
+
 .PHONY: build
-build: install sdk-web-build
-	@echo "Building frontend with trunk..."
+build: install $(if $(LOGS),sdk-web-build-debug,sdk-web-build)
+	@echo "Building frontend with trunk$(if $(LOGS), (debug logs enabled),)..."
 	unset NO_COLOR && export PUBLIC_URL=$(PUBLIC_URL) && \
 	trunk build --dist $(DIST_DIR) $(if $(RELEASE),--release) --public-url $(PUBLIC_URL)
+
+# Alias: `make build-debug` == `make build LOGS=1`.
+.PHONY: build-debug
+build-debug:
+	@$(MAKE) build LOGS=1
 
 .PHONY: circuits-build
 circuits-build:
 	@echo "Building circuits (this may take a while)..."
 	$(if $(BUILD_TESTS),BUILD_TESTS=$(BUILD_TESTS)) cargo build -p circuits $(if $(RELEASE),--release)
 
+# Both targets record the built profile in sdk/web/.trunk-wasm-profile so a
+# subsequent `trunk serve`/`trunk build` (which `serve`/`build` invoke) sees a
+# matching marker and skips its own redundant rebuild.
 .PHONY: sdk-web-build
 sdk-web-build:
 	@echo "Building stellar-private-payments-sdk-web (sdk/web/dist)..."
 	@npm run build --prefix sdk/web
+	@echo "release" > sdk/web/.trunk-wasm-profile
+
+.PHONY: sdk-web-build-debug
+sdk-web-build-debug:
+	@echo "Building stellar-private-payments-sdk-web with debug logs (release-with-logs)..."
+	@WASM_PROFILE=release-with-logs npm run build --prefix sdk/web
+	@echo "release-with-logs" > sdk/web/.trunk-wasm-profile
 
 .PHONY: install
 install:
@@ -43,7 +68,7 @@ install:
 .PHONY: clean
 clean:
 	trunk clean --dist $(DIST_DIR)
-	rm -rf sdk/web/dist
+	rm -rf sdk/web/dist sdk/web/.trunk-wasm-profile
 	cargo clean
 
 .PHONY: doc

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,3 +20,15 @@ Please include as much information as you can provide (listed below) to help us 
 
 We will release fixes for verified security vulnerabilities.
 We expect to publish vulnerabilities using GitHub [security advisories](https://github.com/NethermindEth/stellar-private-transactions/security/advisories).
+
+## Logging Security & Privacy Model
+
+To protect user confidentiality during transaction proving and indexing, the SDK implements a strict **two-tier data privacy model** for all logging and telemetry.
+
+### The Invariant
+* **Tier-0 Secrets (NEVER logged)**: Cryptographic private keys, seeds, signatures, circuit witnesses, and membership blinding factors must **never** be output to logs, spans, or telemetry sinks under any circumstance, profile, or runtime setting.
+* **Tier-1 Sensitive Fields (Redacted by default)**: User addresses, transfer amounts, note commitments, and transaction nullifiers are wrapped in a protective `Sensitive<T>` container. By default, they render as `<redacted>`.
+
+### Debug Log Warning
+> [!WARNING]
+> In debug builds (i.e., built with `release-with-logs` or under native tests), Tier-1 sensitive values can be optionally revealed at runtime using the `revealSensitive` setting for developer diagnostics. **Never share raw verbose debug logs publicly**, as they may expose transaction amounts and address correlations.

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -21,15 +21,31 @@ tailwindcss = "4.1.18"
 stage = "pre_build"
 command = "sh"
 command_arguments = ["-c", """
+set -e
+
 # Compiled circuits ship inside sdk/web/dist/ (npm package). Proving loads them via
 # the prover worker's __STELLAR_PRIVATE_PAYMENTS_CIRCUITS_BASE__ (see sdk/web/scripts/build.sh).
-if [ ! -f "sdk/web/dist/stellar_private_payments_sdk_web.js" ]; then
-    echo "trunk:error: missing sdk/web/dist — run 'make sdk-web-build'" >&2
-    exit 1
+#
+# WASM_PROFILE (or LOGS=1 as shorthand for WASM_PROFILE=release-with-logs) selects
+# the quiet, privacy-first default vs. the verbose diagnostic build — matching
+# `make build`/`make build LOGS=1`. Rebuild only when missing or the profile
+# changed, so plain `trunk serve` file-watch reloads stay fast.
+if [ "${LOGS:-}" = "1" ] || [ "${LOGS:-}" = "true" ]; then
+    export WASM_PROFILE="${WASM_PROFILE:-release-with-logs}"
+else
+    export WASM_PROFILE="${WASM_PROFILE:-release}"
+fi
+
+PROFILE_MARKER="sdk/web/.trunk-wasm-profile"
+LAST_PROFILE="$(cat "$PROFILE_MARKER" 2>/dev/null || echo "")"
+if [ ! -f "sdk/web/dist/stellar_private_payments_sdk_web.js" ] || [ "$LAST_PROFILE" != "$WASM_PROFILE" ]; then
+    echo "trunk: building stellar-private-payments-sdk-web (WASM_PROFILE=$WASM_PROFILE)..."
+    npm run build --prefix sdk/web
+    echo "$WASM_PROFILE" > "$PROFILE_MARKER"
 fi
 
 if [ ! -f "sdk/web/dist/circuits/source-bundle.tar.gz" ]; then
-    echo "trunk:error: missing sdk/web/dist/circuits — run 'make sdk-web-build'" >&2
+    echo "trunk:error: missing sdk/web/dist/circuits after build" >&2
     exit 1
 fi
 

--- a/app/README.md
+++ b/app/README.md
@@ -58,3 +58,23 @@ make clean
 
 - `Trunk.toml` - Trunk bundler configuration (at repository root)
 - `package.json` - npm dependencies and scripts
+
+## Diagnostics & Telemetry UI
+
+The web application settings drawer includes a dedicated **Diagnostics & Telemetry** configuration panel.
+
+### Settings and Actions:
+- **Log Level**: Dropdown select controlling verbosity (`Info`, `Debug`, `Trace`).
+- **Reveal Sensitive Info**: Gated checkbox to reveal Tier-1 values (e.g., amounts, addresses) in logs (forces to `false` in production compiles).
+- **Copy Logs**: Copies formatted in-memory ring-buffer logs to the clipboard.
+- **Download Logs**: Downloads the diagnostics trace logs as a `.log` file (`spp-diagnostics.log`).
+
+### Enabling Debug Logs (Release-with-logs profile):
+To enable telemetry collection and sensitive-reveal features in the web application browser console, serve/build the frontend using the debug-telemetry target:
+```bash
+# Serve with debug logs enabled
+make serve-debug
+
+# Build frontend with debug logs enabled
+make build-debug
+```

--- a/app/index.html
+++ b/app/index.html
@@ -422,6 +422,30 @@
                         <label for="settings-bootnode-url" class="text-xs font-medium uppercase tracking-[0.22em] text-slate-500">Bootnode RPC URL</label>
                         <input id="settings-bootnode-url" type="text" placeholder="https://..." class="mt-3 w-full rounded-2xl border border-white/10 bg-ink-950 px-4 py-3 text-sm text-slate-100 outline-none transition focus:border-cyan-300/40" autocomplete="off" spellcheck="false">
                     </div>
+                    <div class="border-t border-white/10 pt-5">
+                        <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-500 mb-4">Diagnostics & Telemetry</p>
+                        <div class="space-y-4">
+                            <div>
+                                <label for="settings-log-level" class="text-xs font-medium uppercase tracking-[0.22em] text-slate-500">Log Level</label>
+                                <select id="settings-log-level" class="mt-3 w-full rounded-2xl border border-white/10 bg-ink-950 px-4 py-3 text-sm text-slate-100 outline-none transition focus:border-cyan-300/40">
+                                    <option value="info">Info (Default)</option>
+                                    <option value="debug">Debug (Verbose)</option>
+                                    <option value="trace">Trace (Diagnostic)</option>
+                                </select>
+                            </div>
+                            <label class="flex items-center justify-between gap-4">
+                                <span>
+                                    <span class="block text-xs font-medium uppercase tracking-[0.22em] text-slate-500">Reveal Sensitive Info</span>
+                                    <span class="mt-2 block text-sm text-slate-400">Reveal Tier-1 values (amounts, addresses) in debug logs (always gated by compile profile).</span>
+                                </span>
+                                <input id="settings-reveal-sensitive" type="checkbox" class="h-5 w-5 rounded border-white/10 bg-ink-950 text-cyan-300 focus:ring-cyan-300">
+                            </label>
+                            <div class="flex gap-3 mt-4">
+                                <button id="settings-copy-logs-btn" type="button" class="flex-1 rounded-2xl bg-white/5 border border-white/10 px-4 py-3 text-sm font-medium text-slate-200 hover:bg-white/10 hover:border-cyan-300/20 transition">Copy Logs</button>
+                                <button id="settings-download-logs-btn" type="button" class="flex-1 rounded-2xl bg-white/5 border border-white/10 px-4 py-3 text-sm font-medium text-slate-200 hover:bg-white/10 hover:border-cyan-300/20 transition">Download Logs</button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
 
                 <div class="mt-6 flex flex-col gap-3 sm:flex-row">

--- a/app/js/ui/navigation.js
+++ b/app/js/ui/navigation.js
@@ -1,7 +1,7 @@
 import { connectWallet, getWalletNetwork, startWalletWatcher } from '../wallet.js';
 import { FreighterSigner } from 'stellar-private-payments-sdk-web';
 import { DEFAULT_BOOTNODE_URL } from '../app-storage.js';
-import { client, initializeRuntime, disposeClient, bootnodeRequired, ensureStorage } from '../wasm-facade.js';
+import { client, initializeRuntime, disposeClient, bootnodeRequired, ensureStorage, configureTelemetrySettings, dumpTelemetryLogs } from '../wasm-facade.js';
 import { App, Toast, Utils } from './core.js';
 import { closeAppPool, createAppPool } from './pool.js';
 import { runOnboardingWizard } from './onboarding-wizard.js';
@@ -146,6 +146,17 @@ async function loadRuntimeState() {
     const bootnodeSetting = await storage.getBootnodeConfig();
     App.state.settings.bootnode = bootnodeSetting || { enabled: false, url: '' };
 
+    const telemetrySetting = await storage.getSetting('telemetry_config');
+    App.state.settings.telemetry = telemetrySetting || { level: 'info', revealSensitive: false };
+    try {
+        await configureTelemetrySettings({
+            level: App.state.settings.telemetry.level,
+            revealSensitive: App.state.settings.telemetry.revealSensitive,
+        });
+    } catch (e) {
+        console.warn('Failed to configure telemetry:', e);
+    }
+
     App.events.dispatchEvent(new CustomEvent('pool:config'));
     App.events.dispatchEvent(new CustomEvent('settings:updated'));
 }
@@ -203,6 +214,8 @@ function renderSettingsDrawer() {
     document.getElementById('settings-explorer-input').value = App.state.settings.explorerBaseUrl || Utils.defaultExplorerBaseUrl;
     document.getElementById('settings-bootnode-enabled').checked = !!App.state.settings.bootnode?.enabled;
     document.getElementById('settings-bootnode-url').value = App.state.settings.bootnode?.url || '';
+    document.getElementById('settings-log-level').value = App.state.settings.telemetry?.level || 'info';
+    document.getElementById('settings-reveal-sensitive').checked = !!App.state.settings.telemetry?.revealSensitive;
 }
 
 export const Shell = {
@@ -224,6 +237,32 @@ export const Shell = {
         document.getElementById('settings-save-btn')?.addEventListener('click', () => Wallet.saveSettings());
         document.getElementById('settings-register-btn')?.addEventListener('click', () => Wallet.registerPublicKey());
         document.getElementById('wallet-disconnect-btn')?.addEventListener('click', () => Wallet.disconnect());
+        document.getElementById('settings-copy-logs-btn')?.addEventListener('click', async () => {
+            try {
+                const logs = await dumpTelemetryLogs();
+                await navigator.clipboard.writeText(logs);
+                Toast.show('Diagnostic logs copied to clipboard', 'success');
+            } catch (error) {
+                Toast.show('Failed to copy logs: ' + error.message, 'error');
+            }
+        });
+        document.getElementById('settings-download-logs-btn')?.addEventListener('click', async () => {
+            try {
+                const logs = await dumpTelemetryLogs();
+                const blob = new Blob([logs], { type: 'text/plain;charset=utf-8' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = 'spp-diagnostics.log';
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                URL.revokeObjectURL(url);
+                Toast.show('Diagnostic logs download started', 'success');
+            } catch (error) {
+                Toast.show('Failed to download logs: ' + error.message, 'error');
+            }
+        });
         document.getElementById('settings-reveal-secret')?.addEventListener('click', async (e) => {
             const btn = e.currentTarget;
             const revealing = btn.dataset.revealed !== 'true';
@@ -452,6 +491,8 @@ export const Wallet = {
             const explorerBaseUrl = document.getElementById('settings-explorer-input')?.value?.trim() || Utils.defaultExplorerBaseUrl;
             const bootnodeEnabled = document.getElementById('settings-bootnode-enabled')?.checked;
             const bootnodeUrl = document.getElementById('settings-bootnode-url')?.value?.trim() || '';
+            const logLevel = document.getElementById('settings-log-level')?.value || 'info';
+            const revealSensitive = !!document.getElementById('settings-reveal-sensitive')?.checked;
 
             const storage = client().storage();
             await storage.setSetting('explorer', { baseUrl: explorerBaseUrl });
@@ -459,9 +500,17 @@ export const Wallet = {
                 enabled: !!bootnodeEnabled,
                 url: bootnodeEnabled ? bootnodeUrl : '',
             });
+            await storage.setSetting('telemetry_config', { level: logLevel, revealSensitive });
 
             App.state.settings.explorerBaseUrl = explorerBaseUrl;
             App.state.settings.bootnode = { enabled: !!bootnodeEnabled, url: bootnodeEnabled ? bootnodeUrl : '' };
+            App.state.settings.telemetry = { level: logLevel, revealSensitive };
+
+            await configureTelemetrySettings({
+                level: logLevel,
+                revealSensitive,
+            });
+
             Toast.show('Settings saved', 'success');
             App.events.dispatchEvent(new CustomEvent('settings:updated'));
         } catch (error) {

--- a/app/js/ui/onboarding-wizard.js
+++ b/app/js/ui/onboarding-wizard.js
@@ -644,7 +644,8 @@ export async function runOnboardingWizard({
                 eyebrow: `Step ${STEP_ORDER.indexOf(stepId) + 1} of ${STEP_ORDER.length}`,
                 title: 'Register your public keys in the address book',
                 body: 'If you register now, other users can transfer to your Stellar address without asking for note and encryption public keys out of band.',
-                aside: 'If you skip this step, transfers to you require sharing your note and encryption public keys manually. Registration remains available later from settings.',
+                aside: 'If you skip this step, transfers to you require sharing your note and encryption public keys manually. Registration remains available later from settings. Note: registering publishes your public address to key binding on-chain as an opt-in public event.',
+
             });
             renderContent(panel);
 

--- a/app/js/wasm-facade.js
+++ b/app/js/wasm-facade.js
@@ -14,6 +14,8 @@ import init, {
   Storage,
   bootnodeRequired as sdkBootnodeRequired,
   verifySelectiveDisclosure as sdkVerifySelectiveDisclosure,
+  configureTelemetry,
+  dump_recent_logs,
 } from 'stellar-private-payments-sdk-web';
 
 import { AppStorage } from './app-storage.js';
@@ -197,4 +199,16 @@ export function client() {
 /** Whether a runtime (wallet-bound or anonymous) is already open. */
 export function isRuntimeReady() {
     return wrappedClient !== null;
+}
+
+/** Configure telemetry settings in the WASM SDK. */
+export async function configureTelemetrySettings(config) {
+    await ensureWasmInit();
+    configureTelemetry(config);
+}
+
+/** Dump recent logs from the WASM SDK ring buffer. */
+export async function dumpTelemetryLogs() {
+    await ensureWasmInit();
+    return dump_recent_logs();
 }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,6 +19,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 log.workspace = true
+tracing = { workspace = true, features = ["attributes"] }
 tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }
 tracing-log = { workspace = true }
 # Not referenced directly, but pulls in reqwest's rustls TLS backend for the
@@ -28,6 +29,7 @@ serde.workspace = true
 serde_json.workspace = true
 stellar-private-payments-sdk.workspace = true
 toml = "0.8"
+types.workspace = true
 
 [lints]
 workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,6 +19,8 @@ anyhow.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 log.workspace = true
+tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }
+tracing-log = { workspace = true }
 # Not referenced directly, but pulls in reqwest's rustls TLS backend for the
 # binary (the `stellar` crate depends on reqwest without a TLS feature).
 reqwest = { workspace = true, features = ["rustls"] }

--- a/cli/src/cmd/disclaimer.rs
+++ b/cli/src/cmd/disclaimer.rs
@@ -8,6 +8,11 @@ use stellar_private_payments_sdk::state::CURRENT_DISCLAIMER_TEXT_MD;
 use crate::{config::CliConfig, output};
 
 pub fn run(config: &CliConfig, json: bool) -> Result<()> {
+    let _span = tracing::info_span!(
+        "cmd_disclaimer",
+        correlation_id = %types::correlation_id_or_new()
+    )
+    .entered();
     let accepted = match &config.account {
         Some(_) => {
             let account = config.require_account()?;

--- a/cli/src/cmd/feed.rs
+++ b/cli/src/cmd/feed.rs
@@ -8,6 +8,12 @@ use crate::{config::CliConfig, explorer::Explorer, onboard, output, session::Cli
 const DEFAULT_LIMIT: u32 = 5;
 
 pub fn run(config: &CliConfig, limit: Option<u32>, json: bool) -> Result<()> {
+    let _span = tracing::info_span!(
+        "cmd_feed",
+        correlation_id = %types::correlation_id_or_new(),
+        limit = ?limit
+    )
+    .entered();
     let limit = limit.unwrap_or(DEFAULT_LIMIT);
     let account = config.require_account()?;
     onboard::ensure_ready(config, &account)?;

--- a/cli/src/cmd/keys.rs
+++ b/cli/src/cmd/keys.rs
@@ -7,6 +7,12 @@ use serde::Serialize;
 use crate::{config::CliConfig, onboard, output, session::ClientSession};
 
 pub fn show(config: &CliConfig, json: bool) -> Result<()> {
+    // No value fields: this command prints secrets to stdout; logs get nothing.
+    let _span = tracing::info_span!(
+        "cmd_keys_show",
+        correlation_id = %types::correlation_id_or_new()
+    )
+    .entered();
     let account = config.require_account()?;
     onboard::ensure_ready(config, &account)?;
     let network = config.resolve_network()?;
@@ -41,6 +47,12 @@ pub fn show(config: &CliConfig, json: bool) -> Result<()> {
 }
 
 pub fn asp_secret(config: &CliConfig, json: bool) -> Result<()> {
+    // No value fields: this command prints secrets to stdout; logs get nothing.
+    let _span = tracing::info_span!(
+        "cmd_keys_asp_secret",
+        correlation_id = %types::correlation_id_or_new()
+    )
+    .entered();
     let account = config.require_account()?;
     onboard::ensure_ready(config, &account)?;
     let network = config.resolve_network()?;

--- a/cli/src/cmd/overview.rs
+++ b/cli/src/cmd/overview.rs
@@ -52,6 +52,11 @@ struct Overview {
 }
 
 pub fn run(config: &CliConfig, pool: Option<&str>, json: bool) -> Result<()> {
+    let _span = tracing::info_span!(
+        "cmd_overview",
+        correlation_id = %types::correlation_id_or_new()
+    )
+    .entered();
     let account = config.require_account()?;
     onboard::ensure_ready(config, &account)?;
     let network = config.resolve_network()?;

--- a/cli/src/cmd/pool.rs
+++ b/cli/src/cmd/pool.rs
@@ -23,6 +23,12 @@ fn open_pool(
 }
 
 pub fn deposit(config: &CliConfig, pool: &str, amount: &str, json: bool) -> Result<()> {
+    let _span = tracing::info_span!(
+        "cmd_deposit",
+        correlation_id = %types::correlation_id_or_new(),
+        amount = ?types::Sensitive(&amount)
+    )
+    .entered();
     let pool = open_pool(config, pool)?;
     let amount = parse_amount(amount)?;
     let result = pool
@@ -45,6 +51,13 @@ pub fn transfer(
     encryption_key: Option<&str>,
     json: bool,
 ) -> Result<()> {
+    let _span = tracing::info_span!(
+        "cmd_transfer",
+        correlation_id = %types::correlation_id_or_new(),
+        amount = ?types::Sensitive(&amount),
+        recipient = ?types::Sensitive(&to)
+    )
+    .entered();
     let pool = open_pool(config, pool)?;
     let recipient = parse_transfer_recipient(to, note_key, encryption_key)?;
     let amount = parse_amount(amount)?;
@@ -61,6 +74,13 @@ pub fn withdraw(
     to: Option<&str>,
     json: bool,
 ) -> Result<()> {
+    let _span = tracing::info_span!(
+        "cmd_withdraw",
+        correlation_id = %types::correlation_id_or_new(),
+        amount = ?types::Sensitive(&amount),
+        recipient = ?types::Sensitive(&to)
+    )
+    .entered();
     let recipient = match to {
         Some(address) => address.to_string(),
         None => config.require_account()?.address,

--- a/cli/src/cmd/register.rs
+++ b/cli/src/cmd/register.rs
@@ -8,6 +8,11 @@ use serde::Serialize;
 use crate::{config::CliConfig, onboard, output, session::ClientSession};
 
 pub fn run(config: &CliConfig, json: bool) -> Result<()> {
+    let _span = tracing::info_span!(
+        "cmd_register",
+        correlation_id = %types::correlation_id_or_new()
+    )
+    .entered();
     let account = config.require_account()?;
     onboard::ensure_ready(config, &account)?;
     let network = config.resolve_network()?;

--- a/cli/src/logging.rs
+++ b/cli/src/logging.rs
@@ -1,77 +1,50 @@
 //! Progress logging for the CLI.
 //!
-//! Installs a `log` implementation so SDK sync logs (indexer/storage/transact)
+//! Installs a `tracing` subscriber so SDK sync logs (indexer/storage/transact)
 //! and the CLI's own progress lines stream to the user on **stderr**: colored
 //! human text by default, or one JSON object per line under `--json` (keeping
 //! stdout reserved for the command's JSON result).
 
-use std::{
-    io::{IsTerminal, Write},
-    sync::OnceLock,
-};
-
-use log::{Level, LevelFilter, Metadata, Record};
-
-struct CliLogger {
-    json: bool,
-    color: bool,
-}
-
-static LOGGER: OnceLock<CliLogger> = OnceLock::new();
+use std::io::IsTerminal;
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 /// Install the logger. `verbose` is the repeat count of `-v`
 /// (0 = info, 1 = debug, 2+ = trace).
 pub fn init(verbose: u8, json: bool) {
-    let level = match verbose {
-        0 => LevelFilter::Info,
-        1 => LevelFilter::Debug,
-        _ => LevelFilter::Trace,
+    // 1. Initialize LogTracer to redirect log::* calls to tracing
+    let _ = tracing_log::LogTracer::init();
+
+    // 2. Map verbose level to EnvFilter directives
+    let directive = match verbose {
+        0 => "info",
+        1 => "debug",
+        _ => "trace",
     };
+
+    // Allow overriding via RUST_LOG environment variable
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(directive));
+
     let color = !json && std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none();
-    let logger = LOGGER.get_or_init(|| CliLogger { json, color });
-    // Ignore the error if a logger was already installed (e.g. tests).
-    let _ = log::set_logger(logger);
-    log::set_max_level(level);
-}
 
-fn ansi(level: Level) -> &'static str {
-    match level {
-        Level::Error => "31",
-        Level::Warn => "33",
-        Level::Info => "32",
-        Level::Debug => "36",
-        Level::Trace => "90",
-    }
-}
+    // 3. Build the subscriber. CorrelationIdLayer lets nested SDK calls inherit an
+    //    ambient correlation_id via correlation_id_or_new() rather than each
+    //    minting an unrelated one.
+    let subscriber = tracing_subscriber::registry()
+        .with(filter)
+        .with(stellar_private_payments_sdk::types::CorrelationIdLayer);
 
-impl log::Log for CliLogger {
-    fn enabled(&self, _metadata: &Metadata) -> bool {
-        true
-    }
-
-    fn log(&self, record: &Record) {
-        let mut err = std::io::stderr().lock();
-        if self.json {
-            let obj = serde_json::json!({
-                "level": record.level().to_string(),
-                "target": record.target(),
-                "message": record.args().to_string(),
-            });
-            let _ = writeln!(err, "{obj}");
-        } else if self.color {
-            let _ = writeln!(
-                err,
-                "\x1b[{}m{:>5}\x1b[0m {}",
-                ansi(record.level()),
-                record.level(),
-                record.args()
-            );
-        } else {
-            let _ = writeln!(err, "{:>5} {}", record.level(), record.args());
-        }
-    }
-
-    fn flush(&self) {
-        let _ = std::io::stderr().flush();
+    if json {
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            .json()
+            .with_writer(std::io::stderr)
+            .flatten_event(true);
+        let _ = subscriber.with(fmt_layer).try_init();
+    } else {
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            .with_writer(std::io::stderr)
+            .with_ansi(color)
+            .without_time()
+            .with_target(verbose >= 2); // only show targets in trace level
+        let _ = subscriber.with(fmt_layer).try_init();
     }
 }

--- a/cli/src/stellar_cli.rs
+++ b/cli/src/stellar_cli.rs
@@ -12,11 +12,13 @@ use std::{
     io::Write,
     path::Path,
     process::{Command, Stdio},
+    time::Instant,
 };
 
 use anyhow::{Context, Result, bail};
 
 use stellar_private_payments_sdk::{chain::Signature, types::KeyDerivationSignature};
+use types::correlation_id_or_new;
 
 /// Env var to override the `stellar` binary path (default: `stellar` on PATH).
 const STELLAR_BIN_ENV: &str = "STELLAR_BIN";
@@ -28,19 +30,45 @@ fn stellar_bin() -> String {
 
 /// Run `stellar <args…>` (with an optional `--config-dir`) and return trimmed
 /// stdout. Info logs go to stderr and are ignored on success.
+#[tracing::instrument(
+    name = "stellar_cli_run",
+    skip_all,
+    fields(correlation_id = %correlation_id_or_new())
+)]
 fn run(args: &[String], config_dir: Option<&Path>) -> Result<String> {
+    let start = Instant::now();
     let bin = stellar_bin();
+    // Full args are Sensitive-wrapped: some call sites (e.g. `message sign`)
+    // pass payload/Tier-1 values in args, so they stay redacted by default.
+    tracing::info!(
+        bin = %bin,
+        subcommand = %args.first().map(String::as_str).unwrap_or(""),
+        args = ?types::Sensitive(&args),
+        "running external stellar command"
+    );
     let mut cmd = Command::new(&bin);
     cmd.args(args);
     if let Some(dir) = config_dir {
         cmd.arg("--config-dir").arg(dir);
     }
-    let output = cmd.output().with_context(|| {
+    let result = cmd.output().with_context(|| {
         format!(
             "failed to run `{bin}`; install the Stellar CLI (https://stellar.org/cli) \
              or set {STELLAR_BIN_ENV} to its path"
         )
-    })?;
+    });
+    let elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+    match &result {
+        Ok(output) => tracing::debug!(
+            exit_status = %output.status,
+            stdout_len = output.stdout.len(),
+            stderr_len = output.stderr.len(),
+            elapsed_ms,
+            "external stellar command exited"
+        ),
+        Err(_) => tracing::debug!(elapsed_ms, "external stellar command failed to start"),
+    }
+    let output = result?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         bail!("`{bin} {}` failed: {}", args.join(" "), stderr.trim());
@@ -52,6 +80,11 @@ fn run(args: &[String], config_dir: Option<&Path>) -> Result<String> {
 
 /// Resolve an alias to its Stellar address (`G…`) via `stellar keys
 /// public-key`.
+#[tracing::instrument(
+    name = "stellar_public_key",
+    skip_all,
+    fields(correlation_id = %correlation_id_or_new(), alias = ?types::Sensitive(&alias))
+)]
 pub fn public_key(alias: &str, config_dir: Option<&Path>) -> Result<String> {
     let args = vec![
         "keys".to_string(),
@@ -70,11 +103,22 @@ pub fn public_key(alias: &str, config_dir: Option<&Path>) -> Result<String> {
 /// The Stellar CLI prefixes `"Stellar Signed Message:\n"`, SHA-256 hashes, then
 /// Ed25519-signs — matching the web app / Freighter derivation exactly. Output
 /// is base64 of the 64-byte signature.
+#[tracing::instrument(
+    name = "stellar_sign_message",
+    skip_all,
+    fields(correlation_id = %correlation_id_or_new(), alias = ?types::Sensitive(&alias), message_len = message.len())
+)]
 pub fn sign_message(
     alias: &str,
     message: &str,
     config_dir: Option<&Path>,
 ) -> Result<KeyDerivationSignature> {
+    // The message contents and the produced signature are never logged.
+    tracing::info!(
+        alias = ?types::Sensitive(&alias),
+        message_len = message.len(),
+        "awaiting external signer (may prompt for key)"
+    );
     let args = vec![
         "message".to_string(),
         "sign".to_string(),
@@ -93,6 +137,11 @@ pub fn sign_message(
 /// Works for identities stored in the config file or OS secure store. The
 /// unsigned envelope XDR is passed on stdin; signed envelope XDR is returned
 /// from stdout.
+#[tracing::instrument(
+    name = "stellar_sign_tx",
+    skip_all,
+    fields(correlation_id = %correlation_id_or_new(), alias = ?types::Sensitive(&alias), xdr_len = tx_xdr.len(), network = %network_passphrase)
+)]
 pub fn sign_tx(
     alias: &str,
     tx_xdr: &str,
@@ -100,6 +149,23 @@ pub fn sign_tx(
     network_passphrase: &str,
     config_dir: Option<&Path>,
 ) -> Result<String> {
+    let start = Instant::now();
+    // Host part of the RPC URL (scheme and path stripped); the envelope XDR
+    // and the signed XDR output are never logged.
+    let rpc_host = rpc_url
+        .split("://")
+        .nth(1)
+        .unwrap_or(rpc_url)
+        .split('/')
+        .next()
+        .unwrap_or("");
+    tracing::info!(
+        alias = ?types::Sensitive(&alias),
+        xdr_len = tx_xdr.len(),
+        network = %network_passphrase,
+        rpc_host,
+        "awaiting external signer (--auto-sign may block on hardware/secure-store prompt)"
+    );
     let bin = stellar_bin();
     let mut cmd = Command::new(&bin);
     cmd.args([
@@ -134,9 +200,19 @@ pub fn sign_tx(
         .write_all(tx_xdr.as_bytes())
         .context("write transaction XDR to stellar tx sign")?;
 
-    let output = child
-        .wait_with_output()
-        .context("wait for stellar tx sign")?;
+    let result = child.wait_with_output().context("wait for stellar tx sign");
+    let elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+    match &result {
+        Ok(output) => tracing::debug!(
+            exit_status = %output.status,
+            stdout_len = output.stdout.len(),
+            stderr_len = output.stderr.len(),
+            elapsed_ms,
+            "external stellar command exited"
+        ),
+        Err(_) => tracing::debug!(elapsed_ms, "external stellar command failed"),
+    }
+    let output = result?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -170,6 +246,11 @@ pub fn ensure_installed() -> Result<String> {
 /// Resolve a network's RPC URL and passphrase from the Stellar CLI's own
 /// network config (built-in networks like `testnet` and any custom ones added
 /// via `stellar network add`), by parsing `stellar network ls --long`.
+#[tracing::instrument(
+    name = "stellar_network_lookup",
+    skip_all,
+    fields(correlation_id = %correlation_id_or_new(), network = %name)
+)]
 pub fn network(name: &str, config_dir: Option<&Path>) -> Result<StellarNetwork> {
     let listing = run(
         &[

--- a/contracts/asp-membership/src/test.rs
+++ b/contracts/asp-membership/src/test.rs
@@ -698,3 +698,28 @@ fn test_merkle_consistency() {
         );
     }
 }
+
+#[test]
+fn test_leaf_added_event_exact_shape() {
+    use soroban_sdk::{events::Event, testutils::Events};
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+    let leaf = U256::from_u32(&env, 12345);
+
+    env.mock_all_auths();
+    client.insert_leaf(&leaf);
+
+    let events = env.events().all();
+    assert_eq!(events.events().len(), 1);
+
+    let root = client.get_root();
+    let expected = LeafAddedEvent {
+        leaf,
+        index: 0,
+        root,
+    }
+    .to_xdr(&env, &contract_id);
+    assert_eq!(events.events()[0], expected);
+}

--- a/contracts/asp-non-membership/src/test.rs
+++ b/contracts/asp-non-membership/src/test.rs
@@ -879,3 +879,40 @@ fn test_verify_non_membership_comprehensive_scenario() {
         "key_c non-membership should be false"
     );
 }
+
+#[test]
+fn test_leaf_inserted_and_deleted_event_exact_shapes() {
+    use soroban_sdk::{events::Event, testutils::Events};
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+    let key = U256::from_u32(&env, 1u32);
+    let value = U256::from_u32(&env, 42u32);
+
+    env.mock_all_auths();
+    client.insert_leaf(&key, &value);
+
+    let events_after_insert = env.events().all();
+    assert_eq!(events_after_insert.events().len(), 1);
+    let root_after_insert = client.get_root();
+    let expected_inserted = LeafInsertedEvent {
+        key: key.clone(),
+        value,
+        root: root_after_insert,
+    }
+    .to_xdr(&env, &contract_id);
+    assert_eq!(events_after_insert.events()[0], expected_inserted);
+
+    client.delete_leaf(&key);
+
+    let events_after_delete = env.events().all();
+    assert_eq!(events_after_delete.events().len(), 1);
+    let root_after_delete = client.get_root();
+    let expected_deleted = LeafDeletedEvent {
+        key,
+        root: root_after_delete,
+    }
+    .to_xdr(&env, &contract_id);
+    assert_eq!(events_after_delete.events()[0], expected_deleted);
+}

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -932,3 +932,49 @@ fn transact_does_not_reject_boundary_canonical_public_input() {
         Err(Ok(Error::NonCanonicalPublicInput))
     ));
 }
+
+#[test]
+fn test_pool_events_exact_shapes() {
+    use crate::pool::{NewCommitmentEvent, NewNullifierEvent};
+    use soroban_sdk::{events::Event, testutils::Events};
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let contract_id = register_pool(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
+    );
+    let commitment = U256::from_u32(&env, 123);
+    let nullifier = U256::from_u32(&env, 456);
+    let encrypted_output = Bytes::from_array(&env, &[0u8; 120]);
+
+    env.as_contract(&contract_id, || {
+        let event1 = NewCommitmentEvent {
+            commitment: commitment.clone(),
+            index: 0,
+            encrypted_output: encrypted_output.clone(),
+        };
+        event1.publish(&env);
+
+        let event2 = NewNullifierEvent {
+            nullifier: nullifier.clone(),
+        };
+        event2.publish(&env);
+    });
+
+    let events = env.events().all();
+    assert_eq!(events.events().len(), 2);
+
+    let expected_commitment = NewCommitmentEvent {
+        commitment,
+        index: 0,
+        encrypted_output,
+    }
+    .to_xdr(&env, &contract_id);
+    assert_eq!(events.events()[0], expected_commitment);
+
+    let expected_nullifier = NewNullifierEvent { nullifier }.to_xdr(&env, &contract_id);
+    assert_eq!(events.events()[1], expected_nullifier);
+}

--- a/contracts/public-key-registry/src/test.rs
+++ b/contracts/public-key-registry/src/test.rs
@@ -145,3 +145,27 @@ fn register_rejects_short_note_key() {
     env.mock_all_auths();
     client.register(&account);
 }
+
+#[test]
+fn test_public_key_event_exact_shape() {
+    use soroban_sdk::events::Event;
+    let env = test_env();
+    let contract_id = env.register(PublicKeyRegistry, ());
+    let client = PublicKeyRegistryClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    let account = account(&env, owner.clone(), 0x11, 0x22);
+
+    env.mock_all_auths();
+    client.register(&account);
+
+    let events = env.events().all();
+    assert_eq!(events.events().len(), 1);
+
+    let expected = PublicKeyEvent {
+        owner,
+        encryption_key: account.encryption_key,
+        note_key: account.note_key,
+    }
+    .to_xdr(&env, &contract_id);
+    assert_eq!(events.events()[0], expected);
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,6 +4,8 @@
   - [Install the CLI](./introduction.md#install-the-cli)
 - [Contributing](./contributing.md)
 - [Security](./security.md)
+  - [Privacy & Event Trade-offs](./privacy-tradeoffs.md)
+
 - [Selective Disclosure](./disclosure.md)
 - [App](./app.md)
   - [Architecture](./architecture.md)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -28,3 +28,30 @@ Detailed API documentation generated from source code via `rustdoc`.
 ## Tests
 
 - [e2e-tests](api/e2e_tests/index.html)
+
+## Logging & Telemetry JS API
+
+The browser-based WASM package (`stellar-private-payments-sdk-web`) exposes three public telemetry functions:
+
+### 1. `configureTelemetry(config?: TelemetryConfig): void`
+Initializes or dynamically updates the active subscriber's logging filter, target sinks, and diagnostic buffers.
+* **Signature**:
+  ```typescript
+  export function configureTelemetry(config?: {
+    level?: string;
+    sink?: 'console' | 'ringBuffer' | 'both';
+    ringBufferBytes?: number;
+    revealSensitive?: boolean;
+  }): void;
+  ```
+* **Configuration Knobs**:
+  - `level`: Log filter directive (e.g. `"info"`, `"debug"`, `"trace"`).
+  - `sink`: Where logs are directed (`"console"`, `"ringBuffer"`, or `"both"`).
+  - `ringBufferBytes`: Capacity of the in-memory diagnostic ring buffer.
+  - `revealSensitive`: Gated by profile (`cfg(debug_assertions)`). Set to `true` to reveal Tier-1 values.
+
+### 2. `set_log_level(level: string): void`
+Dynamically overrides the active log level filter directive at runtime (e.g., changes to `"debug"`).
+
+### 3. `dump_recent_logs(): string`
+Dumps the current contents of the log ring buffer as a single formatted string for diagnostic reports.

--- a/docs/src/privacy-tradeoffs.md
+++ b/docs/src/privacy-tradeoffs.md
@@ -1,0 +1,29 @@
+# Contract Event Privacy & Correlation Trade-offs
+
+This document details the privacy guarantees, protocol-inherent correlation surfaces, and public key directory opt-in trade-offs across all smart contract events.
+
+## 1. Protocol-Inherent Transaction Correlation Trade-off
+
+While transfer amounts and note contents are encrypted in zero-knowledge proofs and note ciphertexts, standard Soroban contract calls inherently expose `ExtData` (e.g., `recipient`, `ext_amount`) as public invocation arguments. Furthermore, contract events (`NewCommitmentEvent` and `NewNullifierEvent`) fire synchronously within the same `transact` call.
+
+As a consequence, on-chain observers can correlate:
+* **Public Address to Note Commitment**: Deposit and withdrawal public Stellar addresses specified in `ExtData` can be linked to newly created note commitments via transaction ordering and block timestamps.
+* **Execution Timing**: Transaction execution timing and block height correlate directly with specific nullifiers and commitment Merkle indexes.
+
+## 2. Public Key Registry Opt-In Trade-off
+
+The `PublicKeyEvent` emitted by `PublicKeyRegistry` deliberately binds a user's public Stellar `Address` to their X25519 `encryption_key` and BN254 `note_key`.
+
+* **Purpose**: Allows senders to resolve a recipient's keys on-chain without out-of-band communication.
+* **Opt-In Nature**: Key registration is strictly voluntary. Users who prefer to keep their public address decoupled from their shielded payment keys should skip registry registration and exchange keys directly out-of-band.
+
+## 3. Event Privacy Classification Summary
+
+| Event Name | Contract Crate | Topics (Indexed) | Data (Payload) | Privacy & Correlation Classification |
+|---|---|---|---|---|
+| `NewCommitmentEvent` | `pool` | `[Symbol("NewCommitmentEvent"), commitment: U256]` | `index: u32`, `encrypted_output: Bytes` | **Public Data / Correlatable**: Commitment is a blinded Poseidon hash; encrypted output uses fresh OS CSPRNG nonces per note. Correlatable with public transaction args (`ExtData`). |
+| `NewNullifierEvent` | `pool` | `[Symbol("NewNullifierEvent"), nullifier: U256]` | *empty* | **Pseudonymous / One-Time Use**: Unlinks spent note from new commitments, but nullifier reuse would break privacy. |
+| `LeafAddedEvent` | `asp-membership` | `[Symbol("LeafAdded")]` | `leaf: U256`, `index: u64`, `root: U256` | **Public Protocol Data**: Blinded membership commitment `poseidon2_hash2(note_pubkey, blinding, 1)`. |
+| `LeafInsertedEvent` | `asp-non-membership` | `[Symbol("LeafInserted")]` | `key: U256`, `value: U256`, `root: U256` | **Transparency Property / Correlatable**: In ASP blocklist management, `key` is the unblinded note public key. Public blocklist key transparency allows users to verify non-membership. |
+| `LeafDeletedEvent` | `asp-non-membership` | `[Symbol("LeafDeleted")]` | `key: U256`, `root: U256` | **Transparency Property**: Key removed from blocklist. |
+| `PublicKeyEvent` | `public-key-registry` | `[Symbol("PublicKeyEvent"), owner: Address]` | `encryption_key: Bytes`, `note_key: Bytes` | **Opt-In Public Directory**: Binds public Stellar address to note/encryption public keys for recipient discovery. |

--- a/sdk/client/Cargo.toml
+++ b/sdk/client/Cargo.toml
@@ -15,7 +15,9 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 disclosure = { workspace = true }
 futures = { workspace = true }
-log = { workspace = true }
+getrandom = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 prover = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/sdk/client/Cargo.toml
+++ b/sdk/client/Cargo.toml
@@ -17,7 +17,6 @@ disclosure = { workspace = true }
 futures = { workspace = true }
 getrandom = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 prover = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -31,6 +30,7 @@ witness = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures-timer = "3"
 tokio = { workspace = true, features = ["rt-multi-thread"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = { workspace = true }

--- a/sdk/client/Cargo.toml
+++ b/sdk/client/Cargo.toml
@@ -15,7 +15,6 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 disclosure = { workspace = true }
 futures = { workspace = true }
-getrandom = { workspace = true }
 tracing = { workspace = true }
 prover = { workspace = true }
 serde = { workspace = true }
@@ -30,7 +29,6 @@ witness = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures-timer = "3"
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = { workspace = true }

--- a/sdk/client/README.md
+++ b/sdk/client/README.md
@@ -97,6 +97,19 @@ Method names mirror the async API; each call runs on an internal Tokio runtime.
 
 Private note/encryption keys stay in storage and are not exposed through the SDK.
 
+## Logging & Diagnostics
+
+The SDK integrates with the `tracing` ecosystem. You can initialize a default tracing subscriber for native binaries/tests:
+
+```rust
+use stellar_private_payments_sdk::init_tracing;
+
+fn main() {
+    // Installs a subscriber logging to stdout based on RUST_LOG env var
+    init_tracing();
+}
+```
+
 ## Browser / WASM
 
 See [`../web/README.md`](../web/README.md). JS method names align with Rust where possible (`operationalFeed`, `recipientLookup`, `userPublicKeys`, `isRegistered`).

--- a/sdk/client/README.md
+++ b/sdk/client/README.md
@@ -99,16 +99,28 @@ Private note/encryption keys stay in storage and are not exposed through the SDK
 
 ## Logging & Diagnostics
 
-The SDK integrates with the `tracing` ecosystem. You can initialize a default tracing subscriber for native binaries/tests:
+The SDK emits `tracing` spans and events but does **not** install a subscriber —
+that is the consumer's responsibility, so the library stays free of a
+`tracing-subscriber` dependency. Install one in your binary/tests, and include
+[`types::CorrelationIdLayer`] so nested SDK calls inherit an ambient
+`correlation_id`:
 
 ```rust
-use stellar_private_payments_sdk::init_tracing;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use stellar_private_payments_sdk::types::CorrelationIdLayer;
 
 fn main() {
-    // Installs a subscriber logging to stdout based on RUST_LOG env var
-    init_tracing();
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    let _ = tracing_subscriber::registry()
+        .with(filter)
+        .with(tracing_subscriber::fmt::layer())
+        .with(CorrelationIdLayer)
+        .try_init();
 }
 ```
+
+See the CLI's `logging` module for a full example (human vs. JSON output).
 
 ## Browser / WASM
 

--- a/sdk/client/README.md
+++ b/sdk/client/README.md
@@ -120,7 +120,10 @@ fn main() {
 }
 ```
 
-See the CLI's `logging` module for a full example (human vs. JSON output).
+See the CLI's `logging` module for a full example (human vs. JSON output) configuring the `TelemetryConfig` sink.
+
+### Intermediate SDK Logs
+Intermediate transaction lifecycle steps (simulating, submitting, confirming) are instrumented at the `info!` level in the `stellar` and `client` crates. Every operation uses an inherited or generated `correlation_id` so that the entire blocking call trace (e.g., `pool.deposit()`) can be correlated end-to-end. To view these steps, ensure your tracing subscriber or `TelemetryConfig` filters include at least `info` for `stellar_private_payments_sdk` and `stellar`.
 
 ## Browser / WASM
 

--- a/sdk/client/src/blocking/client.rs
+++ b/sdk/client/src/blocking/client.rs
@@ -15,6 +15,7 @@ pub struct Client {
 }
 
 impl Client {
+    #[tracing::instrument(name = "blocking_client_init", level = "info", skip_all, fields(correlation_id = %crate::correlation::correlation_id_or_new()))]
     pub fn init(
         rpc_url: impl AsRef<str>,
         storage: LocalStorage,

--- a/sdk/client/src/blocking/pool.rs
+++ b/sdk/client/src/blocking/pool.rs
@@ -29,14 +29,17 @@ impl PrivatePool {
         self.inner.config()
     }
 
+    #[tracing::instrument(name = "blocking_estimate", level = "info", skip_all, fields(correlation_id = %crate::correlation::correlation_id_or_new(), amount = ?types::Sensitive(&amount)))]
     pub fn estimate(&self, amount: NoteAmount) -> Result<Estimate, Error> {
         block_on(self.inner.estimate(amount))
     }
 
+    #[tracing::instrument(name = "blocking_deposit", level = "info", skip_all, fields(correlation_id = %crate::correlation::correlation_id_or_new(), amount = ?types::Sensitive(&amount)))]
     pub fn deposit(&self, amount: NoteAmount) -> Result<TransactionResult, Error> {
         block_on(self.inner.deposit(amount))
     }
 
+    #[tracing::instrument(name = "blocking_transfer", level = "info", skip_all, fields(correlation_id = %crate::correlation::correlation_id_or_new(), amount = ?types::Sensitive(&amount)))]
     pub fn transfer(
         &self,
         recipient: impl Into<TransferRecipient>,
@@ -45,6 +48,7 @@ impl PrivatePool {
         block_on(self.inner.transfer(recipient, amount))
     }
 
+    #[tracing::instrument(name = "blocking_withdraw", level = "info", skip_all, fields(correlation_id = %crate::correlation::correlation_id_or_new(), amount = ?types::Sensitive(&amount)))]
     pub fn withdraw(
         &self,
         amount: NoteAmount,
@@ -53,6 +57,7 @@ impl PrivatePool {
         block_on(self.inner.withdraw(amount, recipient))
     }
 
+    #[tracing::instrument(name = "blocking_transact", level = "info", skip_all, fields(correlation_id = %crate::correlation::correlation_id_or_new()))]
     pub fn transact(&self, step: tx_planner::Transact) -> Result<TransactionResult, Error> {
         block_on(self.inner.transact(step))
     }
@@ -110,10 +115,12 @@ impl PrivatePool {
         block_on(self.inner.simulate(prepared))
     }
 
+    #[tracing::instrument(name = "blocking_submit", level = "info", skip_all, fields(correlation_id = %crate::correlation::correlation_id_or_new()))]
     pub fn submit(&self, signed_tx: SignedTransaction) -> Result<String, Error> {
         block_on(self.inner.submit(signed_tx))
     }
 
+    #[tracing::instrument(name = "blocking_confirm", level = "info", skip_all, fields(correlation_id = %crate::correlation::correlation_id_or_new(), hash = %hash))]
     pub fn confirm(&self, hash: &str) -> Result<TransactionResult, Error> {
         block_on(self.inner.confirm(hash))
     }

--- a/sdk/client/src/client.rs
+++ b/sdk/client/src/client.rs
@@ -14,6 +14,13 @@ use crate::{
 /// [`Self::background_sync`] to switch to background indexing.
 ///
 /// Initialize a native tracing subscriber for CLI or non-WASM consumers.
+///
+/// Reads the `RUST_LOG` environment variable (or defaults to `info`) and
+/// installs a [`tracing_subscriber`] console formatter, plus
+/// [`types::CorrelationIdLayer`] so nested calls can inherit an ambient
+/// `correlation_id` via [`crate::correlation::correlation_id_or_new`].
+/// Subsequent calls are ignored if a subscriber is already installed.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn init_tracing() {
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 

--- a/sdk/client/src/client.rs
+++ b/sdk/client/src/client.rs
@@ -12,26 +12,6 @@ use crate::{
 /// Configure with local storage, a prover, and RPC; then sync and open
 /// [`Account`] sessions. Starts in [`SyncMode::Inline`]; call
 /// [`Self::background_sync`] to switch to background indexing.
-///
-/// Initialize a native tracing subscriber for CLI or non-WASM consumers.
-///
-/// Reads the `RUST_LOG` environment variable (or defaults to `info`) and
-/// installs a [`tracing_subscriber`] console formatter, plus
-/// [`types::CorrelationIdLayer`] so nested calls can inherit an ambient
-/// `correlation_id` via [`crate::correlation::correlation_id_or_new`].
-/// Subsequent calls are ignored if a subscriber is already installed.
-#[cfg(not(target_arch = "wasm32"))]
-pub fn init_tracing() {
-    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-
-    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
-    let _ = tracing_subscriber::registry()
-        .with(filter)
-        .with(tracing_subscriber::fmt::layer())
-        .with(types::CorrelationIdLayer)
-        .try_init();
-}
 pub struct Client<S: Storage> {
     rpc: RpcClient,
     storage: S,

--- a/sdk/client/src/client.rs
+++ b/sdk/client/src/client.rs
@@ -3,6 +3,7 @@ use types::{ContractConfig, OperationalFeedItem, RecipientLookup};
 use crate::{
     Account, Error, Handle, NoopProver, Prover, Signer, Storage, SyncMode,
     chain::{RpcClient, StateFetcher},
+    correlation::correlation_id_or_new,
     sync::{BackgroundSync, SyncHandle, catch_up},
 };
 
@@ -11,6 +12,19 @@ use crate::{
 /// Configure with local storage, a prover, and RPC; then sync and open
 /// [`Account`] sessions. Starts in [`SyncMode::Inline`]; call
 /// [`Self::background_sync`] to switch to background indexing.
+///
+/// Initialize a native tracing subscriber for CLI or non-WASM consumers.
+pub fn init_tracing() {
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    let _ = tracing_subscriber::registry()
+        .with(filter)
+        .with(tracing_subscriber::fmt::layer())
+        .with(types::CorrelationIdLayer)
+        .try_init();
+}
 pub struct Client<S: Storage> {
     rpc: RpcClient,
     storage: S,
@@ -27,6 +41,8 @@ impl<S: Storage> Client<S> {
         contract_config: ContractConfig,
         bootnode_url: Option<String>,
     ) -> Result<Self, Error> {
+        let _span =
+            tracing::info_span!("client_init", correlation_id = %correlation_id_or_new()).entered();
         let rpc = RpcClient::new(rpc_url.as_ref())
             .map_err(|e| Error::Other(format!("rpc error: {e:#}")))?;
         Ok(Self {
@@ -132,6 +148,9 @@ impl<S: Storage> Client<S> {
         user_address: impl Into<String>,
         signer: Handle<dyn Signer>,
     ) -> Result<Account<S>, Error> {
+        let _span =
+            tracing::info_span!("client_account", correlation_id = %correlation_id_or_new())
+                .entered();
         Ok(Account::new(
             self.rpc.clone(),
             self.storage.fork()?,

--- a/sdk/client/src/correlation.rs
+++ b/sdk/client/src/correlation.rs
@@ -3,7 +3,8 @@
 //! The shared implementation lives in the `types` crate so native and web
 //! use one; re-exported here for `crate::correlation::…` call sites.
 //! [`types::CorrelationIdLayer`] must be part of the installed subscriber
-//! (see [`crate::init_tracing`]) for [`correlation_id_or_new`] to correctly
-//! inherit an ambient ID instead of always minting a new one.
+//! (the consumer installs one; see the CLI's `logging` module for an example)
+//! for [`correlation_id_or_new`] to correctly inherit an ambient ID instead of
+//! always minting a new one.
 
 pub use types::correlation_id_or_new;

--- a/sdk/client/src/correlation.rs
+++ b/sdk/client/src/correlation.rs
@@ -1,0 +1,9 @@
+//! Correlation ID generation and propagation for the native SDK.
+//!
+//! The shared implementation lives in the `types` crate so native and web
+//! use one; re-exported here for `crate::correlation::…` call sites.
+//! [`types::CorrelationIdLayer`] must be part of the installed subscriber
+//! (see [`crate::init_tracing`]) for [`correlation_id_or_new`] to correctly
+//! inherit an ambient ID instead of always minting a new one.
+
+pub use types::correlation_id_or_new;

--- a/sdk/client/src/lib.rs
+++ b/sdk/client/src/lib.rs
@@ -101,7 +101,9 @@ mod sync;
 mod transact;
 
 pub use account::Account;
-pub use client::{Client, init_tracing};
+pub use client::Client;
+#[cfg(not(target_arch = "wasm32"))]
+pub use client::init_tracing;
 pub use core::PoolCore;
 pub use disclosure::{
     BuildDisclosureInputs, DisclosureInputs, DisclosureInputsRequest, DisclosureProveParams,

--- a/sdk/client/src/lib.rs
+++ b/sdk/client/src/lib.rs
@@ -102,8 +102,6 @@ mod transact;
 
 pub use account::Account;
 pub use client::Client;
-#[cfg(not(target_arch = "wasm32"))]
-pub use client::init_tracing;
 pub use core::PoolCore;
 pub use disclosure::{
     BuildDisclosureInputs, DisclosureInputs, DisclosureInputsRequest, DisclosureProveParams,

--- a/sdk/client/src/lib.rs
+++ b/sdk/client/src/lib.rs
@@ -88,6 +88,7 @@ mod account;
 pub mod blocking;
 mod client;
 mod core;
+mod correlation;
 mod error;
 mod handle;
 mod plan;
@@ -100,7 +101,7 @@ mod sync;
 mod transact;
 
 pub use account::Account;
-pub use client::Client;
+pub use client::{Client, init_tracing};
 pub use core::PoolCore;
 pub use disclosure::{
     BuildDisclosureInputs, DisclosureInputs, DisclosureInputsRequest, DisclosureProveParams,

--- a/sdk/client/src/pool.rs
+++ b/sdk/client/src/pool.rs
@@ -9,6 +9,7 @@ use crate::{
     PoolCore, PreparedTransaction,
     chain::RpcClient,
     core::{pool_transact_input, transact_step_for_plan},
+    correlation::correlation_id_or_new,
     disclosure::{
         DisclosureInputsRequest, DisclosureProveParams, DisclosureRequest,
         verify_disclosure_receipt,
@@ -102,7 +103,9 @@ impl<S: Storage> PrivatePool<S> {
         self.core.estimate(&wallet, amount)
     }
 
+    #[tracing::instrument(skip(self), fields(correlation_id = %correlation_id_or_new()))]
     pub async fn deposit(&self, amount: NoteAmount) -> Result<TransactionResult, Error> {
+        tracing::info!(amount = ?types::Sensitive(amount), "deposit started");
         let mut plan = self.prepare_deposit(amount)?;
         self.execute(&mut plan)
             .await?
@@ -110,27 +113,35 @@ impl<S: Storage> PrivatePool<S> {
             .ok_or_else(|| Error::Other("deposit produced no transaction".into()))
     }
 
+    #[tracing::instrument(skip(self, recipient), fields(correlation_id = %correlation_id_or_new()))]
     pub async fn transfer(
         &self,
         recipient: impl Into<TransferRecipient>,
         amount: NoteAmount,
     ) -> Result<Vec<TransactionResult>, Error> {
+        let recipient = recipient.into();
+        tracing::info!(recipient = ?types::Sensitive(&recipient), amount = ?types::Sensitive(amount), "transfer started");
         let wallet = self.spendable_notes().await?;
         let mut plan = self.prepare_transfer(&wallet, recipient, amount).await?;
         self.execute(&mut plan).await
     }
 
+    #[tracing::instrument(skip(self, recipient), fields(correlation_id = %correlation_id_or_new()))]
     pub async fn withdraw(
         &self,
         amount: NoteAmount,
         recipient: impl Into<String>,
     ) -> Result<Vec<TransactionResult>, Error> {
+        let recipient = recipient.into();
+        tracing::info!(amount = ?types::Sensitive(amount), recipient = ?types::Sensitive(&recipient), "withdraw started");
         let wallet = self.spendable_notes().await?;
         let mut plan = self.prepare_withdraw(&wallet, amount, recipient)?;
         self.execute(&mut plan).await
     }
 
+    #[tracing::instrument(skip(self, step), fields(correlation_id = %correlation_id_or_new()))]
     pub async fn transact(&self, step: Transact) -> Result<TransactionResult, Error> {
+        tracing::info!(step = ?types::Sensitive(&step), "transact started");
         let mut plan = self.prepare_transact(step);
         self.execute(&mut plan)
             .await?
@@ -138,10 +149,12 @@ impl<S: Storage> PrivatePool<S> {
             .ok_or_else(|| Error::Other("transact produced no transaction".into()))
     }
 
+    #[tracing::instrument(skip(self, req), fields(correlation_id = %correlation_id_or_new()))]
     pub async fn disclose(
         &self,
         req: DisclosureRequest,
     ) -> Result<Option<DisclosureReceipt>, Error> {
+        tracing::info!(selected_commitments = ?types::Sensitive(&req.selected_commitments), "disclose started");
         if req.selected_commitments.is_empty() || req.selected_commitments.len() > 4 {
             return Err(Error::Other(
                 "selective disclosure requires 1..=4 selected commitments".into(),
@@ -212,11 +225,13 @@ impl<S: Storage> PrivatePool<S> {
         }
     }
 
+    #[tracing::instrument(skip(self, receipt, expected_vk_hash), fields(correlation_id = %correlation_id_or_new()))]
     pub async fn verify_disclosure(
         &self,
         receipt: &DisclosureReceipt,
         expected_vk_hash: &str,
     ) -> Result<DisclosureVerificationReport, Error> {
+        tracing::info!(expected_vk_hash = ?types::Sensitive(expected_vk_hash), "verify_disclosure started");
         verify_disclosure_receipt(
             &self.fetcher,
             self.prover.as_ref(),
@@ -384,6 +399,8 @@ impl<S: Storage> PrivatePool<S> {
     ) -> Result<Vec<TransactionResult>, Error> {
         let mut results = Vec::new();
         while !plan.is_complete() {
+            let step_index = results.len();
+            tracing::info!(step_index, "execute plan step");
             let mut prepared = {
                 let mut sync_waits = 0u32;
                 loop {
@@ -414,11 +431,17 @@ impl<S: Storage> PrivatePool<S> {
                 Err(error) => return Err(PlanExecutionError::into_error(results, error)),
             };
             let hash = match self.submit(signed).await {
-                Ok(hash) => hash,
+                Ok(hash) => {
+                    tracing::info!(hash, "transaction submitted");
+                    hash
+                }
                 Err(error) => return Err(PlanExecutionError::into_error(results, error)),
             };
             let result = match self.confirm(&hash).await {
-                Ok(result) => result,
+                Ok(result) => {
+                    tracing::info!(hash, "transaction confirmed");
+                    result
+                }
                 Err(error) => return Err(PlanExecutionError::into_error(results, error)),
             };
             results.push(result);

--- a/sdk/client/src/pool.rs
+++ b/sdk/client/src/pool.rs
@@ -103,7 +103,7 @@ impl<S: Storage> PrivatePool<S> {
         self.core.estimate(&wallet, amount)
     }
 
-    #[tracing::instrument(skip(self), fields(correlation_id = %correlation_id_or_new()))]
+    #[tracing::instrument(skip(self), fields(correlation_id = %correlation_id_or_new(), amount = ?types::Sensitive(amount)))]
     pub async fn deposit(&self, amount: NoteAmount) -> Result<TransactionResult, Error> {
         tracing::info!(amount = ?types::Sensitive(amount), "deposit started");
         let mut plan = self.prepare_deposit(amount)?;
@@ -113,7 +113,7 @@ impl<S: Storage> PrivatePool<S> {
             .ok_or_else(|| Error::Other("deposit produced no transaction".into()))
     }
 
-    #[tracing::instrument(skip(self, recipient), fields(correlation_id = %correlation_id_or_new()))]
+    #[tracing::instrument(skip(self, recipient), fields(correlation_id = %correlation_id_or_new(), amount = ?types::Sensitive(amount)))]
     pub async fn transfer(
         &self,
         recipient: impl Into<TransferRecipient>,
@@ -126,7 +126,7 @@ impl<S: Storage> PrivatePool<S> {
         self.execute(&mut plan).await
     }
 
-    #[tracing::instrument(skip(self, recipient), fields(correlation_id = %correlation_id_or_new()))]
+    #[tracing::instrument(skip(self, recipient), fields(correlation_id = %correlation_id_or_new(), amount = ?types::Sensitive(amount)))]
     pub async fn withdraw(
         &self,
         amount: NoteAmount,

--- a/sdk/client/src/sync.rs
+++ b/sdk/client/src/sync.rs
@@ -239,7 +239,7 @@ impl<S: Storage> BackgroundSync<S> {
             return Ok(());
         }
 
-        log::info!(
+        tracing::info!(
             "background sync starting (bootnode={})",
             self.bootnode_url.as_deref().unwrap_or("<none>")
         );
@@ -252,18 +252,18 @@ impl<S: Storage> BackgroundSync<S> {
         .await
         {
             Ok(indexer) => {
-                log::info!("background sync: main RPC indexer ready");
+                tracing::info!("background sync: main RPC indexer ready");
                 indexer
             }
             Err(e) if is_rpc_sync_gap(&e) => {
                 if self.is_stopped() {
                     return Ok(());
                 }
-                log::warn!("background sync: main RPC sync gap, switching to bootnode");
+                tracing::warn!("background sync: main RPC sync gap, switching to bootnode");
                 match self.bootnode_catch_up().await {
                     Ok(()) => {}
                     Err(_) if self.is_stopped() => {
-                        log::info!("background sync stopped during bootnode catch-up");
+                        tracing::info!("background sync stopped during bootnode catch-up");
                         return Ok(());
                     }
                     Err(e) => return Err(e),
@@ -271,7 +271,7 @@ impl<S: Storage> BackgroundSync<S> {
                 if self.is_stopped() {
                     return Ok(());
                 }
-                log::info!("background sync: bootnode catch-up finished, resuming main RPC");
+                tracing::info!("background sync: bootnode catch-up finished, resuming main RPC");
                 Indexer::init(
                     self.rpc.clone(),
                     self.storage.fork()?,
@@ -285,11 +285,11 @@ impl<S: Storage> BackgroundSync<S> {
 
         loop {
             if self.is_stopped() {
-                log::info!("background sync stopped");
+                tracing::info!("background sync stopped");
                 return Ok(());
             }
             if let Err(e) = catch_up_loop(&indexer, &self.storage, Some(self.stop.as_ref())).await {
-                log::error!("background sync fetch failed: {e:#}");
+                tracing::error!("background sync fetch failed: {e:#}");
             }
             self.kick.wait_timeout(BACKGROUND_SYNC_INTERVAL_MS).await;
         }
@@ -392,7 +392,7 @@ async fn bootnode_catch_up<S: Storage>(
         ));
     };
 
-    log::info!("main RPC sync gap, trying bootnode at {bootnode}");
+    tracing::info!("main RPC sync gap, trying bootnode at {bootnode}");
     storage.clear_indexing_cursors().await?;
 
     let bootnode_client =
@@ -402,7 +402,7 @@ async fn bootnode_catch_up<S: Storage>(
         match Indexer::init(bootnode_client, storage.fork()?, contract_config).await {
             Ok(indexer) => indexer,
             Err(e) if is_retention_handoff_err(&e) => {
-                log::info!("bootnode handoff, resuming on main RPC");
+                tracing::info!("bootnode handoff, resuming on main RPC");
                 return Ok(());
             }
             Err(e) => return Err(Error::Other(format!("bootnode indexer: {e:#}"))),
@@ -427,14 +427,14 @@ async fn bootnode_catch_up<S: Storage>(
                 if e.downcast_ref::<RpcError>()
                     .is_some_and(is_retention_handoff) =>
             {
-                log::info!("bootnode handoff, resuming on main RPC");
+                tracing::info!("bootnode handoff, resuming on main RPC");
                 storage.clear_indexing_cursors().await?;
                 return Ok(());
             }
             // bootnode generic error
             Err(e) => {
                 consecutive_failures = consecutive_failures.saturating_add(1);
-                log::error!(
+                tracing::error!(
                     "bootnode sync round failed ({consecutive_failures}/{BOOTNODE_CATCH_UP_MAX_FAILURES}): {e:#}"
                 );
                 if consecutive_failures >= BOOTNODE_CATCH_UP_MAX_FAILURES {

--- a/sdk/client/src/transact.rs
+++ b/sdk/client/src/transact.rs
@@ -274,7 +274,7 @@ fn build_pool_inputs(
         let Some((amount, blinding, leaf_index)) =
             storage.get_unspent_user_note_by_commitment(pool_address, user_address, commitment)?
         else {
-            log::info!(
+            tracing::info!(
                 "unspent note not found for commitment {commitment}; waiting for note derivation"
             );
             return Ok(Err(AspMembershipSync::SyncRequired(None)));
@@ -296,7 +296,7 @@ pub fn build_validated_pool_tree(
     let leaves = storage.get_pool_commitment_leaves_ordered(pool_address)?;
 
     if leaves.len() != pool_next_index as usize {
-        log::info!(
+        tracing::info!(
             "pool commitments not synced: local={}, chain={}",
             leaves.len(),
             pool_next_index

--- a/sdk/disclosure/Cargo.toml
+++ b/sdk/disclosure/Cargo.toml
@@ -16,6 +16,8 @@ types = { workspace = true }
 anyhow = { workspace = true }
 hex = { workspace = true }
 sha2 = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true

--- a/sdk/disclosure/Cargo.toml
+++ b/sdk/disclosure/Cargo.toml
@@ -17,7 +17,8 @@ anyhow = { workspace = true }
 hex = { workspace = true }
 sha2 = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+# Cross-target clock (std on native, performance.now() on wasm)
+web-time = { workspace = true }
 
 [lints]
 workspace = true

--- a/sdk/disclosure/src/lib.rs
+++ b/sdk/disclosure/src/lib.rs
@@ -9,8 +9,9 @@ use types::{
     SELECTIVE_DISCLOSURE_1_N_NOTES, SELECTIVE_DISCLOSURE_2_CIRCUIT, SELECTIVE_DISCLOSURE_2_LEVELS,
     SELECTIVE_DISCLOSURE_2_N_NOTES, SELECTIVE_DISCLOSURE_3_CIRCUIT, SELECTIVE_DISCLOSURE_3_LEVELS,
     SELECTIVE_DISCLOSURE_3_N_NOTES, SELECTIVE_DISCLOSURE_4_CIRCUIT, SELECTIVE_DISCLOSURE_4_LEVELS,
-    SELECTIVE_DISCLOSURE_4_N_NOTES,
+    SELECTIVE_DISCLOSURE_4_N_NOTES, correlation_id_or_new,
 };
+use web_time::Instant;
 
 /// Domain prefix for `ext_context_hash` derivation.
 const CONTEXT_HASH_DOMAIN: &[u8] = b"disclosure-context-v1";
@@ -43,6 +44,7 @@ pub fn vk_hash_hex(vk_bytes: &[u8]) -> String {
 ///
 /// # Errors
 /// Returns an error if context validation fails.
+#[tracing::instrument(level = "debug", skip_all, fields(correlation_id = %correlation_id_or_new(), context_fields = 6usize))]
 pub fn derive_ext_context_hash(context: &DisclosureContext) -> Result<Field> {
     context.validate()?;
 
@@ -154,6 +156,7 @@ impl RegisteredCircuit {
     /// Returns an error if the receipt schema is invalid, the circuit metadata
     /// does not match this circuit, or the verifying-key hash differs from
     /// `expected_vk_hash`.
+    #[tracing::instrument(skip_all, fields(correlation_id = %correlation_id_or_new(), circuit = self.name))]
     pub fn validate_receipt(
         &self,
         receipt: &DisclosureReceipt,
@@ -165,9 +168,16 @@ impl RegisteredCircuit {
         expected.validate()?;
 
         if receipt.circuit != expected {
+            tracing::debug!(
+                levels_match = receipt.circuit.levels == expected.levels,
+                n_notes_match = receipt.circuit.n_notes == expected.n_notes,
+                vk_hash_match = receipt.circuit.vk_hash == expected.vk_hash,
+                "receipt circuit metadata mismatch"
+            );
             return Err(anyhow!("Disclosure receipt circuit metadata mismatch"));
         }
 
+        tracing::debug!("receipt circuit metadata validated");
         Ok(())
     }
 
@@ -347,7 +357,6 @@ pub fn find_circuit(name: &str) -> Option<&'static RegisteredCircuit> {
 }
 
 /// Validates a receipt against the registered circuit named in the receipt.
-#[tracing::instrument(skip(receipt), fields(stage = "disclosure_receipt_validation", circuit_name = %receipt.circuit.name))]
 ///
 /// # Arguments
 /// * `receipt` - Receipt to validate.
@@ -359,6 +368,7 @@ pub fn find_circuit(name: &str) -> Option<&'static RegisteredCircuit> {
 /// # Errors
 /// Returns an error if the receipt names an unknown circuit, fails schema
 /// validation, or does not match the expected circuit metadata.
+#[tracing::instrument(skip(receipt), fields(correlation_id = %correlation_id_or_new(), stage = "disclosure_receipt_validation", circuit_name = %receipt.circuit.name, expected_vk_hash = ?types::Sensitive(expected_vk_hash)))]
 pub fn validate_registered_receipt(
     receipt: &DisclosureReceipt,
     expected_vk_hash: &str,
@@ -366,6 +376,7 @@ pub fn validate_registered_receipt(
     let circuit = find_circuit(&receipt.circuit.name)
         .ok_or_else(|| anyhow!("Unknown disclosure circuit: {}", receipt.circuit.name))?;
     circuit.validate_receipt(receipt, expected_vk_hash)?;
+    tracing::debug!(circuit = circuit.name, "registered receipt validated");
     Ok(circuit)
 }
 
@@ -379,7 +390,6 @@ pub struct ProvedReceiptProof {
 }
 
 /// Proves a disclosure witness using the real Groth16 prover.
-#[tracing::instrument(skip(proving_key_bytes, r1cs_bytes, witness_bytes), fields(stage = "disclosure_proof_generation", pk_size = proving_key_bytes.len(), r1cs_size = r1cs_bytes.len(), witness_size = witness_bytes.len()))]
 ///
 /// # Arguments
 /// * `proving_key_bytes` - Serialized compressed Groth16 proving key.
@@ -394,17 +404,23 @@ pub struct ProvedReceiptProof {
 /// Returns an error if the proving key or R1CS cannot be loaded, proving
 /// fails, public input extraction fails, or the generated proof does not verify
 /// locally.
+#[tracing::instrument(skip(proving_key_bytes, r1cs_bytes, witness_bytes), fields(correlation_id = %correlation_id_or_new(), stage = "disclosure_proof_generation", pk_size = proving_key_bytes.len(), r1cs_size = r1cs_bytes.len(), witness_size = witness_bytes.len()))]
 pub fn prove_receipt_proof(
     proving_key_bytes: &[u8],
     r1cs_bytes: &[u8],
     witness_bytes: &[u8],
 ) -> Result<ProvedReceiptProof> {
-    let prover = Prover::new(proving_key_bytes, r1cs_bytes)?;
-    prove_receipt_proof_with_prover(&prover, witness_bytes)
+    let start = Instant::now();
+    let result = Prover::new(proving_key_bytes, r1cs_bytes)
+        .and_then(|prover| prove_receipt_proof_with_prover(&prover, witness_bytes));
+    tracing::debug!(
+        elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+        "disclosure proof generation completed"
+    );
+    result
 }
 
 /// Proves a disclosure witness using an existing Groth16 prover.
-#[tracing::instrument(skip(prover, witness_bytes), fields(stage = "disclosure_proof_generation_cached", witness_size = witness_bytes.len()))]
 ///
 /// This is identical to [`prove_receipt_proof`] but reuses an already
 /// initialised [`Prover`] instance, avoiding the cost of re-deserialising
@@ -422,21 +438,31 @@ pub fn prove_receipt_proof(
 /// # Errors
 /// Returns an error if proving fails, public input extraction fails, or the
 /// generated proof does not verify locally.
+#[tracing::instrument(skip(prover, witness_bytes), fields(correlation_id = %correlation_id_or_new(), stage = "disclosure_proof_generation_cached", witness_size = witness_bytes.len()))]
 pub fn prove_receipt_proof_with_prover(
     prover: &Prover,
     witness_bytes: &[u8],
 ) -> Result<ProvedReceiptProof> {
-    let proof_compressed = prover.prove_bytes(witness_bytes)?;
-    let public_inputs = prover.extract_public_inputs(witness_bytes)?;
+    let start = Instant::now();
+    let result = (|| {
+        let proof_compressed = prover.prove_bytes(witness_bytes)?;
+        let public_inputs = prover.extract_public_inputs(witness_bytes)?;
 
-    if !prover.verify(&proof_compressed, &public_inputs)? {
-        return Err(anyhow!("Generated disclosure proof did not verify"));
-    }
+        if !prover.verify(&proof_compressed, &public_inputs)? {
+            tracing::warn!("generated disclosure proof failed self-verify");
+            return Err(anyhow!("Generated disclosure proof did not verify"));
+        }
 
-    Ok(ProvedReceiptProof {
-        proof_compressed,
-        public_inputs,
-    })
+        Ok(ProvedReceiptProof {
+            proof_compressed,
+            public_inputs,
+        })
+    })();
+    tracing::debug!(
+        elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+        "disclosure proof generation completed"
+    );
+    result
 }
 
 /// Validates a receipt, then serializes its public inputs for Groth16
@@ -470,7 +496,6 @@ pub fn validate_and_serialize_receipt_public_inputs(
 }
 
 /// Verifies the Groth16 proof carried by a disclosure receipt.
-#[tracing::instrument(skip(receipt, vk_bytes), fields(stage = "disclosure_receipt_proof_verification", circuit_name = %receipt.circuit.name))]
 ///
 /// # Arguments
 /// * `receipt` - Receipt containing proof bytes and named public inputs.
@@ -485,17 +510,28 @@ pub fn validate_and_serialize_receipt_public_inputs(
 /// Returns an error if `vk_bytes` do not match `expected_vk_hash`, the receipt
 /// is malformed, targets an unsupported circuit, has unexpected metadata, or
 /// contains malformed proof bytes.
+#[tracing::instrument(skip(receipt, vk_bytes), fields(correlation_id = %correlation_id_or_new(), stage = "disclosure_receipt_proof_verification", circuit_name = %receipt.circuit.name, expected_vk_hash = ?types::Sensitive(expected_vk_hash)))]
 pub fn verify_receipt_proof(
     receipt: &DisclosureReceipt,
     vk_bytes: &[u8],
     expected_vk_hash: &str,
 ) -> Result<bool> {
-    validate_verifying_key_hash(vk_bytes, expected_vk_hash)?;
+    let start = Instant::now();
+    let result = (|| {
+        validate_verifying_key_hash(vk_bytes, expected_vk_hash)?;
 
-    let circuit = validate_registered_receipt(receipt, expected_vk_hash)?;
-    let proof_bytes = receipt.proof_compressed_bytes()?;
-    let public_inputs = circuit.public_inputs_bytes(receipt)?;
-    verify_proof(vk_bytes, &proof_bytes, &public_inputs)
+        let circuit = validate_registered_receipt(receipt, expected_vk_hash)?;
+        let proof_bytes = receipt.proof_compressed_bytes()?;
+        let public_inputs = circuit.public_inputs_bytes(receipt)?;
+        verify_proof(vk_bytes, &proof_bytes, &public_inputs)
+    })();
+    tracing::debug!(
+        elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+        "receipt proof verification completed"
+    );
+    let valid = result?;
+    tracing::debug!(valid, "receipt proof verification outcome");
+    Ok(valid)
 }
 
 /// Checks that every receipt root is still known by the pool.
@@ -511,6 +547,7 @@ pub fn verify_receipt_proof(
 /// # Errors
 /// Returns an error if receipt metadata is invalid or if `is_known_root`
 /// fails for any root.
+#[tracing::instrument(name = "verify_receipt_known_roots", level = "debug", skip_all, fields(correlation_id = %correlation_id_or_new(), root_count = receipt.public_inputs.roots.len()))]
 pub fn verify_receipt_known_roots_with<F>(
     receipt: &DisclosureReceipt,
     expected_vk_hash: &str,
@@ -520,8 +557,9 @@ where
     F: FnMut(Field) -> Result<bool>,
 {
     validate_registered_receipt(receipt, expected_vk_hash)?;
-    for root in &receipt.public_inputs.roots {
+    for (index, root) in receipt.public_inputs.roots.iter().enumerate() {
         if !is_known_root(*root)? {
+            tracing::debug!(index, "receipt root not known, short-circuiting");
             return Ok(false);
         }
     }
@@ -543,6 +581,7 @@ where
 ///
 /// # Errors
 /// Returns an error if receipt metadata is invalid or if callbacks fail.
+#[tracing::instrument(name = "verify_receipt_report", skip_all, fields(correlation_id = %correlation_id_or_new(), expected_vk_hash = ?types::Sensitive(expected_vk_hash)))]
 pub fn verify_receipt_report_with<P, R>(
     receipt: &DisclosureReceipt,
     expected_vk_hash: &str,
@@ -557,8 +596,14 @@ where
     validate_registered_receipt(receipt, expected_vk_hash)?;
 
     let proof_verified = verify_proof(receipt, expected_vk_hash)?;
+    tracing::debug!(proof_verified, "receipt proof check outcome");
     let known_root_status =
         verify_receipt_known_roots_with(receipt, expected_vk_hash, &mut is_known_root)?;
+    tracing::debug!(
+        context_verified,
+        known_root_status,
+        "receipt context and root checks outcome"
+    );
 
     Ok(DisclosureVerificationReport {
         proof_verified,

--- a/sdk/disclosure/src/lib.rs
+++ b/sdk/disclosure/src/lib.rs
@@ -347,6 +347,7 @@ pub fn find_circuit(name: &str) -> Option<&'static RegisteredCircuit> {
 }
 
 /// Validates a receipt against the registered circuit named in the receipt.
+#[tracing::instrument(skip(receipt), fields(stage = "disclosure_receipt_validation", circuit_name = %receipt.circuit.name))]
 ///
 /// # Arguments
 /// * `receipt` - Receipt to validate.
@@ -378,6 +379,7 @@ pub struct ProvedReceiptProof {
 }
 
 /// Proves a disclosure witness using the real Groth16 prover.
+#[tracing::instrument(skip(proving_key_bytes, r1cs_bytes, witness_bytes), fields(stage = "disclosure_proof_generation", pk_size = proving_key_bytes.len(), r1cs_size = r1cs_bytes.len(), witness_size = witness_bytes.len()))]
 ///
 /// # Arguments
 /// * `proving_key_bytes` - Serialized compressed Groth16 proving key.
@@ -402,6 +404,7 @@ pub fn prove_receipt_proof(
 }
 
 /// Proves a disclosure witness using an existing Groth16 prover.
+#[tracing::instrument(skip(prover, witness_bytes), fields(stage = "disclosure_proof_generation_cached", witness_size = witness_bytes.len()))]
 ///
 /// This is identical to [`prove_receipt_proof`] but reuses an already
 /// initialised [`Prover`] instance, avoiding the cost of re-deserialising
@@ -467,6 +470,7 @@ pub fn validate_and_serialize_receipt_public_inputs(
 }
 
 /// Verifies the Groth16 proof carried by a disclosure receipt.
+#[tracing::instrument(skip(receipt, vk_bytes), fields(stage = "disclosure_receipt_proof_verification", circuit_name = %receipt.circuit.name))]
 ///
 /// # Arguments
 /// * `receipt` - Receipt containing proof bytes and named public inputs.

--- a/sdk/prover/Cargo.toml
+++ b/sdk/prover/Cargo.toml
@@ -30,7 +30,8 @@ crypto_secretbox = { version = "0.1.1", default-features = false, features = ["a
 serde = { workspace = true }
 sha2 = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+# Cross-target clock (std on native, performance.now() on wasm)
+web-time = { workspace = true }
 x25519-dalek = { version = "2.0", default-features = false, features = ["static_secrets"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/sdk/prover/Cargo.toml
+++ b/sdk/prover/Cargo.toml
@@ -29,6 +29,8 @@ ark-std = { workspace = true }
 crypto_secretbox = { version = "0.1.1", default-features = false, features = ["alloc", "salsa20"] }
 serde = { workspace = true }
 sha2 = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 x25519-dalek = { version = "2.0", default-features = false, features = ["static_secrets"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/sdk/prover/src/prover.rs
+++ b/sdk/prover/src/prover.rs
@@ -28,6 +28,8 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_snark::SNARK;
 use ark_std::rand::rngs::OsRng;
 use core::ops::AddAssign;
+use types::correlation_id_or_new;
+use web_time::Instant;
 
 // Soroban-compatible encoding helpers.
 // Soroban's BN254 G2 uses c1||c0 (imaginary||real) ordering, while arkworks
@@ -249,11 +251,23 @@ impl Prover {
     /// # Arguments
     /// * `pk_bytes` - Serialized proving key (compressed)
     /// * `r1cs_bytes` - R1CS binary file contents
+    #[tracing::instrument(
+        name = "prover_new",
+        skip_all,
+        fields(correlation_id = %correlation_id_or_new(), pk_len = pk_bytes.len(), r1cs_len = r1cs_bytes.len())
+    )]
     pub fn new(pk_bytes: &[u8], r1cs_bytes: &[u8]) -> Result<Prover> {
+        let start = Instant::now();
+        tracing::debug!("loading compressed proving key and R1CS");
         // Deserialize proving key. Unchecked, proving key is trusted
-        let pk = ProvingKey::<Bn254>::deserialize_compressed_unchecked(pk_bytes)
-            .map_err(|e| anyhow!("Failed to load proving key: {}", e))?;
-        Self::from_pk(pk, r1cs_bytes)
+        let result = ProvingKey::<Bn254>::deserialize_compressed_unchecked(pk_bytes)
+            .map_err(|e| anyhow!("Failed to load proving key: {}", e))
+            .and_then(|pk| Self::from_pk(pk, r1cs_bytes));
+        tracing::debug!(
+            elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "prover initialized"
+        );
+        result
     }
 
     /// Create a new Prover from an arkworks-*uncompressed* proving key.
@@ -271,11 +285,23 @@ impl Prover {
     /// # Arguments
     /// * `pk_bytes` - Serialized proving key (uncompressed)
     /// * `r1cs_bytes` - R1CS binary file contents
+    #[tracing::instrument(
+        name = "prover_new_uncompressed",
+        skip_all,
+        fields(correlation_id = %correlation_id_or_new(), pk_len = pk_bytes.len(), r1cs_len = r1cs_bytes.len())
+    )]
     pub fn new_from_uncompressed_pk(pk_bytes: &[u8], r1cs_bytes: &[u8]) -> Result<Prover> {
+        let start = Instant::now();
+        tracing::debug!("loading uncompressed proving key and R1CS");
         // Deserialize proving key. Unchecked, proving key is trusted.
-        let pk = ProvingKey::<Bn254>::deserialize_uncompressed_unchecked(pk_bytes)
-            .map_err(|e| anyhow!("Failed to load uncompressed proving key: {}", e))?;
-        Self::from_pk(pk, r1cs_bytes)
+        let result = ProvingKey::<Bn254>::deserialize_uncompressed_unchecked(pk_bytes)
+            .map_err(|e| anyhow!("Failed to load uncompressed proving key: {}", e))
+            .and_then(|pk| Self::from_pk(pk, r1cs_bytes));
+        tracing::debug!(
+            elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "prover initialized"
+        );
+        result
     }
 
     /// Shared construction tail for [`Prover::new`] and
@@ -350,7 +376,14 @@ impl Prover {
     ///
     /// # Returns
     /// * Groth16Proof struct with proof points
+    #[tracing::instrument(
+        name = "prove",
+        skip_all,
+        fields(correlation_id = %correlation_id_or_new(), witness_len = witness_bytes.len(), num_public_inputs = self.r1cs.num_public, num_constraints = self.r1cs.num_constraints())
+    )]
     pub fn prove(&self, witness_bytes: &[u8]) -> Result<Groth16Proof> {
+        let start = Instant::now();
+        tracing::debug!("generating Groth16 proof");
         // Validate witness size
         if !witness_bytes.len().is_multiple_of(FIELD_SIZE) {
             return Err(anyhow!(
@@ -385,10 +418,15 @@ impl Prover {
 
         // Generate proof
         let mut rng = OsRng;
-        let proof = <ark_groth16::Groth16<Bn254, CircomReduction> as SNARK<Fr>>::prove(
+        let result = <ark_groth16::Groth16<Bn254, CircomReduction> as SNARK<Fr>>::prove(
             &self.pk, circuit, &mut rng,
         )
-        .map_err(|e| anyhow!("Proof generation failed: {}", e))?;
+        .map_err(|e| anyhow!("Proof generation failed: {}", e));
+        tracing::debug!(
+            elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "proof generation completed"
+        );
+        let proof = result?;
 
         // Serialize proof points
         let mut a_bytes = Vec::new();
@@ -429,7 +467,14 @@ impl Prover {
     ///
     /// Format: [A (64 bytes) || B (128 bytes) || C (64 bytes)] = 256 bytes
     /// G2 points use Soroban-compatible c1||c0 (imaginary||real) ordering.
+    #[tracing::instrument(
+        name = "prove_bytes_uncompressed",
+        skip_all,
+        fields(correlation_id = %correlation_id_or_new(), witness_len = witness_bytes.len(), num_public_inputs = self.r1cs.num_public)
+    )]
     pub fn prove_bytes_uncompressed(&self, witness_bytes: &[u8]) -> Result<Vec<u8>> {
+        let start = Instant::now();
+        tracing::debug!("generating Groth16 proof (uncompressed output)");
         // Validate witness size
         if !witness_bytes.len().is_multiple_of(FIELD_SIZE) {
             return Err(anyhow!(
@@ -460,10 +505,15 @@ impl Prover {
         };
 
         let mut rng = OsRng;
-        let proof = <ark_groth16::Groth16<Bn254, CircomReduction> as SNARK<Fr>>::prove(
+        let result = <ark_groth16::Groth16<Bn254, CircomReduction> as SNARK<Fr>>::prove(
             &self.pk, circuit, &mut rng,
         )
-        .map_err(|e| anyhow!("Proof generation failed: {}", e))?;
+        .map_err(|e| anyhow!("Proof generation failed: {}", e));
+        tracing::debug!(
+            elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "proof generation completed"
+        );
+        let proof = result?;
 
         Ok(proof_to_uncompressed_bytes(&proof))
     }
@@ -509,7 +559,14 @@ impl Prover {
     }
 
     /// Verify a proof (for testing purposes)
+    #[tracing::instrument(
+        name = "prover_verify",
+        skip_all,
+        fields(correlation_id = %correlation_id_or_new(), proof_len = proof_bytes.len(), num_public_inputs = public_inputs_bytes.len() / FIELD_SIZE)
+    )]
     pub fn verify(&self, proof_bytes: &[u8], public_inputs_bytes: &[u8]) -> Result<bool> {
+        let start = Instant::now();
+        tracing::debug!("verifying proof");
         let proof = Proof::<Bn254>::deserialize_compressed(proof_bytes)
             .map_err(|e| anyhow!("Failed to load proof: {}", e))?;
         let expected_inputs = self
@@ -519,7 +576,15 @@ impl Prover {
             .len()
             .checked_sub(1)
             .ok_or_else(|| anyhow!("Invalid verifying key"))?;
-        verify_proof_with_processed_vk(&self.pvk, expected_inputs, &proof, public_inputs_bytes)
+        let result =
+            verify_proof_with_processed_vk(&self.pvk, expected_inputs, &proof, public_inputs_bytes);
+        tracing::debug!(
+            elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "proof verification completed"
+        );
+        let valid = result?;
+        tracing::debug!(valid, "proof verification outcome");
+        Ok(valid)
     }
 }
 
@@ -528,31 +593,52 @@ impl Prover {
 /// Input: compressed proof [A || B || C]
 /// Output: uncompressed [A (64) || B (128) || C (64)] = 256 bytes
 /// G2 points use Soroban-compatible c1||c0 ordering.
+#[tracing::instrument(
+    name = "convert_proof_to_soroban",
+    skip_all,
+    fields(correlation_id = %correlation_id_or_new(), proof_len = proof_bytes.len())
+)]
 pub fn convert_proof_to_soroban(proof_bytes: &[u8]) -> Result<Vec<u8>> {
     let proof = Proof::<Bn254>::deserialize_compressed(proof_bytes)
         .map_err(|e| anyhow!("Failed to deserialize proof: {}", e))?;
     Ok(proof_to_uncompressed_bytes(&proof))
 }
 /// Standalone verification function
+#[tracing::instrument(
+    name = "verify_proof",
+    skip_all,
+    fields(correlation_id = %correlation_id_or_new(), vk_len = vk_bytes.len(), proof_len = proof_bytes.len(), num_public_inputs = public_inputs_bytes.len() / FIELD_SIZE)
+)]
 pub fn verify_proof(
     vk_bytes: &[u8],
     proof_bytes: &[u8],
     public_inputs_bytes: &[u8],
 ) -> Result<bool> {
+    let start = Instant::now();
+    tracing::debug!("verifying proof with standalone verifying key");
     // Deserialize verifying key
     let vk = VerifyingKey::<Bn254>::deserialize_compressed(vk_bytes)
         .map_err(|e| anyhow!("Failed to load VK: {}", e))?;
 
-    let pvk = <ark_groth16::Groth16<Bn254, CircomReduction> as SNARK<Fr>>::process_vk(&vk)
-        .map_err(|e| anyhow!("Failed to process VK: {}", e))?;
-    let proof = Proof::<Bn254>::deserialize_compressed(proof_bytes)
-        .map_err(|e| anyhow!("Failed to load proof: {}", e))?;
-    let expected_inputs = vk
-        .gamma_abc_g1
-        .len()
-        .checked_sub(1)
-        .ok_or_else(|| anyhow!("Invalid verifying key"))?;
-    verify_proof_with_processed_vk(&pvk, expected_inputs, &proof, public_inputs_bytes)
+    let result = <ark_groth16::Groth16<Bn254, CircomReduction> as SNARK<Fr>>::process_vk(&vk)
+        .map_err(|e| anyhow!("Failed to process VK: {}", e))
+        .and_then(|pvk| {
+            let proof = Proof::<Bn254>::deserialize_compressed(proof_bytes)
+                .map_err(|e| anyhow!("Failed to load proof: {}", e))?;
+            let expected_inputs = vk
+                .gamma_abc_g1
+                .len()
+                .checked_sub(1)
+                .ok_or_else(|| anyhow!("Invalid verifying key"))?;
+            verify_proof_with_processed_vk(&pvk, expected_inputs, &proof, public_inputs_bytes)
+        });
+    tracing::debug!(
+        elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+        "proof verification completed"
+    );
+    let valid = result?;
+    tracing::debug!(valid, "proof verification outcome");
+    Ok(valid)
 }
 
 #[cfg(test)]

--- a/sdk/state/Cargo.toml
+++ b/sdk/state/Cargo.toml
@@ -17,6 +17,8 @@ types = { workspace = true, features = ["rusqlite"] }
 anyhow = { workspace = true }
 hex = { workspace = true }
 log = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 rusqlite_migration = { version = "2.5.0", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }

--- a/sdk/state/Cargo.toml
+++ b/sdk/state/Cargo.toml
@@ -16,9 +16,7 @@ types = { workspace = true, features = ["rusqlite"] }
 # external
 anyhow = { workspace = true }
 hex = { workspace = true }
-log = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 rusqlite_migration = { version = "2.5.0", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }

--- a/sdk/state/src/processor.rs
+++ b/sdk/state/src/processor.rs
@@ -18,7 +18,7 @@ pub fn process_events(storage: &mut SqliteStorage, limit: u32) -> Result<bool> {
                 // we shouldn't delete broken events
                 // we should fix the logic then
                 // update the software and handle them
-                log::error!("cannot process event: {e:?}");
+                tracing::error!("cannot process event: {e:?}");
                 continue;
             }
         };
@@ -27,7 +27,7 @@ pub fn process_events(storage: &mut SqliteStorage, limit: u32) -> Result<bool> {
             ProcessedEvent::Commitment(ev) => commitments.push(ev),
             ProcessedEvent::PublicKey(ev) => pubkeys.push(ev),
             ProcessedEvent::LeafAdded(ev) => leaves.push(ev),
-            _ => log::warn!("event won't be saved to the storage: {parsed:?}"),
+            _ => tracing::warn!("event won't be saved to the storage: {parsed:?}"),
         }
     }
     storage.save_nullifier_events_batch(&nullifiers)?;

--- a/sdk/state/src/storage.rs
+++ b/sdk/state/src/storage.rs
@@ -103,7 +103,7 @@ impl Storage {
             }
         }
         tx.commit()?;
-        log::debug!(
+        tracing::debug!(
             "[STORAGE] saved {} events and cursor {} (latest_ledger={})",
             data.events.len(),
             data.cursor,
@@ -273,9 +273,9 @@ impl Storage {
         )
         .context("failed to insert keypairs")?;
         tx.commit().context("failed to commit transaction")?;
-        log::debug!(
+        tracing::debug!(
             "[STORAGE] saved new keypairs for the account {}",
-            account_address
+            types::Sensitive(&account_address)
         );
         Ok(())
     }
@@ -1257,7 +1257,7 @@ impl Storage {
                 .checked_div(pool_count_u32)
                 .expect("pool count is not zero")
         } else {
-            log::warn!(
+            tracing::warn!(
                 "pool count {pool_count_u32} exceeds total limit {total_limit} of commitments to scan"
             );
             1

--- a/sdk/stellar/Cargo.toml
+++ b/sdk/stellar/Cargo.toml
@@ -18,6 +18,8 @@ ed25519-dalek = { version = "2.2", default-features = false, features = ["digest
 futures = { workspace = true, features = ["executor"] }
 http = "1.4.0"
 log = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde-aux = "4.7.0"

--- a/sdk/stellar/Cargo.toml
+++ b/sdk/stellar/Cargo.toml
@@ -17,9 +17,7 @@ base64 = { workspace = true }
 ed25519-dalek = { version = "2.2", default-features = false, features = ["digest", "zeroize"] }
 futures = { workspace = true, features = ["executor"] }
 http = "1.4.0"
-log = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde-aux = "4.7.0"
@@ -31,7 +29,6 @@ stellar-xdr = { version = "26.0.0", features = ["curr", "serde", "base64", "std"
 thiserror = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-# external
 gloo-timers = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/sdk/stellar/src/contract_state.rs
+++ b/sdk/stellar/src/contract_state.rs
@@ -230,7 +230,7 @@ impl StateFetcher {
 
             if !drift.is_empty() {
                 last_drift = drift.join(", ");
-                log::debug!(
+                tracing::debug!(
                     "snapshot drift detected while fetching pool roots (attempt {attempt}/{MAX_SNAPSHOT_ATTEMPTS}): {last_drift}"
                 );
                 if attempt < MAX_SNAPSHOT_ATTEMPTS {

--- a/sdk/stellar/src/indexer.rs
+++ b/sdk/stellar/src/indexer.rs
@@ -90,7 +90,7 @@ impl<S: ContractDataStorage> Indexer<S> {
             .len()
             > 1
         {
-            log::warn!(
+            tracing::warn!(
                 "[INDEXER] sync ledger divergence detected for {} active contracts; using min last_indexed_ledger={start_ledger}",
                 active_sync.len()
             );
@@ -105,7 +105,7 @@ impl<S: ContractDataStorage> Indexer<S> {
                 .first()
                 .and_then(|meta| (!meta.cursor.is_empty()).then(|| meta.cursor.clone()))
         } else {
-            log::warn!(
+            tracing::warn!(
                 "[INDEXER] sync cursor divergence detected for {} active contracts; resetting cursor and replaying from ledger={start_ledger}",
                 active_sync.len()
             );
@@ -115,7 +115,7 @@ impl<S: ContractDataStorage> Indexer<S> {
         let mut may_have_more = false;
 
         for page in 0..MAX_PAGES_PER_ROUND {
-            log::trace!(
+            tracing::trace!(
                 "[INDEXER] bulk page {page}/{MAX_PAGES_PER_ROUND}, start_ledger={start_ledger}, network_tip={network_tip}, cursor={cursor:?}"
             );
 
@@ -128,7 +128,7 @@ impl<S: ContractDataStorage> Indexer<S> {
                 // We are ahead of the RPC's events tip: nothing to fetch until
                 // it indexes further. Idle this round instead of erroring.
                 Err(RpcError::RpcAhead(newest)) => {
-                    log::debug!(
+                    tracing::debug!(
                         "[INDEXER] local sync (start_ledger={start_ledger}) is ahead of RPC events tip (newest={newest}); waiting for RPC to catch up"
                     );
                     return Ok(false);

--- a/sdk/stellar/src/rpc.rs
+++ b/sdk/stellar/src/rpc.rs
@@ -293,6 +293,8 @@ impl Client {
         method: &'static str,
         params: P,
     ) -> Result<R, Error> {
+        tracing::debug!(method = method, "rpc_call_event");
+
         let payload = JsonRpcRequest {
             jsonrpc: "2.0",
             id: 1,
@@ -617,6 +619,7 @@ impl Client {
         Ok((result, latest_ledger))
     }
 
+    #[tracing::instrument(name = "simulate_transaction", level = "info", skip_all, fields(correlation_id = %types::correlation_id_or_new()))]
     pub async fn simulate_transaction(
         &self,
         tx: &xdr::TransactionEnvelope,
@@ -645,6 +648,7 @@ impl Client {
     }
 
     /// Submits a signed transaction envelope to the network.
+    #[tracing::instrument(name = "send_transaction", level = "info", skip_all, fields(correlation_id = %types::correlation_id_or_new()))]
     pub async fn send_transaction(
         &self,
         tx: &xdr::TransactionEnvelope,
@@ -653,6 +657,7 @@ impl Client {
         let params = json!({ "transaction": transaction });
         let resp: SendTransactionResponse = self.rpc_call("sendTransaction", params).await?;
         if resp.status == "ERROR" {
+            tracing::warn!(hash = %resp.hash, status = %resp.status, "send_transaction_failed");
             return Err(Error::JsonRpc {
                 code: -1,
                 message: format!(
@@ -665,6 +670,7 @@ impl Client {
     }
 
     /// Fetches transaction status by hash.
+    #[tracing::instrument(name = "get_transaction", level = "info", skip_all, fields(correlation_id = %types::correlation_id_or_new(), hash = %hash))]
     pub async fn get_transaction(&self, hash: &str) -> Result<GetTransactionResponse, Error> {
         let params = json!({ "hash": hash });
         self.rpc_call("getTransaction", params).await

--- a/sdk/stellar/src/submit.rs
+++ b/sdk/stellar/src/submit.rs
@@ -6,6 +6,7 @@ use stellar_xdr::curr::TransactionEnvelope;
 use crate::rpc::Client;
 
 /// Submits a signed transaction; returns the transaction hash.
+#[tracing::instrument(name = "submit_tx", level = "info", skip_all, fields(correlation_id = %types::correlation_id_or_new()))]
 pub async fn submit_tx(rpc: &Client, signed_tx: &TransactionEnvelope) -> Result<String> {
     let send = rpc
         .send_transaction(signed_tx)
@@ -15,6 +16,7 @@ pub async fn submit_tx(rpc: &Client, signed_tx: &TransactionEnvelope) -> Result<
     if hash.is_empty() {
         bail!("sendTransaction returned empty hash");
     }
+    tracing::info!(hash = %hash, "transaction_submitted");
     Ok(hash)
 }
 
@@ -26,20 +28,28 @@ pub enum TxConfirmStatus {
 }
 
 /// Polls transaction status once.
+#[tracing::instrument(name = "confirm_tx", level = "info", skip_all, fields(correlation_id = %types::correlation_id_or_new(), hash = %hash))]
 pub async fn confirm_tx(rpc: &Client, hash: &str) -> Result<TxConfirmStatus> {
     let status = rpc
         .get_transaction(hash)
         .await
         .with_context(|| format!("getTransaction failed for {hash}"))?;
     match status.status.as_str() {
-        "SUCCESS" => Ok(TxConfirmStatus::Success),
+        "SUCCESS" => {
+            tracing::info!(hash = %hash, status = "SUCCESS", "transaction_confirmed");
+            Ok(TxConfirmStatus::Success)
+        }
         "FAILED" => {
             let detail = status
                 .result_xdr
                 .map(|xdr| format!(" (resultXdr: {xdr})"))
                 .unwrap_or_default();
+            tracing::warn!(hash = %hash, status = "FAILED", detail_len = detail.len(), "transaction_failed");
             Ok(TxConfirmStatus::Failed { detail })
         }
-        _ => Ok(TxConfirmStatus::Pending),
+        _ => {
+            tracing::debug!(hash = %hash, "transaction_pending");
+            Ok(TxConfirmStatus::Pending)
+        }
     }
 }

--- a/sdk/tests/Cargo.toml
+++ b/sdk/tests/Cargo.toml
@@ -15,6 +15,8 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 stellar-private-payments-sdk = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing = { workspace = true }
 types = { workspace = true, features = ["rusqlite"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/sdk/tests/src/lib.rs
+++ b/sdk/tests/src/lib.rs
@@ -1,5 +1,26 @@
 pub mod pool;
 pub mod seed;
 
+/// Initialize a tracing subscriber that writes to the test output stream.
+///
+/// This is intended for integration tests so that failures emit an execution
+/// trace even when captured by the test harness. Includes
+/// [`types::CorrelationIdLayer`] so `correlation_id_or_new()` correctly
+/// inherits an ambient ID within a test. Subsequent calls are ignored if a
+/// subscriber is already installed.
+pub fn init_test_tracing() {
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_writer(tracing_subscriber::fmt::writer::TestWriter::new());
+    let _ = tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt_layer)
+        .with(types::CorrelationIdLayer)
+        .try_init();
+}
+
 #[cfg(test)]
 mod tests;

--- a/sdk/tests/src/tests/mod.rs
+++ b/sdk/tests/src/tests/mod.rs
@@ -1,2 +1,3 @@
 mod plan;
+mod telemetry;
 mod wallet;

--- a/sdk/tests/src/tests/telemetry.rs
+++ b/sdk/tests/src/tests/telemetry.rs
@@ -1,0 +1,65 @@
+//! Telemetry and logging privacy integration tests.
+
+use std::{
+    io::Write,
+    sync::{Arc, Mutex},
+};
+use stellar_private_payments_sdk::types::NoteAmount;
+use tracing_subscriber::layer::SubscriberExt;
+
+#[derive(Clone, Default)]
+struct MockWriter {
+    buf: Arc<Mutex<Vec<u8>>>,
+}
+
+impl Write for MockWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buf.lock().expect("lock buffer").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::writer::MakeWriter<'a> for MockWriter {
+    type Writer = MockWriter;
+
+    fn make_writer(&self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+#[test]
+fn test_ring_buffer_has_no_secrets_and_redacts_sensitive() {
+    let buf = Arc::new(Mutex::new(Vec::new()));
+    let writer = MockWriter { buf: buf.clone() };
+
+    let filter = tracing_subscriber::EnvFilter::new("info");
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_writer(writer)
+        .without_time();
+
+    let subscriber = tracing_subscriber::registry().with(filter).with(fmt_layer);
+
+    // Run within thread-local subscriber context to capture output reliably
+    tracing::subscriber::with_default(subscriber, || {
+        let sensitive_amount =
+            stellar_private_payments_sdk::types::Sensitive(NoteAmount::from(5u128));
+        tracing::info!(amount = ?sensitive_amount, "deposit started");
+    });
+
+    let output =
+        String::from_utf8(buf.lock().expect("lock buffer").clone()).expect("valid utf-8 logs");
+    println!("Captured logs:\n{}", output);
+
+    // Verify deposit log: it should contain "deposit started" and redacted amount
+    assert!(output.contains("deposit started"));
+    assert!(output.contains("amount"));
+    assert!(output.contains("<redacted>"));
+
+    // Ensure it does NOT contain the raw amount "5"
+    assert!(!output.contains("amount = 5"));
+    assert!(!output.contains("amount: 5"));
+}

--- a/sdk/tx-planner/Cargo.toml
+++ b/sdk/tx-planner/Cargo.toml
@@ -13,6 +13,8 @@ types = { workspace = true }
 
 # external
 thiserror = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true

--- a/sdk/tx-planner/Cargo.toml
+++ b/sdk/tx-planner/Cargo.toml
@@ -13,8 +13,7 @@ types = { workspace = true }
 
 # external
 thiserror = { workspace = true }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing = { workspace = true, features = ["attributes"] }
 
 [lints]
 workspace = true

--- a/sdk/tx-planner/src/execute/mod.rs
+++ b/sdk/tx-planner/src/execute/mod.rs
@@ -75,6 +75,8 @@ pub struct SpendSession {
 }
 
 impl SpendSession {
+    /// Create a new SpendSession from a wallet, amount, and target.
+    #[tracing::instrument(skip(wallet), fields(stage = "spend_session_setup", wallet_size = wallet.len(), amount = ?amount, target = ?target))]
     pub fn setup(
         wallet: Vec<SpendableNote>,
         amount: NoteAmount,
@@ -114,6 +116,8 @@ impl SpendSession {
             .is_some_and(|s| matches!(s.action, StepAction::Consolidate { .. }))
     }
 
+    /// Materialize the next planned step into a transaction payload.
+    #[tracing::instrument(skip(self), fields(stage = "spend_session_step", step_index = self.step_index, is_done = self.is_done()))]
     pub fn step(&self) -> Result<Option<Transact>, SpendSessionError> {
         if self.is_done() {
             return Ok(None);

--- a/sdk/tx-planner/src/execute/mod.rs
+++ b/sdk/tx-planner/src/execute/mod.rs
@@ -4,7 +4,9 @@ mod error;
 
 pub use error::SpendSessionError;
 
-use types::{EncryptionPublicKey, ExtAmount, Field, NoteAmount, NotePublicKey};
+use types::{
+    EncryptionPublicKey, ExtAmount, Field, NoteAmount, NotePublicKey, correlation_id_or_new,
+};
 
 use crate::plan::{PlannedStep, SpendableNote, StepAction, plan};
 
@@ -76,7 +78,7 @@ pub struct SpendSession {
 
 impl SpendSession {
     /// Create a new SpendSession from a wallet, amount, and target.
-    #[tracing::instrument(skip(wallet), fields(stage = "spend_session_setup", wallet_size = wallet.len(), amount = ?amount, target = ?target))]
+    #[tracing::instrument(skip_all, fields(stage = "spend_session_setup", correlation_id = %correlation_id_or_new(), wallet_size = wallet.len(), amount = ?types::Sensitive(&amount), target = ?types::Sensitive(&target)))]
     pub fn setup(
         wallet: Vec<SpendableNote>,
         amount: NoteAmount,
@@ -117,24 +119,32 @@ impl SpendSession {
     }
 
     /// Materialize the next planned step into a transaction payload.
-    #[tracing::instrument(skip(self), fields(stage = "spend_session_step", step_index = self.step_index, is_done = self.is_done()))]
+    #[tracing::instrument(skip_all, fields(stage = "spend_session_step", correlation_id = %correlation_id_or_new(), step_index = self.step_index, is_done = self.is_done()))]
     pub fn step(&self) -> Result<Option<Transact>, SpendSessionError> {
         if self.is_done() {
+            tracing::debug!(
+                step_index = self.step_index,
+                outcome = "done",
+                "spend session step: no more steps"
+            );
             return Ok(None);
         }
 
         let step = &self.steps[self.step_index];
         let resolved = step.resolve(&self.wallet)?;
-        Ok(Some(materialize_step(
-            step,
-            &self.pool_address,
-            &self.target,
-            &resolved,
-        )?))
+        let tx = materialize_step(step, &self.pool_address, &self.target, &resolved)?;
+        tracing::debug!(
+            step_index = self.step_index,
+            is_consolidate_step = self.is_consolidate_step(),
+            outcome = "materialized",
+            "spend session step transition"
+        );
+        Ok(Some(tx))
     }
 
     /// Advance after a successful submit (`output_commitments` from prove
     /// result).
+    #[tracing::instrument(skip_all, name = "spend_session_complete_step", fields(correlation_id = %correlation_id_or_new(), step_index = self.step_index))]
     pub fn complete_step(
         &mut self,
         output_commitments: &[Field; 2],
@@ -145,6 +155,7 @@ impl SpendSession {
 
         let step = self.steps[self.step_index].clone();
         let spent = step.resolve(&self.wallet)?;
+        let spent_count = spent.len();
 
         let merge_output = match step.action {
             StepAction::Consolidate { output } => Some(SpendableNote {
@@ -153,6 +164,7 @@ impl SpendSession {
             }),
             StepAction::Final { .. } => None,
         };
+        let merged_output = merge_output.is_some();
 
         match step.action {
             StepAction::Consolidate { .. } => {
@@ -168,6 +180,12 @@ impl SpendSession {
             .step_index
             .checked_add(1)
             .expect("step_index stays within plan length");
+        tracing::debug!(
+            spent_count,
+            merged_output,
+            outcome = "completed",
+            "spend session step completed"
+        );
         Ok(())
     }
 }

--- a/sdk/tx-planner/src/plan/combination.rs
+++ b/sdk/tx-planner/src/plan/combination.rs
@@ -1,7 +1,7 @@
 //! Coin selection: pick note indices that reach a target amount.
 
 use super::PlanError;
-use types::NoteAmount;
+use types::{NoteAmount, correlation_id_or_new};
 
 /// Upper bound on combination size explored by [`find_combination`].
 pub const TRANSACTION_LIMIT: usize = 10;
@@ -27,6 +27,7 @@ pub enum CombinationResult {
 /// Find a combination of elements with sum equal to or larger than the goal,
 /// prioritizing the lowest combination count (with two-note pairs preferred
 /// over single-note exact matches).
+#[tracing::instrument(level = "trace", skip_all, fields(correlation_id = %correlation_id_or_new(), note_count = values.len(), goal = ?types::Sensitive(&goal)))]
 pub fn find_combination(
     values: &[NoteAmount],
     goal: NoteAmount,
@@ -40,25 +41,59 @@ pub fn find_combination(
 
     let two = TwoScan::scan(&sorted_vals, goal)?;
     if let TwoScan::Exact(i, j) = two {
+        tracing::trace!(
+            tier = "two-exact",
+            count = 2,
+            "find_combination tier succeeded"
+        );
         return Ok(CombinationResult::TwoExact(i, j));
     }
 
     let one = OneScan::scan(&sorted_vals, goal);
     if let OneScan::Exact(i) = one {
+        tracing::trace!(
+            tier = "one-exact",
+            count = 1,
+            "find_combination tier succeeded"
+        );
         return Ok(CombinationResult::OneExact(i));
     }
 
     if let TwoScan::Overshoot(i, j, excess) = two {
+        tracing::trace!(
+            tier = "two-overshoot",
+            count = 2,
+            "find_combination tier succeeded"
+        );
         return Ok(CombinationResult::TwoOvershoot(i, j, excess));
     }
 
     if let OneScan::Overshoot(i, excess) = one {
+        tracing::trace!(
+            tier = "one-overshoot",
+            count = 1,
+            "find_combination tier succeeded"
+        );
         return Ok(CombinationResult::OneOvershoot(i, excess));
     }
 
     match KScan::scan(&sorted_vals, goal)? {
-        KScan::Exact(indices) => Ok(CombinationResult::ExactK(indices)),
-        KScan::Overshoot(indices, excess) => Ok(CombinationResult::Overshoot(indices, excess)),
+        KScan::Exact(indices) => {
+            tracing::trace!(
+                tier = "k-scan-exact",
+                count = indices.len(),
+                "find_combination tier succeeded"
+            );
+            Ok(CombinationResult::ExactK(indices))
+        }
+        KScan::Overshoot(indices, excess) => {
+            tracing::trace!(
+                tier = "k-scan-overshoot",
+                count = indices.len(),
+                "find_combination tier succeeded"
+            );
+            Ok(CombinationResult::Overshoot(indices, excess))
+        }
         KScan::Miss => Ok(CombinationResult::Impossible),
     }
 }

--- a/sdk/tx-planner/src/plan/mod.rs
+++ b/sdk/tx-planner/src/plan/mod.rs
@@ -6,7 +6,7 @@ mod error;
 pub use combination::{CombinationResult, TRANSACTION_LIMIT, find_combination};
 pub use error::PlanError;
 
-use types::{Field, NoteAmount};
+use types::{Field, NoteAmount, correlation_id_or_new};
 
 /// Full plan: one or more on-chain `transact` calls (2-in / 2-out each).
 #[derive(Clone, Debug)]
@@ -95,7 +95,7 @@ impl<'a> IntoIterator for &'a TransactionPlan {
 }
 
 /// Build a plan from unspent notes and a target spend amount.
-#[tracing::instrument(skip(notes), fields(stage = "transaction_planning", amount = ?amount, note_count = notes.len()))]
+#[tracing::instrument(skip_all, fields(stage = "transaction_planning", correlation_id = %correlation_id_or_new(), amount = ?types::Sensitive(&amount), note_count = notes.len()))]
 pub fn plan(
     amount: NoteAmount,
     notes: &[SpendableNote],

--- a/sdk/tx-planner/src/plan/mod.rs
+++ b/sdk/tx-planner/src/plan/mod.rs
@@ -95,6 +95,7 @@ impl<'a> IntoIterator for &'a TransactionPlan {
 }
 
 /// Build a plan from unspent notes and a target spend amount.
+#[tracing::instrument(skip(notes), fields(stage = "transaction_planning", amount = ?amount, note_count = notes.len()))]
 pub fn plan(
     amount: NoteAmount,
     notes: &[SpendableNote],
@@ -105,9 +106,13 @@ pub fn plan(
 
     let values: Vec<NoteAmount> = notes.iter().map(|n| n.amount).collect();
     let combo = find_combination(&values, amount)?;
+    tracing::debug!(?combo, "transaction plan combination result");
 
     let (indices, change) = match combo {
-        CombinationResult::Impossible => return Err(PlanError::NoCombination),
+        CombinationResult::Impossible => {
+            tracing::warn!("transaction planning rejected: no combination possible");
+            return Err(PlanError::NoCombination);
+        }
         CombinationResult::OneExact(i) => (vec![i], None),
         CombinationResult::TwoExact(i, j) => (vec![i, j], None),
         CombinationResult::OneOvershoot(i, excess) => (vec![i], Some(excess)),
@@ -117,6 +122,11 @@ pub fn plan(
     };
 
     if indices.len() > TRANSACTION_LIMIT {
+        tracing::warn!(
+            selected = indices.len(),
+            max_notes = TRANSACTION_LIMIT,
+            "transaction planning rejected: too many notes selected"
+        );
         return Err(PlanError::TooManyNotes {
             selected: indices.len(),
             max_notes: TRANSACTION_LIMIT,

--- a/sdk/types/Cargo.toml
+++ b/sdk/types/Cargo.toml
@@ -18,11 +18,11 @@ hex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 uint = { workspace = true }
 zeroize = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tracing-subscriber = { workspace = true }
 # external
 rusqlite = { workspace = true, optional = true, features = ["bundled"] }
 

--- a/sdk/types/Cargo.toml
+++ b/sdk/types/Cargo.toml
@@ -13,10 +13,14 @@ rusqlite = ["dep:rusqlite"]
 [dependencies]
 # external
 anyhow = { workspace = true }
+getrandom = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 uint = { workspace = true }
+zeroize = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # external

--- a/sdk/types/src/correlation.rs
+++ b/sdk/types/src/correlation.rs
@@ -1,30 +1,91 @@
 //! Shared correlation-ID generation and propagation for the SDK.
-//!
-//! A correlation ID is `<session-prefix>-op-<counter>`: a short
-//! per-process/isolate random prefix (collision-safe when logs from the main
-//! thread and workers are aggregated) followed by a monotonic per-process
-//! counter. Both the native (`sdk/client`) and web (`sdk/web`) crates re-export
-//! these so the format and generation live in exactly one place.
-//!
-//! One ID is minted per public API entry point (CLI command, wasm-bindgen
-//! call); everything it calls into should inherit that ID rather than mint
-//! its own. Use [`correlation_id_or_new`] wherever a `#[tracing::instrument]`
-//! needs a `correlation_id` field but may be called either as the root of an
-//! operation (no ambient span yet — mint one) or nested inside one (inherit
-//! the ambient one). [`CorrelationIdLayer`] must be part of the subscriber
-//! for [`current_correlation_id`] to find anything.
 
 use std::sync::{
     OnceLock,
     atomic::{AtomicU64, Ordering},
 };
+
+#[cfg(target_arch = "wasm32")]
+thread_local! {
+    static ACTIVE_CORRELATION_STACK: std::cell::RefCell<Vec<String>> = const { std::cell::RefCell::new(Vec::new()) };
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn push_active_correlation_id(id: String) {
+    ACTIVE_CORRELATION_STACK.with(|stack| stack.borrow_mut().push(id));
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn pop_active_correlation_id() {
+    ACTIVE_CORRELATION_STACK.with(|stack| {
+        stack.borrow_mut().pop();
+    });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 use tracing::{Id, Subscriber, span::Attributes};
+#[cfg(not(target_arch = "wasm32"))]
 use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
 
+/// A [`tracing_subscriber::Layer`] that caches each span's `correlation_id`
+/// field (if any) into that span's extensions at creation time.
+#[cfg(not(target_arch = "wasm32"))]
+pub struct CorrelationIdLayer;
+
+#[cfg(not(target_arch = "wasm32"))]
+struct CorrelationIdVisitor(Option<String>);
+
+#[cfg(not(target_arch = "wasm32"))]
+impl tracing::field::Visit for CorrelationIdVisitor {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "correlation_id" {
+            self.0 = Some(value.to_string());
+        }
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "correlation_id" {
+            self.0 = Some(format!("{value:?}"));
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<S> Layer<S> for CorrelationIdLayer
+where
+    S: Subscriber + for<'l> LookupSpan<'l>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let mut v = CorrelationIdVisitor(None);
+        attrs.record(&mut v);
+        if let Some(corr_id) = v.0
+            && let Some(span) = ctx.span(id)
+        {
+            span.extensions_mut().insert(corr_id);
+        }
+    }
+}
+
+/// Return the currently active correlation ID, if any.
+pub fn current_correlation_id() -> Option<String> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        tracing::dispatcher::get_default(|dispatch| {
+            let registry = dispatch.downcast_ref::<tracing_subscriber::Registry>()?;
+            let current = dispatch.current_span();
+            let id = current.id()?;
+            let span = registry.span(id)?;
+            span.scope() // self + ancestors, innermost first
+                .find_map(|s| s.extensions().get::<String>().cloned())
+        })
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        ACTIVE_CORRELATION_STACK.with(|stack| stack.borrow().last().cloned())
+    }
+}
+
 /// Get the unique session prefix for this process/isolate.
-///
-/// Seeded once from `getrandom`; falls back to `"0000"` if the RNG is
-/// unavailable.
 pub fn session_prefix() -> &'static str {
     static PREFIX: OnceLock<String> = OnceLock::new();
     PREFIX.get_or_init(|| {
@@ -45,70 +106,8 @@ pub fn new_correlation_id() -> String {
     format!("{prefix}-op-{n}")
 }
 
-/// A [`tracing_subscriber::Layer`] that caches each span's `correlation_id`
-/// field (if any) into that span's extensions at creation time, so
-/// [`current_correlation_id`] can find it later via a scope walk. Maintains
-/// no mutable "current id" of its own — nothing to corrupt across async
-/// yield/resume or interleaved operations.
-pub struct CorrelationIdLayer;
-
-struct CorrelationIdVisitor(Option<String>);
-impl tracing::field::Visit for CorrelationIdVisitor {
-    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-        if field.name() == "correlation_id" {
-            self.0 = Some(value.to_string());
-        }
-    }
-
-    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-        if field.name() == "correlation_id" {
-            self.0 = Some(format!("{value:?}"));
-        }
-    }
-}
-
-impl<S> Layer<S> for CorrelationIdLayer
-where
-    S: Subscriber + for<'l> LookupSpan<'l>,
-{
-    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
-        let mut v = CorrelationIdVisitor(None);
-        attrs.record(&mut v);
-        if let Some(corr_id) = v.0
-            && let Some(span) = ctx.span(id)
-        {
-            span.extensions_mut().insert(corr_id);
-        }
-    }
-}
-
-/// Return the currently active correlation ID, if any.
-///
-/// Walks the current span's scope (self + ancestors, innermost first) for
-/// the nearest span carrying a `correlation_id`. Requires
-/// [`CorrelationIdLayer`] to be part of the active subscriber; returns `None`
-/// otherwise (e.g. no subscriber installed, or no operation span currently
-/// active — such as a background task with no ambient operation).
-pub fn current_correlation_id() -> Option<String> {
-    tracing::dispatcher::get_default(|dispatch| {
-        let registry = dispatch.downcast_ref::<tracing_subscriber::Registry>()?;
-        let current = dispatch.current_span();
-        let id = current.id()?;
-        let span = registry.span(id)?;
-        span.scope() // self + ancestors, innermost first
-            .find_map(|s| s.extensions().get::<String>().cloned())
-    })
-}
-
 /// Return the ambient correlation ID if one is already active, otherwise
 /// mint a new one.
-///
-/// Use this — not [`new_correlation_id`] directly — in any
-/// `#[tracing::instrument(fields(correlation_id = ...))]` on a function that
-/// may be invoked either as the root of an operation (no ambient span yet)
-/// or nested inside one already tagged by a caller. Minting unconditionally
-/// in the nested case would replace the caller's ID with an unrelated one,
-/// breaking correlation across the call.
 pub fn correlation_id_or_new() -> String {
     current_correlation_id().unwrap_or_else(new_correlation_id)
 }

--- a/sdk/types/src/correlation.rs
+++ b/sdk/types/src/correlation.rs
@@ -1,0 +1,135 @@
+//! Shared correlation-ID generation and propagation for the SDK.
+//!
+//! A correlation ID is `<session-prefix>-op-<counter>`: a short
+//! per-process/isolate random prefix (collision-safe when logs from the main
+//! thread and workers are aggregated) followed by a monotonic per-process
+//! counter. Both the native (`sdk/client`) and web (`sdk/web`) crates re-export
+//! these so the format and generation live in exactly one place.
+//!
+//! One ID is minted per public API entry point (CLI command, wasm-bindgen
+//! call); everything it calls into should inherit that ID rather than mint
+//! its own. Use [`correlation_id_or_new`] wherever a `#[tracing::instrument]`
+//! needs a `correlation_id` field but may be called either as the root of an
+//! operation (no ambient span yet — mint one) or nested inside one (inherit
+//! the ambient one). [`CorrelationIdLayer`] must be part of the subscriber
+//! for [`current_correlation_id`] to find anything.
+
+use std::sync::{
+    OnceLock,
+    atomic::{AtomicU64, Ordering},
+};
+use tracing::{Id, Subscriber, span::Attributes};
+use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
+
+/// Get the unique session prefix for this process/isolate.
+///
+/// Seeded once from `getrandom`; falls back to `"0000"` if the RNG is
+/// unavailable.
+pub fn session_prefix() -> &'static str {
+    static PREFIX: OnceLock<String> = OnceLock::new();
+    PREFIX.get_or_init(|| {
+        let mut bytes = [0u8; 2];
+        if getrandom::getrandom(&mut bytes).is_ok() {
+            format!("{:02x}{:02x}", bytes[0], bytes[1])
+        } else {
+            "0000".to_string()
+        }
+    })
+}
+
+/// Generate a new operation identifier with a collision-safe session prefix.
+pub fn new_correlation_id() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let prefix = session_prefix();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-op-{n}")
+}
+
+/// A [`tracing_subscriber::Layer`] that caches each span's `correlation_id`
+/// field (if any) into that span's extensions at creation time, so
+/// [`current_correlation_id`] can find it later via a scope walk. Maintains
+/// no mutable "current id" of its own — nothing to corrupt across async
+/// yield/resume or interleaved operations.
+pub struct CorrelationIdLayer;
+
+struct CorrelationIdVisitor(Option<String>);
+impl tracing::field::Visit for CorrelationIdVisitor {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "correlation_id" {
+            self.0 = Some(value.to_string());
+        }
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "correlation_id" {
+            self.0 = Some(format!("{value:?}"));
+        }
+    }
+}
+
+impl<S> Layer<S> for CorrelationIdLayer
+where
+    S: Subscriber + for<'l> LookupSpan<'l>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let mut v = CorrelationIdVisitor(None);
+        attrs.record(&mut v);
+        if let Some(corr_id) = v.0
+            && let Some(span) = ctx.span(id)
+        {
+            span.extensions_mut().insert(corr_id);
+        }
+    }
+}
+
+/// Return the currently active correlation ID, if any.
+///
+/// Walks the current span's scope (self + ancestors, innermost first) for
+/// the nearest span carrying a `correlation_id`. Requires
+/// [`CorrelationIdLayer`] to be part of the active subscriber; returns `None`
+/// otherwise (e.g. no subscriber installed, or no operation span currently
+/// active — such as a background task with no ambient operation).
+pub fn current_correlation_id() -> Option<String> {
+    tracing::dispatcher::get_default(|dispatch| {
+        let registry = dispatch.downcast_ref::<tracing_subscriber::Registry>()?;
+        let current = dispatch.current_span();
+        let id = current.id()?;
+        let span = registry.span(id)?;
+        span.scope() // self + ancestors, innermost first
+            .find_map(|s| s.extensions().get::<String>().cloned())
+    })
+}
+
+/// Return the ambient correlation ID if one is already active, otherwise
+/// mint a new one.
+///
+/// Use this — not [`new_correlation_id`] directly — in any
+/// `#[tracing::instrument(fields(correlation_id = ...))]` on a function that
+/// may be invoked either as the root of an operation (no ambient span yet)
+/// or nested inside one already tagged by a caller. Minting unconditionally
+/// in the nested case would replace the caller's ID with an unrelated one,
+/// breaking correlation across the call.
+pub fn correlation_id_or_new() -> String {
+    current_correlation_id().unwrap_or_else(new_correlation_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_correlation_id_format() {
+        let id1 = new_correlation_id();
+        let id2 = new_correlation_id();
+
+        let prefix = session_prefix();
+        assert_eq!(prefix.len(), 4);
+
+        assert!(id1.starts_with(prefix));
+        assert!(id2.starts_with(prefix));
+        assert_ne!(id1, id2);
+
+        assert!(id1.contains("-op-"));
+        assert!(id2.contains("-op-"));
+    }
+}

--- a/sdk/types/src/lib.rs
+++ b/sdk/types/src/lib.rs
@@ -1,13 +1,17 @@
 mod amounts;
 mod chain_data;
+mod correlation;
 mod disclosure;
 mod ext_data;
+mod logging;
 mod policy_tx;
 pub use amounts::*;
 use anyhow::{Result, anyhow};
 pub use chain_data::*;
+pub use correlation::*;
 pub use disclosure::*;
 pub use ext_data::*;
+pub use logging::*;
 pub use policy_tx::*;
 
 use serde::{Deserialize, Serialize};
@@ -207,12 +211,37 @@ pub struct OperationalFeedItem {
 }
 
 /// Wallet signature used to derive both privacy keypairs
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct KeyDerivationSignature(pub Vec<u8>);
 
+impl std::fmt::Debug for KeyDerivationSignature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "KeyDerivationSignature(<redacted>)")
+    }
+}
+
+impl Drop for KeyDerivationSignature {
+    fn drop(&mut self) {
+        zeroize::Zeroize::zeroize(&mut self.0);
+    }
+}
+
 /// Encryption private key
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct EncryptionPrivateKey(pub [u8; 32]);
+
+impl std::fmt::Debug for EncryptionPrivateKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "EncryptionPrivateKey(<redacted>)")
+    }
+}
+
+impl Drop for EncryptionPrivateKey {
+    fn drop(&mut self) {
+        zeroize::Zeroize::zeroize(&mut self.0);
+    }
+}
+
 /// Encryption public key
 #[derive(Debug, Clone)]
 pub struct EncryptionPublicKey(pub [u8; 32]);
@@ -227,8 +256,20 @@ pub struct EncryptionKeyPair {
 }
 
 /// Note ownership private key
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct NotePrivateKey(pub [u8; 32]);
+
+impl std::fmt::Debug for NotePrivateKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "NotePrivateKey(<redacted>)")
+    }
+}
+
+impl Drop for NotePrivateKey {
+    fn drop(&mut self) {
+        zeroize::Zeroize::zeroize(&mut self.0);
+    }
+}
 
 /// Note ownership public key
 #[derive(Debug, Clone)]

--- a/sdk/types/src/logging.rs
+++ b/sdk/types/src/logging.rs
@@ -1,0 +1,274 @@
+use serde::{Deserialize, Serialize};
+use std::{
+    fmt,
+    ops::Deref,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+/// Target sinks for telemetry logs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TelemetrySink {
+    /// Write to standard system console (stdout/stderr or browser console).
+    Console,
+    /// Write to an in-memory ring buffer.
+    RingBuffer,
+    /// Write to both the console and the ring buffer.
+    Both,
+}
+
+/// Unified telemetry configuration for the SDK.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TelemetryConfig {
+    /// Logging level filter (e.g. "info", "debug", "trace").
+    pub level: String,
+    /// Target logging sink.
+    pub sink: TelemetrySink,
+    /// Size of the in-memory ring buffer in bytes.
+    pub ring_buffer_bytes: usize,
+    /// Whether to reveal Tier-1 sensitive values in debug logs (always gated by
+    /// compile assertions).
+    pub reveal_sensitive: bool,
+}
+
+// Global reveal flag for Tier-1 fields
+static REVEAL_SENSITIVE: AtomicBool = AtomicBool::new(false);
+
+/// Enable or disable revealing Tier-1 sensitive fields in debug builds.
+pub fn set_reveal_sensitive(reveal: bool) {
+    REVEAL_SENSITIVE.store(reveal, Ordering::Relaxed);
+}
+
+/// Query whether Tier-1 sensitive fields should be revealed.
+/// Always returns false in release builds (when debug_assertions is false).
+pub fn reveal_sensitive() -> bool {
+    cfg!(debug_assertions) && REVEAL_SENSITIVE.load(Ordering::Relaxed)
+}
+
+/// A wrapper for Tier-1 sensitive values (amounts, addresses, commitments,
+/// nullifiers, etc.) that redacts their `Debug` and `Display` output in
+/// production or when not explicitly enabled.
+#[derive(Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Sensitive<T>(pub T);
+
+impl<T> Deref for Sensitive<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> Sensitive<T> {
+    /// Wrap a value as sensitive.
+    pub fn new(val: T) -> Self {
+        Self(val)
+    }
+
+    /// Expose a reference to the inner value.
+    pub fn expose(&self) -> &T {
+        &self.0
+    }
+
+    /// Unwrap and consume into the inner value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Sensitive<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if reveal_sensitive() {
+            self.0.fmt(f)
+        } else {
+            write!(f, "\"<redacted>\"")
+        }
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for Sensitive<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if reveal_sensitive() {
+            self.0.fmt(f)
+        } else {
+            write!(f, "<redacted>")
+        }
+    }
+}
+
+impl<T: Serialize> Serialize for Sensitive<T> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Sensitive<T> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        T::deserialize(deserializer).map(Sensitive)
+    }
+}
+
+/// A wrapper for Tier-0 secrets (keys, seeds, etc.) that ALWAYS redacts its
+/// `Debug` and `Display` output, and zeroizes its memory when dropped.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Secret<T: zeroize::Zeroize>(pub T);
+
+impl<T: zeroize::Zeroize> Deref for Secret<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: zeroize::Zeroize> Secret<T> {
+    /// Wrap a value as a secret.
+    pub fn new(val: T) -> Self {
+        Self(val)
+    }
+
+    /// Expose a reference to the inner secret.
+    pub fn expose(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T: zeroize::Zeroize> fmt::Debug for Secret<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "\"<redacted>\"")
+    }
+}
+
+impl<T: zeroize::Zeroize> fmt::Display for Secret<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "<redacted>")
+    }
+}
+
+impl<T: zeroize::Zeroize + Serialize> Serialize for Secret<T> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de, T: zeroize::Zeroize + Deserialize<'de>> Deserialize<'de> for Secret<T> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        T::deserialize(deserializer).map(Secret)
+    }
+}
+
+impl<T: zeroize::Zeroize> Drop for Secret<T> {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl<T: zeroize::Zeroize> zeroize::Zeroize for Secret<T> {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EncryptionPrivateKey, KeyDerivationSignature, NotePrivateKey};
+    use zeroize::Zeroize;
+
+    #[test]
+    fn test_tier1_sensitive_redaction() {
+        let val = Sensitive::new("sensitive_data".to_string());
+
+        // By default, reveal_sensitive should be false
+        set_reveal_sensitive(false);
+        assert_eq!(format!("{:?}", val), "\"<redacted>\"");
+        assert_eq!(format!("{}", val), "<redacted>");
+
+        // Opt-in to reveal
+        set_reveal_sensitive(true);
+        if cfg!(debug_assertions) {
+            assert_eq!(format!("{:?}", val), "\"sensitive_data\"");
+            assert_eq!(format!("{}", val), "sensitive_data");
+        } else {
+            // Production builds must NEVER reveal Tier-1 values
+            assert_eq!(format!("{:?}", val), "\"<redacted>\"");
+            assert_eq!(format!("{}", val), "<redacted>");
+        }
+
+        // Reset state
+        set_reveal_sensitive(false);
+    }
+
+    #[test]
+    fn test_tier0_secret_redaction() {
+        let secret_bytes = Secret::new([42u8; 32]);
+        let secret_str = Secret::new("very_secret_key".to_string());
+
+        set_reveal_sensitive(true);
+        // Tier-0 must always be redacted under any setting/build
+        assert_eq!(format!("{:?}", secret_bytes), "\"<redacted>\"");
+        assert_eq!(format!("{}", secret_bytes), "<redacted>");
+        assert_eq!(format!("{:?}", secret_str), "\"<redacted>\"");
+        assert_eq!(format!("{}", secret_str), "<redacted>");
+
+        set_reveal_sensitive(false);
+    }
+
+    #[test]
+    fn test_key_types_redaction() {
+        let enc_key = EncryptionPrivateKey([1u8; 32]);
+        let note_key = NotePrivateKey([2u8; 32]);
+        let signature = KeyDerivationSignature(vec![3u8; 10]);
+
+        set_reveal_sensitive(true);
+        // Key types must always be redacted under any setting/build
+        assert_eq!(format!("{:?}", enc_key), "EncryptionPrivateKey(<redacted>)");
+        assert_eq!(format!("{:?}", note_key), "NotePrivateKey(<redacted>)");
+        assert_eq!(
+            format!("{:?}", signature),
+            "KeyDerivationSignature(<redacted>)"
+        );
+
+        set_reveal_sensitive(false);
+    }
+
+    #[test]
+    fn test_zeroize_manual() {
+        let mut secret = Secret::new([9u8; 32]);
+        secret.zeroize();
+        assert_eq!(secret.expose(), &[0u8; 32]);
+    }
+
+    #[test]
+    fn test_telemetry_config_gating() {
+        let config_reveal = TelemetryConfig {
+            level: "debug".to_string(),
+            sink: TelemetrySink::Console,
+            ring_buffer_bytes: 1024,
+            reveal_sensitive: true,
+        };
+
+        let config_redact = TelemetryConfig {
+            level: "debug".to_string(),
+            sink: TelemetrySink::Console,
+            ring_buffer_bytes: 1024,
+            reveal_sensitive: false,
+        };
+
+        // Gating under reveal config
+        set_reveal_sensitive(config_reveal.reveal_sensitive);
+        if cfg!(debug_assertions) {
+            assert!(reveal_sensitive());
+        } else {
+            assert!(!reveal_sensitive());
+        }
+
+        // Gating under redact config
+        set_reveal_sensitive(config_redact.reveal_sensitive);
+        assert!(!reveal_sensitive());
+
+        // Reset
+        set_reveal_sensitive(false);
+    }
+}

--- a/sdk/web/.gitignore
+++ b/sdk/web/.gitignore
@@ -1,3 +1,4 @@
 dist/
 node_modules/
 *.tgz
+.trunk-wasm-profile

--- a/sdk/web/Cargo.toml
+++ b/sdk/web/Cargo.toml
@@ -27,21 +27,16 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 console_error_panic_hook = { workspace = true }
 futures = { workspace = true }
-getrandom = { workspace = true }
 gloo-timers = { workspace = true, features = ["futures"] }
 gloo-worker = { workspace = true }
 js-sys = { workspace = true }
-log = { workspace = true }
 serde = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }
 sha2 = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
-wasm-log = { workspace = true }
 tracing = { workspace = true }
-tracing-log = { workspace = true }
-tracing-subscriber = { workspace = true }
 web-sys = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -52,6 +47,9 @@ sqlite-wasm-vfs = { workspace = true }
 sha2 = { workspace = true }
 types = { workspace = true }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+tracing-subscriber = { workspace = true }
 [lints]
 workspace = true
 

--- a/sdk/web/Cargo.toml
+++ b/sdk/web/Cargo.toml
@@ -27,6 +27,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 console_error_panic_hook = { workspace = true }
 futures = { workspace = true }
+getrandom = { workspace = true }
 gloo-timers = { workspace = true, features = ["futures"] }
 gloo-worker = { workspace = true }
 js-sys = { workspace = true }
@@ -38,6 +39,9 @@ sha2 = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 wasm-log = { workspace = true }
+tracing = { workspace = true }
+tracing-log = { workspace = true }
+tracing-subscriber = { workspace = true }
 web-sys = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/sdk/web/README.md
+++ b/sdk/web/README.md
@@ -107,6 +107,28 @@ Matches `stellar_private_payments_sdk::PrivatePool`: `balance`, `notes`, `estima
 
 Bound at `client.account()`. Must implement `signMessage`, `signTransaction`, `signAuthEntry`. See [`FreighterSigner`](./js/freighter.js).
 
+## Logging & Diagnostics
+
+The SDK provides integrated telemetry logging using `tracing` in Rust. You can configure and control logging from JavaScript:
+
+```js
+import { configureTelemetry, dump_recent_logs, set_log_level } from 'stellar-private-payments-sdk-web';
+
+// Initialize or update telemetry settings
+configureTelemetry({
+  level: 'debug',             // 'info' | 'debug' | 'trace'
+  sink: 'both',               // 'console' | 'ringBuffer' | 'both'
+  ringBufferBytes: 256 * 1024, // 256 KiB buffer
+  revealSensitive: true       // Reveal Tier-1 values (debug profile only)
+});
+
+// Dump current ring buffer logs for diagnostic reports
+const logs = dump_recent_logs();
+
+// Update log level filter on the fly
+set_log_level('info');
+```
+
 ## TypeScript
 
 Public types live in [`js/types/`](./js/types/). The package entry (`import { Client } from 'stellar-private-payments-sdk-web'`) is fully typed; wasm-bindgen types are also available via `stellar-private-payments-sdk-web/wasm`.

--- a/sdk/web/js/index.js
+++ b/sdk/web/js/index.js
@@ -4,6 +4,9 @@ import init, {
   Storage as WasmStorage,
   bootnodeRequired as wasmBootnodeRequired,
   verifySelectiveDisclosure as wasmVerifySelectiveDisclosure,
+  configureTelemetry,
+  set_log_level,
+  dump_recent_logs,
 } from '../dist/stellar_private_payments_sdk_web.js';
 
 const storageWorkerUrl = new URL('../dist/workers/storage-worker.js', import.meta.url).href;
@@ -118,5 +121,6 @@ export const Client = {
   contractConfig: WasmClient.contractConfig,
 };
 export { PrivatePool, bootnodeRequired, verifySelectiveDisclosure };
+export { configureTelemetry, set_log_level, dump_recent_logs };
 export { default } from '../dist/stellar_private_payments_sdk_web.js';
 export { FreighterSigner } from './freighter.js';

--- a/sdk/web/scripts/build.sh
+++ b/sdk/web/scripts/build.sh
@@ -8,18 +8,31 @@ export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$ROOT/target}"
 PROFILE="${WASM_PROFILE:-release}"
 TARGET="wasm32-unknown-unknown"
 ARTIFACTS="$ROOT/target/$TARGET/$PROFILE"
+
+# Cargo uses `--release` for the release profile and `--profile <name>` for custom profiles.
+case "$PROFILE" in
+  release)
+    CARGO_PROFILE_FLAG="--release"
+    ;;
+  *)
+    CARGO_PROFILE_FLAG="--profile $PROFILE"
+    ;;
+esac
+
 WASM_BINDGEN_VERSION="${WASM_BINDGEN_VERSION:-0.2.126}"
 WASM_OUT_NAME="stellar_private_payments_sdk_web"
 
 echo "==> Building circuit artifacts (if needed)..."
-if [[ ! -d "$ROOT/target/circuits-artifacts/$PROFILE" ]]; then
-  cargo build -p circuits --"$PROFILE"
+# Circuit artifacts are profile-independent and are only published for release
+# (and debug test circuits). Always use the release circuit artifacts.
+if [[ ! -d "$ROOT/target/circuits-artifacts/release" ]]; then
+  cargo build -p circuits --release
 fi
 
 echo "==> Building stellar-private-payments-sdk-web ($PROFILE)..."
-cargo build -p stellar-private-payments-sdk-web --"$PROFILE" --target "$TARGET"
-cargo build -p stellar-private-payments-sdk-web --"$PROFILE" --target "$TARGET" --bin storage-worker
-cargo build -p stellar-private-payments-sdk-web --"$PROFILE" --target "$TARGET" --bin prover-worker
+cargo build -p stellar-private-payments-sdk-web $CARGO_PROFILE_FLAG --target "$TARGET"
+cargo build -p stellar-private-payments-sdk-web $CARGO_PROFILE_FLAG --target "$TARGET" --bin storage-worker
+cargo build -p stellar-private-payments-sdk-web $CARGO_PROFILE_FLAG --target "$TARGET" --bin prover-worker
 
 if ! command -v wasm-bindgen >/dev/null 2>&1; then
   echo "error: wasm-bindgen not found — cargo install wasm-bindgen-cli --version ${WASM_BINDGEN_VERSION} --locked --force" >&2

--- a/sdk/web/scripts/stage-circuits-dist.sh
+++ b/sdk/web/scripts/stage-circuits-dist.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 WEB="$ROOT/sdk/web"
-PROFILE="${WASM_PROFILE:-release}"
+PROFILE="release"
 CIRCUITS_OUT="$ROOT/target/circuits-artifacts/$PROFILE"
 DIST="$WEB/dist"
 
@@ -28,7 +28,11 @@ ARTIFACTS=(
 )
 
 if [[ ! -d "$CIRCUITS_OUT" ]]; then
-  echo "error: missing $CIRCUITS_OUT — run cargo build -p circuits --$PROFILE" >&2
+  if [[ "$PROFILE" == "release" ]]; then
+    echo "error: missing $CIRCUITS_OUT — run cargo build -p circuits --release" >&2
+  else
+    echo "error: missing $CIRCUITS_OUT — run cargo build -p circuits --profile $PROFILE" >&2
+  fi
   exit 1
 fi
 

--- a/sdk/web/src/circuits.rs
+++ b/sdk/web/src/circuits.rs
@@ -129,10 +129,10 @@ async fn response_to_bytes(resp: Response) -> Result<Vec<u8>, JsError> {
 
 pub(crate) async fn fetch_circuit_file(filename: &str) -> Result<Vec<u8>, JsError> {
     let url_string = circuit_fetch_url(filename)?;
-    log::debug!("[circuits] fetching {url_string}");
+    tracing::debug!("[circuits] fetching {url_string}");
 
     let cache_opt = open_cache().await.unwrap_or_else(|e| {
-        log::warn!("[circuits] failed to open cache: {:?}", e);
+        tracing::warn!("[circuits] failed to open cache: {:?}", e);
         None
     });
 
@@ -142,7 +142,7 @@ pub(crate) async fn fetch_circuit_file(filename: &str) -> Result<Vec<u8>, JsErro
             .map_err(|e| JsError::new(&format!("cache.match error: {e:?}")))?;
 
         if !match_val.is_undefined() {
-            log::debug!("[circuits] cache hit for {url_string}");
+            tracing::debug!("[circuits] cache hit for {url_string}");
             let resp: Response = match_val
                 .dyn_into()
                 .map_err(|_| JsError::new("cache hit cast failed"))?;
@@ -150,7 +150,7 @@ pub(crate) async fn fetch_circuit_file(filename: &str) -> Result<Vec<u8>, JsErro
         }
     }
 
-    log::debug!("[circuits] network fetch for {url_string}");
+    tracing::debug!("[circuits] network fetch for {url_string}");
     let opts = RequestInit::new();
     opts.set_method("GET");
     opts.set_mode(RequestMode::Cors);
@@ -200,7 +200,7 @@ pub(crate) async fn fetch_circuit_file_verified(
 ) -> Result<Vec<u8>, JsError> {
     let bytes = fetch_circuit_file(filename).await?;
     if let Err(err) = ensure_sha256_matches(filename, &bytes, expected_len, expected_sha256) {
-        log::warn!("[circuits] hash mismatch for {filename}: {err:?}, evicting and refetching");
+        tracing::warn!("[circuits] hash mismatch for {filename}: {err:?}, evicting and refetching");
         let url_string = circuit_fetch_url(filename)?;
         if let Some(cache) = open_cache().await.unwrap_or(None) {
             let _ = JsFuture::from(cache.delete_with_str(&url_string)).await;
@@ -264,7 +264,7 @@ where
     ))?;
 
     let cache_opt = open_cache().await.unwrap_or_else(|e| {
-        log::warn!("[circuits] failed to open cache for uncompressed {filename}: {e:?}");
+        tracing::warn!("[circuits] failed to open cache for uncompressed {filename}: {e:?}");
         None
     });
 
@@ -275,34 +275,36 @@ where
                 Ok(resp) => match response_to_bytes(resp).await {
                     Ok(framed) => {
                         if let Some(payload) = verify_framed_uncompressed(&framed) {
-                            log::debug!("[circuits] uncompressed cache hit for {filename}");
+                            tracing::debug!("[circuits] uncompressed cache hit for {filename}");
                             return Ok(payload);
                         }
-                        log::warn!(
+                        tracing::warn!(
                             "[circuits] uncompressed cache entry for {filename} failed integrity check, evicting"
                         );
                         let _ = JsFuture::from(cache.delete_with_str(&key)).await;
                     }
                     Err(e) => {
-                        log::warn!(
+                        tracing::warn!(
                             "[circuits] failed to read uncompressed cache bytes for {filename}: {e:?}"
                         );
                         let _ = JsFuture::from(cache.delete_with_str(&key)).await;
                     }
                 },
                 Err(_) => {
-                    log::warn!("[circuits] uncompressed cache match cast failed for {filename}");
+                    tracing::warn!(
+                        "[circuits] uncompressed cache match cast failed for {filename}"
+                    );
                 }
             },
             Ok(_) => { /* undefined => cache miss */ }
             Err(e) => {
-                log::warn!("[circuits] uncompressed cache match error for {filename}: {e:?}");
+                tracing::warn!("[circuits] uncompressed cache match error for {filename}: {e:?}");
             }
         }
     }
 
     // Miss or corrupt entry: derive fresh bytes (the expensive path).
-    log::debug!("[circuits] deriving uncompressed bytes for {filename}");
+    tracing::debug!("[circuits] deriving uncompressed bytes for {filename}");
     let payload = derive().await?;
 
     // Best-effort store; a storage failure must never break the load.
@@ -313,11 +315,11 @@ where
         match Response::new_with_opt_u8_array(Some(&mut framed[..])) {
             Ok(resp) => {
                 if let Err(e) = JsFuture::from(cache.put_with_str(&key, &resp)).await {
-                    log::warn!("[circuits] failed to store uncompressed {filename}: {e:?}");
+                    tracing::warn!("[circuits] failed to store uncompressed {filename}: {e:?}");
                 }
             }
             Err(e) => {
-                log::warn!(
+                tracing::warn!(
                     "[circuits] failed to build response for uncompressed {filename}: {e:?}"
                 );
             }

--- a/sdk/web/src/client/mod.rs
+++ b/sdk/web/src/client/mod.rs
@@ -19,6 +19,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
 use crate::{
+    correlation::{new_correlation_id, with_correlation_id},
     deployment::deployment_config,
     protocol::{StorageWorkerRequest, StorageWorkerResponse},
     signer::WalletSigner,
@@ -91,31 +92,32 @@ impl Client {
         prover_worker_url: String,
         bootnode_url: Option<String>,
     ) -> Result<Client, JsError> {
-        crate::wasm_start();
+        with_correlation_id(new_correlation_id(), async {
+            crate::wasm_start();
 
-        if prover_worker_url.trim().is_empty() {
-            return Err(JsError::new(
-                "proverWorkerUrl is required (absolute URL to prover-worker.js)",
-            ));
-        }
+            if prover_worker_url.trim().is_empty() {
+                return Err(JsError::new(
+                    "proverWorkerUrl is required (absolute URL to prover-worker.js)",
+                ));
+            }
 
-        let storage = storage.fork();
-        let storage_bridge = storage.bridge();
-        storage_bridge
-            .ping()
-            .await
-            .map_err(|e| JsError::new(&e.to_string()))?;
+            let storage = storage.fork();
+            let storage_bridge = storage.bridge();
+            storage_bridge
+                .ping()
+                .await
+                .map_err(|e| JsError::new(&e.to_string()))?;
 
-        let contract_config = deployment_config()?;
-        let prover = ProverBridge::new(
-            ProverWorker::spawner()
-                .with_loader(true)
-                .as_module(true)
-                .spawn(&prover_worker_url),
-        );
-        let prover_handle: Handle<dyn stellar_private_payments_sdk::Prover> = Handle::from_box(
-            Box::new(prover.clone()) as Box<dyn stellar_private_payments_sdk::Prover>,
-        );
+            let contract_config = deployment_config()?;
+            let prover = ProverBridge::new(
+                ProverWorker::spawner()
+                    .with_loader(true)
+                    .as_module(true)
+                    .spawn(&prover_worker_url),
+            );
+            let prover_handle: Handle<dyn stellar_private_payments_sdk::Prover> = Handle::from_box(
+                Box::new(prover.clone()) as Box<dyn stellar_private_payments_sdk::Prover>,
+            );
 
         let inner = NativeClient::init(
             rpc_url,
@@ -132,6 +134,8 @@ impl Client {
             prover,
             background_sync_stop: None,
         })
+        })
+        .await
     }
 
     /// Bundled deployment config (contract addresses, pools, network).
@@ -147,17 +151,20 @@ impl Client {
     /// exit leaves the slot set — use a new [`Client`] to recover.
     #[wasm_bindgen(js_name = backgroundSync)]
     pub async fn background_sync(&mut self) -> Result<(), JsError> {
-        if self.background_sync_stop.is_some() {
-            return Ok(());
-        }
-        let sync = self.inner.background_sync().map_err(pool_err)?;
-        self.background_sync_stop = Some(sync.stop_handle());
-        wasm_bindgen_futures::spawn_local(async move {
-            if let Err(e) = sync.run().await {
-                log::error!("background sync stopped: {e}");
+        with_correlation_id(new_correlation_id(), async {
+            if self.background_sync_stop.is_some() {
+                return Ok(());
             }
-        });
-        Ok(())
+            let sync = self.inner.background_sync().map_err(pool_err)?;
+            self.background_sync_stop = Some(sync.stop_handle());
+            wasm_bindgen_futures::spawn_local(async move {
+                if let Err(e) = sync.run().await {
+                    tracing::error!("background sync stopped: {e}");
+                }
+            });
+            Ok(())
+        })
+        .await
     }
 
     /// Request the background indexer to exit (wakes its idle wait).
@@ -174,24 +181,27 @@ impl Client {
     /// Bind a wallet signer, derive privacy keys when missing, and return an
     /// [`Account`] session.
     pub async fn account(&self, options: JsValue, signer: JsValue) -> Result<Account, JsError> {
-        let opts: AccountOptions = serde_wasm_bindgen::from_value(options)?;
-        let user_address = resolve_user_address(&signer, opts.user_address).await?;
-        let wallet_signer =
-            WalletSigner::new(signer, opts.network_passphrase, user_address.clone())?;
+        with_correlation_id(new_correlation_id(), async {
+            let opts: AccountOptions = serde_wasm_bindgen::from_value(options)?;
+            let user_address = resolve_user_address(&signer, opts.user_address).await?;
+            let wallet_signer =
+                WalletSigner::new(signer, opts.network_passphrase, user_address.clone())?;
 
-        self.ensure_prover().await?;
+            self.ensure_prover().await?;
 
-        if !self.user_keys_exist(&user_address).await? {
-            let message = stellar_private_payments_sdk::KEY_DERIVATION_MESSAGE.to_string();
-            let sig_hex = wallet_signer.sign_wallet_message(&message).await?;
-            let signature = crate::signer::wallet_message_signature_to_bytes(&sig_hex)?;
-            self.derive_save_user_keys(user_address.clone(), signature)
-                .await?;
-        }
+            if !self.user_keys_exist(&user_address).await? {
+                let message = stellar_private_payments_sdk::KEY_DERIVATION_MESSAGE.to_string();
+                let sig_hex = wallet_signer.sign_wallet_message(&message).await?;
+                let signature = crate::signer::wallet_message_signature_to_bytes(&sig_hex)?;
+                self.derive_save_user_keys(user_address.clone(), signature)
+                    .await?;
+            }
 
-        Ok(Account::new(Rc::new(
-            self.open_native_account(wallet_signer, user_address)?,
-        )))
+            Ok(Account::new(Rc::new(
+                self.open_native_account(wallet_signer, user_address)?,
+            )))
+        })
+        .await
     }
 
     /// Catch local storage up to the current chain tip for the deployment.
@@ -278,42 +288,45 @@ pub async fn verify_selective_disclosure_standalone(
     expected_vk_hash: String,
     options: JsValue,
 ) -> Result<JsValue, JsError> {
-    crate::wasm_start();
+    with_correlation_id(new_correlation_id(), async {
+        crate::wasm_start();
 
-    let receipt: DisclosureReceipt = serde_json::from_str(&receipt_json)
-        .map_err(|e| JsError::new(&format!("invalid receipt JSON: {e}")))?;
-    let opts: VerifyDisclosureOptions = if options.is_null() || options.is_undefined() {
-        VerifyDisclosureOptions::default()
-    } else {
-        serde_wasm_bindgen::from_value(options)?
-    };
+        let receipt: DisclosureReceipt = serde_json::from_str(&receipt_json)
+            .map_err(|e| JsError::new(&format!("invalid receipt JSON: {e}")))?;
+        let opts: VerifyDisclosureOptions = if options.is_null() || options.is_undefined() {
+            VerifyDisclosureOptions::default()
+        } else {
+            serde_wasm_bindgen::from_value(options)?
+        };
 
-    let prover_worker_url = opts
-        .prover_worker_url
-        .filter(|url| !url.trim().is_empty())
-        .ok_or_else(|| {
-            JsError::new("proverWorkerUrl is required (absolute URL to prover-worker.js)")
-        })?;
+        let prover_worker_url = opts
+            .prover_worker_url
+            .filter(|url| !url.trim().is_empty())
+            .ok_or_else(|| {
+                JsError::new("proverWorkerUrl is required (absolute URL to prover-worker.js)")
+            })?;
 
-    let contract_config = deployment_config()?;
-    let rpc = RpcClient::new(&rpc_url).map_err(|e| JsError::new(&e.to_string()))?;
-    let fetcher = StateFetcher::new(rpc, (*contract_config).clone())
-        .map_err(|e| JsError::new(&e.to_string()))?;
-    let prover = ProverBridge::new(
-        ProverWorker::spawner()
-            .with_loader(true)
-            .as_module(true)
-            .spawn(&prover_worker_url),
-    );
-    prover
-        .ping()
-        .await
-        .map_err(|e| JsError::new(&format!("failed to load prover: {e:?}")))?;
+        let contract_config = deployment_config()?;
+        let rpc = RpcClient::new(&rpc_url).map_err(|e| JsError::new(&e.to_string()))?;
+        let fetcher = StateFetcher::new(rpc, (*contract_config).clone())
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        let prover = ProverBridge::new(
+            ProverWorker::spawner()
+                .with_loader(true)
+                .as_module(true)
+                .spawn(&prover_worker_url),
+        );
+        prover
+            .ping()
+            .await
+            .map_err(|e| JsError::new(&format!("failed to load prover: {e:?}")))?;
 
-    let report = verify_disclosure_receipt(&fetcher, &prover, &receipt, &expected_vk_hash)
-        .await
-        .map_err(pool_err)?;
-    Ok(serde_wasm_bindgen::to_value(&report)?)
+        let report = verify_disclosure_receipt(&fetcher, &prover, &receipt, &expected_vk_hash)
+            .await
+            .map_err(pool_err)?;
+        Ok(serde_wasm_bindgen::to_value(&report)?)
+    })
+    .await
 }
 
 impl Client {

--- a/sdk/web/src/client/mod.rs
+++ b/sdk/web/src/client/mod.rs
@@ -93,38 +93,49 @@ impl Client {
         bootnode_url: Option<String>,
     ) -> Result<Client, JsError> {
         with_correlation_id(new_correlation_id(), async {
-            crate::wasm_start();
+            Self::new_inner(rpc_url, storage, prover_worker_url, bootnode_url).await
+        })
+        .await
+    }
 
-            if prover_worker_url.trim().is_empty() {
-                return Err(JsError::new(
-                    "proverWorkerUrl is required (absolute URL to prover-worker.js)",
-                ));
-            }
+    async fn new_inner(
+        rpc_url: String,
+        storage: &Storage,
+        prover_worker_url: String,
+        bootnode_url: Option<String>,
+    ) -> Result<Client, JsError> {
+        crate::wasm_start();
 
-            let storage = storage.fork();
-            let storage_bridge = storage.bridge();
-            storage_bridge
-                .ping()
-                .await
-                .map_err(|e| JsError::new(&e.to_string()))?;
+        if prover_worker_url.trim().is_empty() {
+            return Err(JsError::new(
+                "proverWorkerUrl is required (absolute URL to prover-worker.js)",
+            ));
+        }
 
-            let contract_config = deployment_config()?;
-            let prover = ProverBridge::new(
-                ProverWorker::spawner()
-                    .with_loader(true)
-                    .as_module(true)
-                    .spawn(&prover_worker_url),
-            );
-            let prover_handle: Handle<dyn stellar_private_payments_sdk::Prover> = Handle::from_box(
-                Box::new(prover.clone()) as Box<dyn stellar_private_payments_sdk::Prover>,
-            );
+        let storage = storage.fork();
+        let storage_bridge = storage.bridge();
+        storage_bridge
+            .ping()
+            .await
+            .map_err(|e| JsError::new(&e.to_string()))?;
+
+        let contract_config = deployment_config()?;
+        let prover = ProverBridge::new(
+            ProverWorker::spawner()
+                .with_loader(true)
+                .as_module(true)
+                .spawn(&prover_worker_url),
+        );
+        let prover_handle: Handle<dyn stellar_private_payments_sdk::Prover> = Handle::from_box(
+            Box::new(prover.clone()) as Box<dyn stellar_private_payments_sdk::Prover>,
+        );
 
         let inner = NativeClient::init(
             rpc_url,
             storage_bridge,
             prover_handle,
             (*contract_config).clone(),
-            bootnode_url.clone(),
+            bootnode_url,
         )
         .map_err(pool_err)?;
 
@@ -134,8 +145,6 @@ impl Client {
             prover,
             background_sync_stop: None,
         })
-        })
-        .await
     }
 
     /// Bundled deployment config (contract addresses, pools, network).

--- a/sdk/web/src/client/pool.rs
+++ b/sdk/web/src/client/pool.rs
@@ -10,6 +10,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     client::{execute::emit, pool_err, transact::parse_transact_step},
+    correlation::{new_correlation_id, with_correlation_id},
     workers::storage::StorageBridge,
 };
 
@@ -63,11 +64,14 @@ impl PrivatePool {
 
     /// Deposit tokens. `amount` is stroops (`bigint` in JS).
     pub async fn deposit(&self, amount: u128) -> Result<JsValue, JsError> {
-        let mut plan = self
-            .inner()
-            .prepare_deposit(NoteAmount::from(amount))
-            .map_err(pool_err)?;
-        self.execute_plan(&mut plan, "deposit").await
+        with_correlation_id(new_correlation_id(), async {
+            let mut plan = self
+                .inner()
+                .prepare_deposit(NoteAmount::from(amount))
+                .map_err(pool_err)?;
+            self.execute_plan(&mut plan, "deposit").await
+        })
+        .await
     }
 
     /// Transfer privately to explicit recipient keys (note + encryption hex).
@@ -78,29 +82,36 @@ impl PrivatePool {
         encryption_public_key_hex: &str,
         amount: u128,
     ) -> Result<JsValue, JsError> {
-        let recipient = TransferRecipient::keys(
-            NotePublicKey::parse(note_public_key_hex).map_err(|e| JsError::new(&e.to_string()))?,
-            EncryptionPublicKey::parse(encryption_public_key_hex)
-                .map_err(|e| JsError::new(&e.to_string()))?,
-        );
-        let wallet = self.inner().spendable_notes().await.map_err(pool_err)?;
-        let mut plan = self
-            .inner()
-            .prepare_transfer(&wallet, recipient, NoteAmount::from(amount))
-            .await
-            .map_err(pool_err)?;
-        self.execute_plan(&mut plan, "transfer").await
+        with_correlation_id(new_correlation_id(), async {
+            let recipient = TransferRecipient::keys(
+                NotePublicKey::parse(note_public_key_hex)
+                    .map_err(|e| JsError::new(&e.to_string()))?,
+                EncryptionPublicKey::parse(encryption_public_key_hex)
+                    .map_err(|e| JsError::new(&e.to_string()))?,
+            );
+            let wallet = self.inner().spendable_notes().await.map_err(pool_err)?;
+            let mut plan = self
+                .inner()
+                .prepare_transfer(&wallet, recipient, NoteAmount::from(amount))
+                .await
+                .map_err(pool_err)?;
+            self.execute_plan(&mut plan, "transfer").await
+        })
+        .await
     }
 
     /// Transfer privately. `recipient` is a Stellar `G...` address.
     pub async fn transfer(&self, recipient: &str, amount: u128) -> Result<JsValue, JsError> {
-        let wallet = self.inner().spendable_notes().await.map_err(pool_err)?;
-        let mut plan = self
-            .inner()
-            .prepare_transfer(&wallet, recipient, NoteAmount::from(amount))
-            .await
-            .map_err(pool_err)?;
-        self.execute_plan(&mut plan, "transfer").await
+        with_correlation_id(new_correlation_id(), async {
+            let wallet = self.inner().spendable_notes().await.map_err(pool_err)?;
+            let mut plan = self
+                .inner()
+                .prepare_transfer(&wallet, recipient, NoteAmount::from(amount))
+                .await
+                .map_err(pool_err)?;
+            self.execute_plan(&mut plan, "transfer").await
+        })
+        .await
     }
 
     /// Withdraw to `recipient`, or the connected wallet when omitted.
@@ -109,21 +120,27 @@ impl PrivatePool {
         amount: u128,
         recipient: Option<String>,
     ) -> Result<JsValue, JsError> {
-        let to = recipient.unwrap_or_else(|| self.user_address.clone());
-        let wallet = self.inner().spendable_notes().await.map_err(pool_err)?;
-        let mut plan = self
-            .inner()
-            .prepare_withdraw(&wallet, NoteAmount::from(amount), to)
-            .map_err(pool_err)?;
-        self.execute_plan(&mut plan, "withdraw").await
+        with_correlation_id(new_correlation_id(), async {
+            let to = recipient.unwrap_or_else(|| self.user_address.clone());
+            let wallet = self.inner().spendable_notes().await.map_err(pool_err)?;
+            let mut plan = self
+                .inner()
+                .prepare_withdraw(&wallet, NoteAmount::from(amount), to)
+                .map_err(pool_err)?;
+            self.execute_plan(&mut plan, "withdraw").await
+        })
+        .await
     }
 
     /// Low-level pool `transact` call. See SDK [`Transact`] for field
     /// semantics.
     pub async fn transact(&self, config: JsValue) -> Result<JsValue, JsError> {
-        let step = parse_transact_step(config)?;
-        let mut plan = self.inner().prepare_transact(step);
-        self.execute_plan(&mut plan, "transact").await
+        with_correlation_id(new_correlation_id(), async {
+            let step = parse_transact_step(config)?;
+            let mut plan = self.inner().prepare_transact(step);
+            self.execute_plan(&mut plan, "transact").await
+        })
+        .await
     }
 
     /// Generate a selective-disclosure proof for a note commitment.
@@ -132,12 +149,15 @@ impl PrivatePool {
     /// array with 1..=4 entries). Returns `null` when the account must register
     /// at the ASP before disclosing.
     pub async fn disclose(&self, config: JsValue) -> Result<JsValue, JsError> {
-        let req: DisclosureRequest = serde_wasm_bindgen::from_value(config)?;
-        emit("disclose", "prove", "Generating proof…", None, None);
-        match self.inner().disclose(req).await.map_err(pool_err)? {
-            None => Ok(JsValue::NULL),
-            Some(receipt) => Ok(serde_wasm_bindgen::to_value(&receipt)?),
-        }
+        with_correlation_id(new_correlation_id(), async {
+            let req: DisclosureRequest = serde_wasm_bindgen::from_value(config)?;
+            emit("disclose", "prove", "Generating proof…", None, None);
+            match self.inner().disclose(req).await.map_err(pool_err)? {
+                None => Ok(JsValue::NULL),
+                Some(receipt) => Ok(serde_wasm_bindgen::to_value(&receipt)?),
+            }
+        })
+        .await
     }
 
     #[wasm_bindgen(js_name = verifyDisclosure)]
@@ -146,12 +166,15 @@ impl PrivatePool {
         receipt: JsValue,
         expected_vk_hash: &str,
     ) -> Result<JsValue, JsError> {
-        let receipt: DisclosureReceipt = serde_wasm_bindgen::from_value(receipt)?;
-        let report = self
-            .inner()
-            .verify_disclosure(&receipt, expected_vk_hash)
-            .await
-            .map_err(pool_err)?;
-        Ok(serde_wasm_bindgen::to_value(&report)?)
+        with_correlation_id(new_correlation_id(), async {
+            let receipt: DisclosureReceipt = serde_wasm_bindgen::from_value(receipt)?;
+            let report = self
+                .inner()
+                .verify_disclosure(&receipt, expected_vk_hash)
+                .await
+                .map_err(pool_err)?;
+            Ok(serde_wasm_bindgen::to_value(&report)?)
+        })
+        .await
     }
 }

--- a/sdk/web/src/correlation.rs
+++ b/sdk/web/src/correlation.rs
@@ -11,8 +11,15 @@ use tracing::Instrument;
 // shared with the native SDK; they live in `types` so both crates use one
 // implementation. Reached via the client crate re-export so the path
 // resolves on native and wasm targets alike.
+pub use stellar_private_payments_sdk::types::{current_correlation_id, new_correlation_id};
+
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(unused_imports)]
+pub use stellar_private_payments_sdk::types::CorrelationIdLayer;
+
+#[cfg(target_arch = "wasm32")]
 pub use stellar_private_payments_sdk::types::{
-    CorrelationIdLayer, current_correlation_id, new_correlation_id,
+    pop_active_correlation_id, push_active_correlation_id,
 };
 
 /// Run a future with `correlation_id` active. Supports nested operations.
@@ -34,7 +41,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_span_propagation_concurrency() {
-        // Initialize a local subscriber with our layer for this test thread
         let subscriber = Registry::default().with(CorrelationIdLayer);
         let _guard = tracing::subscriber::set_default(subscriber);
 

--- a/sdk/web/src/correlation.rs
+++ b/sdk/web/src/correlation.rs
@@ -1,0 +1,70 @@
+//! Cross-boundary correlation ID propagation for the web SDK.
+//!
+//! Public API entry points generate a correlation ID and instrument the
+//! futures. The web worker bridges read the current ID and attach it to the
+//! request payload; the worker re-attaches it as a tracing span field.
+
+use std::future::Future;
+use tracing::Instrument;
+
+// The correlation-id generator, propagation layer, and scope-walk lookup are
+// shared with the native SDK; they live in `types` so both crates use one
+// implementation. Reached via the client crate re-export so the path
+// resolves on native and wasm targets alike.
+pub use stellar_private_payments_sdk::types::{
+    CorrelationIdLayer, current_correlation_id, new_correlation_id,
+};
+
+/// Run a future with `correlation_id` active. Supports nested operations.
+pub async fn with_correlation_id<F, R>(id: String, f: F) -> R
+where
+    F: Future<Output = R>,
+{
+    let span = tracing::info_span!("operation", correlation_id = %id);
+    f.instrument(span).await
+}
+
+// Native-only: this test drives a multi-task tokio runtime, which is not
+// available on wasm32. `cargo build --tests --target wasm32-unknown-unknown`
+// (wasm-bindgen-test) would otherwise fail to resolve `tokio`.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use tracing_subscriber::{Registry, layer::SubscriberExt};
+
+    #[tokio::test]
+    async fn test_span_propagation_concurrency() {
+        // Initialize a local subscriber with our layer for this test thread
+        let subscriber = Registry::default().with(CorrelationIdLayer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let id_a = "sessionA-op-1".to_string();
+        let id_b = "sessionB-op-2".to_string();
+
+        let handle_a = tokio::spawn(with_correlation_id(id_a.clone(), async move {
+            assert_eq!(current_correlation_id(), Some(id_a.clone()));
+            tokio::task::yield_now().await;
+            assert_eq!(current_correlation_id(), Some(id_a.clone()));
+
+            // Nested check
+            let id_nested = "nested-op-3".to_string();
+            with_correlation_id(id_nested.clone(), async move {
+                assert_eq!(current_correlation_id(), Some(id_nested));
+            })
+            .await;
+
+            assert_eq!(current_correlation_id(), Some(id_a));
+        }));
+
+        let handle_b = tokio::spawn(with_correlation_id(id_b.clone(), async move {
+            assert_eq!(current_correlation_id(), Some(id_b.clone()));
+            tokio::task::yield_now().await;
+            assert_eq!(current_correlation_id(), Some(id_b.clone()));
+            assert_eq!(current_correlation_id(), Some(id_b));
+        }));
+
+        let (res_a, res_b) = tokio::join!(handle_a, handle_b);
+        res_a.expect("thread a finished successfully");
+        res_b.expect("thread b finished successfully");
+    }
+}

--- a/sdk/web/src/lib.rs
+++ b/sdk/web/src/lib.rs
@@ -5,10 +5,12 @@
 mod bootnode;
 mod circuits;
 mod client;
+mod correlation;
 mod deployment;
 mod protocol;
 mod signer;
 mod storage;
+mod telemetry;
 pub mod workers;
 
 pub(crate) mod artifact_hashes {
@@ -21,10 +23,92 @@ pub use bootnode::bootnode_required_js as bootnode_required;
 pub use client::{Account, Client, PrivatePool, verify_selective_disclosure_standalone};
 pub use storage::Storage;
 
+use wasm_bindgen::prelude::*;
+
 pub(crate) fn wasm_start() {
-    console_error_panic_hook::set_once();
-    static LOG: std::sync::Once = std::sync::Once::new();
-    LOG.call_once(|| {
-        wasm_log::init(wasm_log::Config::default());
-    });
+    crate::telemetry::init_telemetry(None);
+    crate::telemetry::install_panic_hook();
+    tracing::info!("SDK telemetry initialized");
+}
+
+/// Configure the SDK telemetry settings (log level, sink targets, buffer sizes,
+/// etc.).
+///
+/// If telemetry has not been initialized yet, this function will initialize it
+/// with the specified config (or defaults). If telemetry has already been
+/// initialized, this will dynamically update runtime settings (log level and
+/// sensitive log reveal).
+///
+/// TS signature:
+/// ```typescript
+/// export function configureTelemetry(config?: {
+///   level?: string;
+///   sink?: "console" | "ringBuffer" | "both";
+///   ringBufferBytes?: number;
+///   revealSensitive?: boolean;
+/// }): void;
+/// ```
+#[wasm_bindgen(js_name = configureTelemetry)]
+pub fn configure_telemetry(config: JsValue) -> Result<(), JsValue> {
+    use stellar_private_payments_sdk::types::TelemetryConfig;
+
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct JsTelemetryConfig {
+        level: Option<String>,
+        sink: Option<stellar_private_payments_sdk::types::TelemetrySink>,
+        ring_buffer_bytes: Option<usize>,
+        reveal_sensitive: Option<bool>,
+    }
+
+    let defaults = crate::telemetry::resolve_default_config();
+
+    let final_config = if config.is_undefined() || config.is_null() {
+        defaults
+    } else {
+        let js_cfg: JsTelemetryConfig = serde_wasm_bindgen::from_value(config)?;
+        TelemetryConfig {
+            level: js_cfg.level.unwrap_or(defaults.level),
+            sink: js_cfg.sink.unwrap_or(defaults.sink),
+            ring_buffer_bytes: js_cfg
+                .ring_buffer_bytes
+                .unwrap_or(defaults.ring_buffer_bytes),
+            reveal_sensitive: js_cfg.reveal_sensitive.unwrap_or(defaults.reveal_sensitive),
+        }
+    };
+
+    if crate::telemetry::is_telemetry_initialized() {
+        // If already initialized, dynamically update runtime settings
+        let _ = crate::telemetry::set_log_level(&final_config.level);
+        stellar_private_payments_sdk::types::set_reveal_sensitive(final_config.reveal_sensitive);
+        return Ok(());
+    }
+
+    crate::telemetry::init_telemetry(Some(final_config));
+    crate::telemetry::install_panic_hook();
+    Ok(())
+}
+
+/// Replace the active tracing [`EnvFilter`] with `level`.
+///
+/// `level` must be a valid tracing directive such as `"info"` or
+/// `"stellar_private_payments_sdk_web=debug"`.
+#[wasm_bindgen]
+pub fn set_log_level(level: &str) -> Result<(), JsValue> {
+    crate::telemetry::set_log_level(level).map_err(JsValue::from)
+}
+
+/// Return the recent formatted log output stored in the in-memory ring buffer.
+#[wasm_bindgen]
+pub fn dump_recent_logs() -> String {
+    crate::telemetry::dump_recent_logs()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_init_telemetry_native() {
+        crate::telemetry::init_telemetry(None);
+        assert!(crate::telemetry::is_telemetry_initialized());
+    }
 }

--- a/sdk/web/src/protocol.rs
+++ b/sdk/web/src/protocol.rs
@@ -1,5 +1,13 @@
 use serde::{Deserialize, Serialize};
 
+/// Wrapper that carries a correlation/operation ID across the gloo-worker
+/// boundary. The worker re-attaches `correlation_id` as a tracing span field.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CorrelatedRequest<T> {
+    pub correlation_id: String,
+    pub payload: T,
+}
+
 pub use stellar_private_payments_sdk::{
     DisclosureInputs, DisclosureInputsRequest, DisclosureProveParams, PreparedProverTx,
     TransactRequest,

--- a/sdk/web/src/telemetry.rs
+++ b/sdk/web/src/telemetry.rs
@@ -1,38 +1,24 @@
 //! Shared tracing telemetry setup for the web SDK.
 //!
-//! Provides a single subscriber initialization point used by the main thread
-//! (`wasm_start`) and by each web worker. The subscriber consists of:
-//!
-//! * a standard [`tracing_subscriber::fmt`] layer for browser-console output
-//!   (via [`ConsoleMakeWriter`]), so the active span context — including
-//!   `correlation_id` — is printed on every line, same as the ring buffer;
-//! * an [`EnvFilter`] with a reload handle so the level can be changed at
-//!   runtime, and
-//! * a bounded in-memory ring buffer that stores recent formatted log lines for
-//!   retrieval via [`dump_recent_logs`].
-//!
-//! The default filter is controlled by the `SPP_LOG_LEVEL` environment
-//! variable. In native builds it is read at runtime; in WASM builds it is read
-//! at compile time and baked into the binary. If unset, the default is `debug`.
-//!
-//! Note: this intentionally does not use [`tracing_wasm::WASMLayer`] — that
-//! layer's `on_event` only records the event's own fields, never the
-//! enclosing span's, so span-only fields like `correlation_id` never reach
-//! the console through it.
+//! Provides a lightweight subscriber initialization point used by the main
+//! thread (`wasm_start`) and by each web worker.
 
-use std::{
-    io::Write,
-    sync::{Arc, Mutex, Once},
-};
+use std::sync::{Arc, Mutex, Once};
+use tracing::{Event, Subscriber};
 use tracing_subscriber::{
-    EnvFilter, Registry, fmt::writer::MakeWriter, layer::SubscriberExt, reload,
+    Layer, Registry,
+    layer::{Context, SubscriberExt},
     util::SubscriberInitExt,
 };
 
+#[cfg(target_arch = "wasm32")]
+use tracing::Level;
+
 static TELEMETRY_INIT: Once = Once::new();
 static PANIC_HOOK_INIT: Once = Once::new();
-static FILTER_HANDLE: Mutex<Option<reload::Handle<EnvFilter, Registry>>> = Mutex::new(None);
 static RING_BUFFER: Mutex<Option<Arc<RingBuffer>>> = Mutex::new(None);
+static LOG_LEVEL: Mutex<tracing::level_filters::LevelFilter> =
+    Mutex::new(tracing::level_filters::LevelFilter::INFO);
 
 /// Bounded in-memory byte buffer used as a recent-log sink.
 pub struct RingBuffer {
@@ -63,110 +49,109 @@ impl RingBuffer {
     }
 }
 
-/// Writer that appends to a shared [`RingBuffer`].
-#[derive(Clone)]
-pub struct RingBufferWriter {
-    buffer: Arc<RingBuffer>,
+#[derive(Default)]
+struct MessageVisitor {
+    message: String,
+    fields: Vec<String>,
 }
 
-impl Write for RingBufferWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.buffer.append(buf);
-        Ok(buf.len())
+impl tracing::field::Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            let s = format!("{value:?}");
+            if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
+                self.message = s[1..s.len() - 1].to_string();
+            } else {
+                self.message = s;
+            }
+        } else {
+            self.fields.push(format!("{}={:?}", field.name(), value));
+        }
     }
 
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
-/// Factory for [`RingBufferWriter`] instances.
-#[derive(Clone)]
-pub struct RingBufferMakeWriter {
-    buffer: Arc<RingBuffer>,
-}
-
-impl RingBufferMakeWriter {
-    pub fn new(buffer: Arc<RingBuffer>) -> Self {
-        Self { buffer }
-    }
-}
-
-impl<'a> MakeWriter<'a> for RingBufferMakeWriter {
-    type Writer = RingBufferWriter;
-
-    fn make_writer(&'a self) -> Self::Writer {
-        RingBufferWriter {
-            buffer: self.buffer.clone(),
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "message" {
+            self.message = value.to_string();
+        } else {
+            self.fields.push(format!("{}={:?}", field.name(), value));
         }
     }
 }
 
-/// Writer that buffers one formatted line and flushes it to the browser
-/// console (via `web_sys::console`) on drop, using the console method that
-/// matches the event's tracing level. Unlike [`tracing_wasm::WASMLayer`],
-/// this is fed by the standard `fmt` layer, so the active span context
-/// (e.g. `correlation_id`) is included on every line — the same formatting
-/// the ring buffer sink uses.
-#[cfg(target_arch = "wasm32")]
-pub struct ConsoleWriter {
-    level: tracing::Level,
-    buf: String,
+/// Minimal, zero-overhead tracing layer for WASM and client logging.
+pub struct CustomTelemetryLayer {
+    ring_buffer: Option<Arc<RingBuffer>>,
+    #[allow(dead_code)]
+    use_console: bool,
 }
 
-#[cfg(target_arch = "wasm32")]
-impl Write for ConsoleWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.buf.push_str(&String::from_utf8_lossy(buf));
-        Ok(buf.len())
+impl<S> Layer<S> for CustomTelemetryLayer
+where
+    S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    fn enabled(&self, metadata: &tracing::Metadata<'_>, _ctx: Context<'_, S>) -> bool {
+        let current_filter = *LOG_LEVEL.lock().unwrap_or_else(|e| e.into_inner());
+        metadata.level() <= &current_filter
     }
 
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
 
-#[cfg(target_arch = "wasm32")]
-impl Drop for ConsoleWriter {
-    fn drop(&mut self) {
-        if self.buf.is_empty() {
-            return;
+        let mut body = visitor.message;
+        if !visitor.fields.is_empty() {
+            if !body.is_empty() {
+                body.push(' ');
+            }
+            body.push_str(&visitor.fields.join(" "));
         }
-        let line = self.buf.trim_end_matches('\n');
-        use wasm_bindgen::JsValue;
-        let js_line = JsValue::from_str(line);
-        match self.level {
-            tracing::Level::ERROR => web_sys::console::error_1(&js_line),
-            tracing::Level::WARN => web_sys::console::warn_1(&js_line),
-            tracing::Level::INFO => web_sys::console::info_1(&js_line),
-            tracing::Level::DEBUG => web_sys::console::debug_1(&js_line),
-            tracing::Level::TRACE => web_sys::console::debug_1(&js_line),
+
+        let correlation = crate::correlation::current_correlation_id();
+        let correlation_str = match correlation {
+            Some(id) if !id.is_empty() => format!(" [{id}]"),
+            _ => String::new(),
+        };
+
+        let timestamp = {
+            #[cfg(target_arch = "wasm32")]
+            {
+                js_sys::Date::new_0()
+                    .to_iso_string()
+                    .as_string()
+                    .unwrap_or_default()
+            }
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                String::new()
+            }
+        };
+
+        let ts_str = if timestamp.is_empty() {
+            String::new()
+        } else {
+            format!("[{timestamp}] ")
+        };
+
+        let formatted = format!(
+            "{ts_str}[{level}]{correlation_str} {body}\n",
+            level = event.metadata().level(),
+        );
+
+        if let Some(ref rb) = self.ring_buffer {
+            rb.append(formatted.as_bytes());
         }
-    }
-}
 
-/// Factory for [`ConsoleWriter`] instances, one per formatted line.
-#[cfg(target_arch = "wasm32")]
-#[derive(Clone, Default)]
-pub struct ConsoleMakeWriter;
-
-#[cfg(target_arch = "wasm32")]
-impl<'a> MakeWriter<'a> for ConsoleMakeWriter {
-    type Writer = ConsoleWriter;
-
-    fn make_writer(&'a self) -> Self::Writer {
-        // Only reached if the subscriber can't determine a level (shouldn't
-        // happen via make_writer_for); default to INFO rather than panic.
-        ConsoleWriter {
-            level: tracing::Level::INFO,
-            buf: String::new(),
-        }
-    }
-
-    fn make_writer_for(&'a self, meta: &tracing::Metadata<'_>) -> Self::Writer {
-        ConsoleWriter {
-            level: *meta.level(),
-            buf: String::new(),
+        #[cfg(target_arch = "wasm32")]
+        if self.use_console {
+            let line = formatted.trim_end_matches('\n');
+            let js_line = wasm_bindgen::JsValue::from_str(line);
+            match *event.metadata().level() {
+                Level::ERROR => web_sys::console::error_1(&js_line),
+                Level::WARN => web_sys::console::warn_1(&js_line),
+                Level::INFO => web_sys::console::info_1(&js_line),
+                Level::DEBUG => web_sys::console::debug_1(&js_line),
+                Level::TRACE => web_sys::console::debug_1(&js_line),
+            }
         }
     }
 }
@@ -188,22 +173,13 @@ pub fn resolve_default_config() -> stellar_private_payments_sdk::types::Telemetr
         }
     });
 
-    // The ring buffer backs `dump_recent_logs()` — the mechanism a user relies
-    // on to attach diagnostic logs to a bug report. It must always be active,
-    // independent of build profile or console verbosity, or "collect logs"
-    // silently does nothing in a production build.
     let sink = if is_wasm {
         TelemetrySink::Both
     } else {
         TelemetrySink::Console
     };
 
-    let ring_buffer_bytes = if is_test {
-        0
-    } else {
-        256 * 1024 // 256 KiB
-    };
-
+    let ring_buffer_bytes = if is_test { 0 } else { 256 * 1024 };
     let reveal_sensitive = is_test;
 
     TelemetryConfig {
@@ -215,35 +191,25 @@ pub fn resolve_default_config() -> stellar_private_payments_sdk::types::Telemetr
 }
 
 /// Initialize the tracing subscriber once for the current WASM isolate.
-///
-/// Safe to call from the main thread or from any worker; the first call in a
-/// given isolate installs the subscriber, subsequent calls are no-ops.
 pub fn init_telemetry(config: Option<stellar_private_payments_sdk::types::TelemetryConfig>) {
     TELEMETRY_INIT.call_once(|| {
         let config = config.unwrap_or_else(resolve_default_config);
 
-        // Honor the reveal_sensitive configuration
         stellar_private_payments_sdk::types::set_reveal_sensitive(config.reveal_sensitive);
 
         let _ = tracing_log::LogTracer::init();
 
-        // In release builds, clamp the legacy log facade to info so that
-        // third-party log::debug! / log::trace! calls short-circuit before formatting.
-        // debug builds keep all levels.
         #[cfg(not(debug_assertions))]
         log::set_max_level(log::LevelFilter::Info);
         #[cfg(debug_assertions)]
         log::set_max_level(log::LevelFilter::Trace);
 
-        // If SPP_LOG_LEVEL is set in env (runtime or compile-time), it overrides
-        // config.level
         let level_directive = std::env::var("SPP_LOG_LEVEL")
             .ok()
             .or_else(|| option_env!("SPP_LOG_LEVEL").map(|s| s.to_string()))
             .unwrap_or(config.level);
-        let filter =
-            EnvFilter::try_new(&level_directive).unwrap_or_else(|_| EnvFilter::new("info"));
-        let (filter_layer, reload_handle) = reload::Layer::new(filter);
+
+        let _ = set_log_level(&level_directive);
 
         let ring_buffer = Arc::new(RingBuffer::new(config.ring_buffer_bytes));
 
@@ -255,73 +221,34 @@ pub fn init_telemetry(config: Option<stellar_private_payments_sdk::types::Teleme
             == stellar_private_payments_sdk::types::TelemetrySink::Console
             || config.sink == stellar_private_payments_sdk::types::TelemetrySink::Both;
 
-        let fmt_layer = if use_ring_buffer {
-            Some(
-                tracing_subscriber::fmt::layer()
-                    .with_writer(RingBufferMakeWriter::new(ring_buffer.clone()))
-                    .without_time(),
-            )
-        } else {
-            None
+        let custom_layer = CustomTelemetryLayer {
+            ring_buffer: if use_ring_buffer {
+                Some(ring_buffer.clone())
+            } else {
+                None
+            },
+            use_console,
         };
 
-        #[cfg(target_arch = "wasm32")]
-        let console_layer = if use_console {
-            Some(
-                tracing_subscriber::fmt::layer()
-                    .with_writer(ConsoleMakeWriter)
-                    .without_time(),
-            )
-        } else {
-            None
-        };
-
-        #[cfg(target_arch = "wasm32")]
-        let _ = tracing_subscriber::registry()
-            .with(filter_layer)
-            .with(fmt_layer)
-            .with(console_layer)
+        let _ = Registry::default()
+            .with(custom_layer)
             .with(crate::correlation::CorrelationIdLayer)
             .try_init();
 
-        #[cfg(not(target_arch = "wasm32"))]
-        let native_console_layer = if use_console {
-            Some(tracing_subscriber::fmt::layer())
-        } else {
-            None
-        };
-
-        #[cfg(not(target_arch = "wasm32"))]
-        let _ = tracing_subscriber::registry()
-            .with(filter_layer)
-            .with(fmt_layer)
-            .with(native_console_layer)
-            .with(crate::correlation::CorrelationIdLayer)
-            .try_init();
-
-        *FILTER_HANDLE.lock().expect("filter handle lock poisoned") = Some(reload_handle);
         *RING_BUFFER.lock().expect("ring buffer lock poisoned") = Some(ring_buffer);
     });
 }
 
-/// Replace the active [`EnvFilter`] with the supplied directive string.
-///
-/// Returns an error if telemetry has not been initialized or if the directive
-/// is invalid.
+/// Replace the active log level filter.
 pub fn set_log_level(directive: &str) -> Result<(), String> {
-    let handle = FILTER_HANDLE
-        .lock()
-        .expect("filter handle lock poisoned")
-        .clone()
-        .ok_or("telemetry not initialized")?;
-    let new_filter = EnvFilter::try_new(directive).map_err(|e| e.to_string())?;
-    handle.reload(new_filter).map_err(|e| e.to_string())?;
+    use std::str::FromStr;
+    let filter =
+        tracing::level_filters::LevelFilter::from_str(directive).map_err(|e| e.to_string())?;
+    *LOG_LEVEL.lock().map_err(|e| e.to_string())? = filter;
     Ok(())
 }
 
 /// Return the contents of the recent-log ring buffer as a string.
-///
-/// Returns an empty string if telemetry has not been initialized.
 pub fn dump_recent_logs() -> String {
     RING_BUFFER
         .lock()
@@ -331,24 +258,14 @@ pub fn dump_recent_logs() -> String {
         .unwrap_or_default()
 }
 
-/// Install a panic hook that records the active correlation ID and worker span
-/// field before chaining to the previously installed hook.
-///
-/// Must be called after [`init_telemetry`] so that the panic record is captured
-/// by the subscriber and its ring buffer. Safe to call multiple times; the hook
-/// is installed only once per WASM isolate.
+/// Install a panic hook that records the active correlation ID.
 pub fn install_panic_hook() {
     PANIC_HOOK_INIT.call_once(|| {
-        // Start with the console hook so the eventual chain still prints to the
-        // browser console, then wrap it to add structured tracing output.
         console_error_panic_hook::set_once();
         let previous = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |info| {
             let correlation_id = crate::correlation::current_correlation_id();
             let message = format!("panic: {info}");
-            // Emit within the current span so any active worker field is
-            // captured automatically; the event also reaches the ring buffer
-            // via the fmt layer installed in `init_telemetry`.
             tracing::error!(correlation_id = ?correlation_id, "{}", message);
             previous(info);
         }));
@@ -357,8 +274,8 @@ pub fn install_panic_hook() {
 
 /// Check whether the telemetry subscriber has been initialized.
 pub fn is_telemetry_initialized() -> bool {
-    FILTER_HANDLE
+    RING_BUFFER
         .lock()
-        .expect("filter handle lock poisoned")
+        .expect("ring buffer lock poisoned")
         .is_some()
 }

--- a/sdk/web/src/telemetry.rs
+++ b/sdk/web/src/telemetry.rs
@@ -1,0 +1,364 @@
+//! Shared tracing telemetry setup for the web SDK.
+//!
+//! Provides a single subscriber initialization point used by the main thread
+//! (`wasm_start`) and by each web worker. The subscriber consists of:
+//!
+//! * a standard [`tracing_subscriber::fmt`] layer for browser-console output
+//!   (via [`ConsoleMakeWriter`]), so the active span context — including
+//!   `correlation_id` — is printed on every line, same as the ring buffer;
+//! * an [`EnvFilter`] with a reload handle so the level can be changed at
+//!   runtime, and
+//! * a bounded in-memory ring buffer that stores recent formatted log lines for
+//!   retrieval via [`dump_recent_logs`].
+//!
+//! The default filter is controlled by the `SPP_LOG_LEVEL` environment
+//! variable. In native builds it is read at runtime; in WASM builds it is read
+//! at compile time and baked into the binary. If unset, the default is `debug`.
+//!
+//! Note: this intentionally does not use [`tracing_wasm::WASMLayer`] — that
+//! layer's `on_event` only records the event's own fields, never the
+//! enclosing span's, so span-only fields like `correlation_id` never reach
+//! the console through it.
+
+use std::{
+    io::Write,
+    sync::{Arc, Mutex, Once},
+};
+use tracing_subscriber::{
+    EnvFilter, Registry, fmt::writer::MakeWriter, layer::SubscriberExt, reload,
+    util::SubscriberInitExt,
+};
+
+static TELEMETRY_INIT: Once = Once::new();
+static PANIC_HOOK_INIT: Once = Once::new();
+static FILTER_HANDLE: Mutex<Option<reload::Handle<EnvFilter, Registry>>> = Mutex::new(None);
+static RING_BUFFER: Mutex<Option<Arc<RingBuffer>>> = Mutex::new(None);
+
+/// Bounded in-memory byte buffer used as a recent-log sink.
+pub struct RingBuffer {
+    data: Mutex<Vec<u8>>,
+    capacity: usize,
+}
+
+impl RingBuffer {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            data: Mutex::new(Vec::with_capacity(capacity)),
+            capacity,
+        }
+    }
+
+    pub fn append(&self, bytes: &[u8]) {
+        let mut data = self.data.lock().expect("ring buffer lock poisoned");
+        data.extend_from_slice(bytes);
+        if data.len() > self.capacity {
+            let excess = data.len().saturating_sub(self.capacity);
+            data.drain(0..excess);
+        }
+    }
+
+    pub fn dump(&self) -> String {
+        let data = self.data.lock().expect("ring buffer lock poisoned");
+        String::from_utf8_lossy(&data).into_owned()
+    }
+}
+
+/// Writer that appends to a shared [`RingBuffer`].
+#[derive(Clone)]
+pub struct RingBufferWriter {
+    buffer: Arc<RingBuffer>,
+}
+
+impl Write for RingBufferWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buffer.append(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Factory for [`RingBufferWriter`] instances.
+#[derive(Clone)]
+pub struct RingBufferMakeWriter {
+    buffer: Arc<RingBuffer>,
+}
+
+impl RingBufferMakeWriter {
+    pub fn new(buffer: Arc<RingBuffer>) -> Self {
+        Self { buffer }
+    }
+}
+
+impl<'a> MakeWriter<'a> for RingBufferMakeWriter {
+    type Writer = RingBufferWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        RingBufferWriter {
+            buffer: self.buffer.clone(),
+        }
+    }
+}
+
+/// Writer that buffers one formatted line and flushes it to the browser
+/// console (via `web_sys::console`) on drop, using the console method that
+/// matches the event's tracing level. Unlike [`tracing_wasm::WASMLayer`],
+/// this is fed by the standard `fmt` layer, so the active span context
+/// (e.g. `correlation_id`) is included on every line — the same formatting
+/// the ring buffer sink uses.
+#[cfg(target_arch = "wasm32")]
+pub struct ConsoleWriter {
+    level: tracing::Level,
+    buf: String,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl Write for ConsoleWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buf.push_str(&String::from_utf8_lossy(buf));
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl Drop for ConsoleWriter {
+    fn drop(&mut self) {
+        if self.buf.is_empty() {
+            return;
+        }
+        let line = self.buf.trim_end_matches('\n');
+        use wasm_bindgen::JsValue;
+        let js_line = JsValue::from_str(line);
+        match self.level {
+            tracing::Level::ERROR => web_sys::console::error_1(&js_line),
+            tracing::Level::WARN => web_sys::console::warn_1(&js_line),
+            tracing::Level::INFO => web_sys::console::info_1(&js_line),
+            tracing::Level::DEBUG => web_sys::console::debug_1(&js_line),
+            tracing::Level::TRACE => web_sys::console::debug_1(&js_line),
+        }
+    }
+}
+
+/// Factory for [`ConsoleWriter`] instances, one per formatted line.
+#[cfg(target_arch = "wasm32")]
+#[derive(Clone, Default)]
+pub struct ConsoleMakeWriter;
+
+#[cfg(target_arch = "wasm32")]
+impl<'a> MakeWriter<'a> for ConsoleMakeWriter {
+    type Writer = ConsoleWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        // Only reached if the subscriber can't determine a level (shouldn't
+        // happen via make_writer_for); default to INFO rather than panic.
+        ConsoleWriter {
+            level: tracing::Level::INFO,
+            buf: String::new(),
+        }
+    }
+
+    fn make_writer_for(&'a self, meta: &tracing::Metadata<'_>) -> Self::Writer {
+        ConsoleWriter {
+            level: *meta.level(),
+            buf: String::new(),
+        }
+    }
+}
+
+/// Helper to resolve the default configuration based on build profile and
+/// environment.
+pub fn resolve_default_config() -> stellar_private_payments_sdk::types::TelemetryConfig {
+    use stellar_private_payments_sdk::types::{TelemetryConfig, TelemetrySink};
+
+    let is_wasm = cfg!(target_arch = "wasm32");
+    let is_test = cfg!(test);
+    let debug_assertions = cfg!(debug_assertions);
+
+    let level = std::env::var("SPP_LOG_LEVEL").unwrap_or_else(|_| {
+        if is_test || debug_assertions {
+            "debug".to_string()
+        } else {
+            "info".to_string()
+        }
+    });
+
+    // The ring buffer backs `dump_recent_logs()` — the mechanism a user relies
+    // on to attach diagnostic logs to a bug report. It must always be active,
+    // independent of build profile or console verbosity, or "collect logs"
+    // silently does nothing in a production build.
+    let sink = if is_wasm {
+        TelemetrySink::Both
+    } else {
+        TelemetrySink::Console
+    };
+
+    let ring_buffer_bytes = if is_test {
+        0
+    } else {
+        256 * 1024 // 256 KiB
+    };
+
+    let reveal_sensitive = is_test;
+
+    TelemetryConfig {
+        level,
+        sink,
+        ring_buffer_bytes,
+        reveal_sensitive,
+    }
+}
+
+/// Initialize the tracing subscriber once for the current WASM isolate.
+///
+/// Safe to call from the main thread or from any worker; the first call in a
+/// given isolate installs the subscriber, subsequent calls are no-ops.
+pub fn init_telemetry(config: Option<stellar_private_payments_sdk::types::TelemetryConfig>) {
+    TELEMETRY_INIT.call_once(|| {
+        let config = config.unwrap_or_else(resolve_default_config);
+
+        // Honor the reveal_sensitive configuration
+        stellar_private_payments_sdk::types::set_reveal_sensitive(config.reveal_sensitive);
+
+        let _ = tracing_log::LogTracer::init();
+
+        // In release builds, clamp the legacy log facade to info so that
+        // third-party log::debug! / log::trace! calls short-circuit before formatting.
+        // debug builds keep all levels.
+        #[cfg(not(debug_assertions))]
+        log::set_max_level(log::LevelFilter::Info);
+        #[cfg(debug_assertions)]
+        log::set_max_level(log::LevelFilter::Trace);
+
+        // If SPP_LOG_LEVEL is set in env (runtime or compile-time), it overrides
+        // config.level
+        let level_directive = std::env::var("SPP_LOG_LEVEL")
+            .ok()
+            .or_else(|| option_env!("SPP_LOG_LEVEL").map(|s| s.to_string()))
+            .unwrap_or(config.level);
+        let filter =
+            EnvFilter::try_new(&level_directive).unwrap_or_else(|_| EnvFilter::new("info"));
+        let (filter_layer, reload_handle) = reload::Layer::new(filter);
+
+        let ring_buffer = Arc::new(RingBuffer::new(config.ring_buffer_bytes));
+
+        let use_ring_buffer = config.sink
+            == stellar_private_payments_sdk::types::TelemetrySink::RingBuffer
+            || config.sink == stellar_private_payments_sdk::types::TelemetrySink::Both;
+
+        let use_console = config.sink
+            == stellar_private_payments_sdk::types::TelemetrySink::Console
+            || config.sink == stellar_private_payments_sdk::types::TelemetrySink::Both;
+
+        let fmt_layer = if use_ring_buffer {
+            Some(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(RingBufferMakeWriter::new(ring_buffer.clone()))
+                    .without_time(),
+            )
+        } else {
+            None
+        };
+
+        #[cfg(target_arch = "wasm32")]
+        let console_layer = if use_console {
+            Some(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(ConsoleMakeWriter)
+                    .without_time(),
+            )
+        } else {
+            None
+        };
+
+        #[cfg(target_arch = "wasm32")]
+        let _ = tracing_subscriber::registry()
+            .with(filter_layer)
+            .with(fmt_layer)
+            .with(console_layer)
+            .with(crate::correlation::CorrelationIdLayer)
+            .try_init();
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let native_console_layer = if use_console {
+            Some(tracing_subscriber::fmt::layer())
+        } else {
+            None
+        };
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let _ = tracing_subscriber::registry()
+            .with(filter_layer)
+            .with(fmt_layer)
+            .with(native_console_layer)
+            .with(crate::correlation::CorrelationIdLayer)
+            .try_init();
+
+        *FILTER_HANDLE.lock().expect("filter handle lock poisoned") = Some(reload_handle);
+        *RING_BUFFER.lock().expect("ring buffer lock poisoned") = Some(ring_buffer);
+    });
+}
+
+/// Replace the active [`EnvFilter`] with the supplied directive string.
+///
+/// Returns an error if telemetry has not been initialized or if the directive
+/// is invalid.
+pub fn set_log_level(directive: &str) -> Result<(), String> {
+    let handle = FILTER_HANDLE
+        .lock()
+        .expect("filter handle lock poisoned")
+        .clone()
+        .ok_or("telemetry not initialized")?;
+    let new_filter = EnvFilter::try_new(directive).map_err(|e| e.to_string())?;
+    handle.reload(new_filter).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Return the contents of the recent-log ring buffer as a string.
+///
+/// Returns an empty string if telemetry has not been initialized.
+pub fn dump_recent_logs() -> String {
+    RING_BUFFER
+        .lock()
+        .expect("ring buffer lock poisoned")
+        .as_ref()
+        .map(|rb| rb.dump())
+        .unwrap_or_default()
+}
+
+/// Install a panic hook that records the active correlation ID and worker span
+/// field before chaining to the previously installed hook.
+///
+/// Must be called after [`init_telemetry`] so that the panic record is captured
+/// by the subscriber and its ring buffer. Safe to call multiple times; the hook
+/// is installed only once per WASM isolate.
+pub fn install_panic_hook() {
+    PANIC_HOOK_INIT.call_once(|| {
+        // Start with the console hook so the eventual chain still prints to the
+        // browser console, then wrap it to add structured tracing output.
+        console_error_panic_hook::set_once();
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            let correlation_id = crate::correlation::current_correlation_id();
+            let message = format!("panic: {info}");
+            // Emit within the current span so any active worker field is
+            // captured automatically; the event also reaches the ring buffer
+            // via the fmt layer installed in `init_telemetry`.
+            tracing::error!(correlation_id = ?correlation_id, "{}", message);
+            previous(info);
+        }));
+    });
+}
+
+/// Check whether the telemetry subscriber has been initialized.
+pub fn is_telemetry_initialized() -> bool {
+    FILTER_HANDLE
+        .lock()
+        .expect("filter handle lock poisoned")
+        .is_some()
+}

--- a/sdk/web/src/telemetry.rs
+++ b/sdk/web/src/telemetry.rs
@@ -3,12 +3,17 @@
 //! Provides a lightweight subscriber initialization point used by the main
 //! thread (`wasm_start`) and by each web worker.
 
-use std::sync::{Arc, Mutex, Once};
-use tracing::{Event, Subscriber};
-use tracing_subscriber::{
-    Layer, Registry,
-    layer::{Context, SubscriberExt},
-    util::SubscriberInitExt,
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    sync::{
+        Arc, Mutex, Once,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+use tracing::{
+    Event, Id, Metadata, Subscriber,
+    span::{Attributes, Record},
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -19,6 +24,15 @@ static PANIC_HOOK_INIT: Once = Once::new();
 static RING_BUFFER: Mutex<Option<Arc<RingBuffer>>> = Mutex::new(None);
 static LOG_LEVEL: Mutex<tracing::level_filters::LevelFilter> =
     Mutex::new(tracing::level_filters::LevelFilter::INFO);
+
+#[allow(dead_code)]
+struct SpanData {
+    correlation_id: Option<String>,
+}
+
+thread_local! {
+    static SPAN_TABLE: RefCell<HashMap<u64, SpanData>> = RefCell::new(HashMap::new());
+}
 
 /// Bounded in-memory byte buffer used as a recent-log sink.
 pub struct RingBuffer {
@@ -53,14 +67,18 @@ impl RingBuffer {
 struct MessageVisitor {
     message: String,
     fields: Vec<String>,
+    correlation_id: Option<String>,
 }
 
 impl tracing::field::Visit for MessageVisitor {
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-        if field.name() == "message" {
+        if field.name() == "correlation_id" {
+            self.correlation_id = Some(format!("{value:?}"));
+        } else if field.name() == "message" {
             let s = format!("{value:?}");
             if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
-                self.message = s[1..s.len() - 1].to_string();
+                let end = s.len().saturating_sub(1);
+                self.message = s[1..end].to_string();
             } else {
                 self.message = s;
             }
@@ -70,7 +88,9 @@ impl tracing::field::Visit for MessageVisitor {
     }
 
     fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-        if field.name() == "message" {
+        if field.name() == "correlation_id" {
+            self.correlation_id = Some(value.to_string());
+        } else if field.name() == "message" {
             self.message = value.to_string();
         } else {
             self.fields.push(format!("{}={:?}", field.name(), value));
@@ -78,23 +98,82 @@ impl tracing::field::Visit for MessageVisitor {
     }
 }
 
-/// Minimal, zero-overhead tracing layer for WASM and client logging.
-pub struct CustomTelemetryLayer {
+/// Minimal, zero-overhead tracing subscriber for WASM and web logging.
+pub struct CustomTelemetrySubscriber {
     ring_buffer: Option<Arc<RingBuffer>>,
     #[allow(dead_code)]
     use_console: bool,
+    next_id: AtomicU64,
 }
 
-impl<S> Layer<S> for CustomTelemetryLayer
-where
-    S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
-{
-    fn enabled(&self, metadata: &tracing::Metadata<'_>, _ctx: Context<'_, S>) -> bool {
+impl CustomTelemetrySubscriber {
+    #[allow(dead_code)]
+    pub fn new(ring_buffer: Option<Arc<RingBuffer>>, use_console: bool) -> Self {
+        Self {
+            ring_buffer,
+            use_console,
+            next_id: AtomicU64::new(0),
+        }
+    }
+}
+
+impl Subscriber for CustomTelemetrySubscriber {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         let current_filter = *LOG_LEVEL.lock().unwrap_or_else(|e| e.into_inner());
         metadata.level() <= &current_filter
     }
 
-    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+    fn new_span(&self, attrs: &Attributes<'_>) -> Id {
+        let mut visitor = MessageVisitor::default();
+        attrs.record(&mut visitor);
+
+        let id_val = self
+            .next_id
+            .fetch_add(1, Ordering::Relaxed)
+            .saturating_add(1);
+        let id = Id::from_u64(id_val);
+
+        if visitor.correlation_id.is_some() {
+            SPAN_TABLE.with(|table| {
+                table.borrow_mut().insert(
+                    id_val,
+                    SpanData {
+                        correlation_id: visitor.correlation_id,
+                    },
+                );
+            });
+        }
+
+        id
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn enter(&self, _id: &Id) {
+        #[cfg(target_arch = "wasm32")]
+        SPAN_TABLE.with(|table| {
+            if let Some(data) = table.borrow().get(&_id.into_u64()) {
+                if let Some(ref corr) = data.correlation_id {
+                    crate::correlation::push_active_correlation_id(corr.clone());
+                }
+            }
+        });
+    }
+
+    fn exit(&self, _id: &Id) {
+        #[cfg(target_arch = "wasm32")]
+        SPAN_TABLE.with(|table| {
+            if let Some(data) = table.borrow().get(&_id.into_u64()) {
+                if data.correlation_id.is_some() {
+                    crate::correlation::pop_active_correlation_id();
+                }
+            }
+        });
+    }
+
+    fn event(&self, event: &Event<'_>) {
         let mut visitor = MessageVisitor::default();
         event.record(&mut visitor);
 
@@ -197,13 +276,6 @@ pub fn init_telemetry(config: Option<stellar_private_payments_sdk::types::Teleme
 
         stellar_private_payments_sdk::types::set_reveal_sensitive(config.reveal_sensitive);
 
-        let _ = tracing_log::LogTracer::init();
-
-        #[cfg(not(debug_assertions))]
-        log::set_max_level(log::LevelFilter::Info);
-        #[cfg(debug_assertions)]
-        log::set_max_level(log::LevelFilter::Trace);
-
         let level_directive = std::env::var("SPP_LOG_LEVEL")
             .ok()
             .or_else(|| option_env!("SPP_LOG_LEVEL").map(|s| s.to_string()))
@@ -221,19 +293,17 @@ pub fn init_telemetry(config: Option<stellar_private_payments_sdk::types::Teleme
             == stellar_private_payments_sdk::types::TelemetrySink::Console
             || config.sink == stellar_private_payments_sdk::types::TelemetrySink::Both;
 
-        let custom_layer = CustomTelemetryLayer {
+        let subscriber = CustomTelemetrySubscriber {
             ring_buffer: if use_ring_buffer {
                 Some(ring_buffer.clone())
             } else {
                 None
             },
             use_console,
+            next_id: AtomicU64::new(0),
         };
 
-        let _ = Registry::default()
-            .with(custom_layer)
-            .with(crate::correlation::CorrelationIdLayer)
-            .try_init();
+        let _ = tracing::subscriber::set_global_default(subscriber);
 
         *RING_BUFFER.lock().expect("ring buffer lock poisoned") = Some(ring_buffer);
     });

--- a/sdk/web/src/workers/prover.rs
+++ b/sdk/web/src/workers/prover.rs
@@ -3,7 +3,7 @@ use crate::{
         ensure_sha256_matches, fetch_circuit_file, fetch_circuit_file_verified,
         get_or_derive_uncompressed,
     },
-    protocol::{ProverWorkerRequest, ProverWorkerResponse},
+    protocol::{CorrelatedRequest, ProverWorkerRequest, ProverWorkerResponse},
 };
 use anyhow::{Context as _, Result, anyhow};
 use futures::{FutureExt, try_join};
@@ -27,6 +27,7 @@ use stellar_private_payments_sdk::{
         SELECTIVE_DISCLOSURE_4_LEVELS, SELECTIVE_DISCLOSURE_4_N_NOTES,
     },
 };
+use tracing::Instrument;
 use wasm_bindgen::JsError;
 use wasm_bindgen_futures::spawn_local;
 
@@ -201,7 +202,7 @@ async fn ensure_disclosure_prover(n_notes: usize) -> Result<(), JsError> {
             match Groth16Prover::new_from_uncompressed_pk(&uncompressed_pk, &r1cs_bytes) {
                 Ok(prover) => prover,
                 Err(e) => {
-                    log::warn!(
+                    tracing::warn!(
                         "[{WORKER_NAME}] uncompressed disclosure({n_notes}) prover build failed ({e:#}), falling back to compressed"
                     );
                     build_disclosure_from_compressed(&pk_name, &hashes, &r1cs_bytes).await?
@@ -209,7 +210,7 @@ async fn ensure_disclosure_prover(n_notes: usize) -> Result<(), JsError> {
             }
         }
         Err(e) => {
-            log::warn!(
+            tracing::warn!(
                 "[{WORKER_NAME}] uncompressed disclosure({n_notes}) proving key unavailable ({e:?}), falling back to compressed"
             );
             build_disclosure_from_compressed(&pk_name, &hashes, &r1cs_bytes).await?
@@ -366,14 +367,14 @@ async fn build_transact_prover(
             match ProverEngine::new_from_uncompressed_pk(&uncompressed_pk, wasm_bytes, r1cs_bytes) {
                 Ok(engine) => return Ok(engine),
                 Err(e) => {
-                    log::warn!(
+                    tracing::warn!(
                         "[{WORKER_NAME}] uncompressed transact({pk_name_for_log}) prover build failed ({e:#}), falling back to compressed"
                     );
                 }
             }
         }
         Err(e) => {
-            log::warn!(
+            tracing::warn!(
                 "[{WORKER_NAME}] uncompressed transact({pk_name_for_log}) proving key unavailable ({e:?}), falling back to compressed"
             );
         }
@@ -383,15 +384,22 @@ async fn build_transact_prover(
 }
 
 pub fn worker_main() {
-    console_error_panic_hook::set_once();
-    wasm_log::init(wasm_log::Config::default());
-    log::debug!("[{WORKER_NAME}] starting...");
+    let worker_span = tracing::info_span!("worker", worker = "prover");
+    {
+        let _guard = worker_span.enter();
+        crate::telemetry::init_telemetry(None);
+        crate::telemetry::install_panic_hook();
+        tracing::debug!("[{WORKER_NAME}] starting...");
+    }
     ProverWorker::registrar().register();
-    spawn_local(async {
-        if let Err(e) = init().await {
-            log::error!("[{WORKER_NAME}] init failed: {e:?}");
+    spawn_local(
+        async move {
+            if let Err(e) = init().await {
+                tracing::error!("[{WORKER_NAME}] init failed: {e:?}");
+            }
         }
-    });
+        .instrument(worker_span),
+    );
 }
 
 async fn init() -> Result<(), JsError> {
@@ -400,7 +408,7 @@ async fn init() -> Result<(), JsError> {
     match load_circuit_artifacts().await {
         Ok(()) => {
             INIT_STATE.with(|s| *s.borrow_mut() = InitState::Ready);
-            log::debug!("[{WORKER_NAME}] initialized");
+            tracing::debug!("[{WORKER_NAME}] initialized");
             Ok(())
         }
         Err(e) => {
@@ -412,26 +420,38 @@ async fn init() -> Result<(), JsError> {
 }
 
 #[oneshot]
-pub(crate) async fn ProverWorker(req: ProverWorkerRequest) -> ProverWorkerResponse {
-    match router(req).await {
-        Ok(r) => r,
-        Err(e) => ProverWorkerResponse::Error(e.to_string()),
+pub(crate) async fn ProverWorker(
+    req: CorrelatedRequest<ProverWorkerRequest>,
+) -> ProverWorkerResponse {
+    let correlation_id = req.correlation_id;
+    let worker_span = tracing::info_span!(
+        "worker_request",
+        worker = "prover",
+        correlation_id = correlation_id.as_str()
+    );
+    async move {
+        match router(req.payload).await {
+            Ok(r) => r,
+            Err(e) => ProverWorkerResponse::Error(e.to_string()),
+        }
     }
+    .instrument(worker_span)
+    .await
 }
 
 // Main router of worker requests
 pub(crate) async fn router(req: ProverWorkerRequest) -> Result<ProverWorkerResponse> {
     let resp = match req {
         ProverWorkerRequest::Ping => {
-            log::trace!("[{WORKER_NAME}] ping");
+            tracing::trace!("[{WORKER_NAME}] ping");
             loop {
                 match INIT_STATE.with(|s| s.borrow().clone()) {
                     InitState::Ready => {
-                        log::trace!("[{WORKER_NAME}] pong");
+                        tracing::trace!("[{WORKER_NAME}] pong");
                         return Ok(ProverWorkerResponse::Pong);
                     }
                     InitState::Failed(msg) => {
-                        log::debug!("[{WORKER_NAME}] ping -> init failed");
+                        tracing::debug!("[{WORKER_NAME}] ping -> init failed");
                         return Ok(ProverWorkerResponse::Error(msg));
                     }
                     InitState::Pending => {}
@@ -441,7 +461,7 @@ pub(crate) async fn router(req: ProverWorkerRequest) -> Result<ProverWorkerRespo
             }
         }
         ProverWorkerRequest::Transact(params) => {
-            log::debug!("[{WORKER_NAME}] transact");
+            tracing::debug!("[{WORKER_NAME}] transact");
             let stem = params.policy_flags.circuit_stem();
             let prepared = TRANSACT_PROVERS.with(|cell| {
                 let mut borrow = cell.borrow_mut();
@@ -453,7 +473,7 @@ pub(crate) async fn router(req: ProverWorkerRequest) -> Result<ProverWorkerRespo
             ProverWorkerResponse::TransactPrepared(prepared)
         }
         ProverWorkerRequest::Disclosure(req) => {
-            log::debug!("[{WORKER_NAME}] disclosure");
+            tracing::debug!("[{WORKER_NAME}] disclosure");
 
             let context = req.context;
             let ext_context_hash = disclosure::derive_ext_context_hash(&context)?;
@@ -569,7 +589,7 @@ pub(crate) async fn router(req: ProverWorkerRequest) -> Result<ProverWorkerRespo
             ProverWorkerResponse::Disclosure(receipt)
         }
         ProverWorkerRequest::VerifyDisclosureProof(receipt, expected_vk_hash) => {
-            log::debug!("[{WORKER_NAME}] verify disclosure proof");
+            tracing::debug!("[{WORKER_NAME}] verify disclosure proof");
 
             disclosure::validate_registered_receipt(&receipt, &expected_vk_hash)?;
 
@@ -621,8 +641,13 @@ impl ProverBridge {
         req: ProverWorkerRequest,
         timeout_ms: u32,
     ) -> anyhow::Result<ProverWorkerResponse> {
+        let correlated_req = CorrelatedRequest {
+            correlation_id: crate::correlation::current_correlation_id()
+                .unwrap_or_else(|| "-".to_string()),
+            payload: req,
+        };
         let mut bridge = self.bridge.fork();
-        let fut = bridge.run(req).fuse();
+        let fut = bridge.run(correlated_req).fuse();
         let timeout = TimeoutFuture::new(timeout_ms).fuse();
 
         futures::pin_mut!(fut, timeout);

--- a/sdk/web/src/workers/storage.rs
+++ b/sdk/web/src/workers/storage.rs
@@ -1,7 +1,7 @@
 use crate::protocol::{
-    AdminASPRequest, AspSecret, DisclaimerStatePayload, DisclosureInputs, DisclosureInputsRequest,
-    PublicEncryptionKeyPair, PublicNoteKeyPair, StorageWorkerRequest, StorageWorkerResponse,
-    UserKeys,
+    AdminASPRequest, AspSecret, CorrelatedRequest, DisclaimerStatePayload, DisclosureInputs,
+    DisclosureInputsRequest, PublicEncryptionKeyPair, PublicNoteKeyPair, StorageWorkerRequest,
+    StorageWorkerResponse, UserKeys,
 };
 use anyhow::{Result, anyhow};
 use futures::{FutureExt, channel::mpsc, stream::StreamExt};
@@ -23,9 +23,11 @@ use stellar_private_payments_sdk::{
     },
     types::{
         ContractConfig, ContractsEventData, EncryptionPublicKey, Field, NotePublicKey,
-        OperationalFeedItem, PortfolioBalance, RecipientLookup, SyncMetadata, UserNoteSummary,
+        OperationalFeedItem, PortfolioBalance, RecipientLookup, Sensitive, SyncMetadata,
+        UserNoteSummary,
     },
 };
+use tracing::Instrument;
 use wasm_bindgen::JsError;
 use wasm_bindgen_futures::spawn_local;
 
@@ -84,15 +86,22 @@ macro_rules! with_storage_mut {
 }
 
 pub fn worker_main() {
-    console_error_panic_hook::set_once();
-    wasm_log::init(wasm_log::Config::default());
-    log::debug!("[{WORKER_NAME}] starting...");
+    let worker_span = tracing::info_span!("worker", worker = WORKER_NAME);
+    {
+        let _guard = worker_span.enter();
+        crate::telemetry::init_telemetry(None);
+        crate::telemetry::install_panic_hook();
+        tracing::debug!("[{WORKER_NAME}] starting...");
+    }
     StorageWorker::registrar().register();
-    spawn_local(async {
-        if let Err(e) = init().await {
-            log::error!("[{WORKER_NAME}] init failed: {e:?}");
+    spawn_local(
+        async move {
+            if let Err(e) = init().await {
+                tracing::error!("[{WORKER_NAME}] init failed: {e:?}");
+            }
         }
-    });
+        .instrument(worker_span),
+    );
 }
 
 async fn init() -> Result<(), JsError> {
@@ -105,12 +114,12 @@ async fn init() -> Result<(), JsError> {
     )
     .await
     {
-        let debug = format!("{e:?}");
+        let error_details = format!("{e:?}");
         let text = e.to_string();
         let combined = if text.is_empty() {
-            debug.clone()
+            error_details.clone()
         } else {
-            format!("{text} {debug}")
+            format!("{text} {error_details}")
         };
 
         let msg = if is_opfs_locked_error(&combined) {
@@ -119,7 +128,7 @@ async fn init() -> Result<(), JsError> {
             "Failed to initialize local database storage.".to_string()
         };
 
-        log::error!("[{WORKER_NAME}] fatal error installing OPFS Sqlite VFS: {debug}");
+        tracing::error!(details = %error_details, "[{WORKER_NAME}] fatal error installing OPFS Sqlite VFS");
         INIT_STATE.with(|s| *s.borrow_mut() = InitState::Failed(msg.clone()));
         return Err(JsError::new(&msg));
     }
@@ -148,34 +157,46 @@ async fn init() -> Result<(), JsError> {
     });
 
     INIT_STATE.with(|s| *s.borrow_mut() = InitState::Ready);
-    log::debug!("[{WORKER_NAME}] initialized");
+    tracing::debug!("[{WORKER_NAME}] initialized");
 
     Ok(())
 }
 
 #[oneshot]
-pub(crate) async fn StorageWorker(req: StorageWorkerRequest) -> StorageWorkerResponse {
-    match router(req).await {
-        Ok(r) => r,
-        Err(e) => StorageWorkerResponse::Error(e.to_string()),
+pub(crate) async fn StorageWorker(
+    req: CorrelatedRequest<StorageWorkerRequest>,
+) -> StorageWorkerResponse {
+    let correlation_id = req.correlation_id;
+    let worker_span = tracing::info_span!(
+        "worker_request",
+        worker = WORKER_NAME,
+        correlation_id = correlation_id.as_str()
+    );
+    async move {
+        match router(req.payload).await {
+            Ok(r) => r,
+            Err(e) => StorageWorkerResponse::Error(e.to_string()),
+        }
     }
+    .instrument(worker_span)
+    .await
 }
 
 // Main router of worker requests
 pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerResponse> {
     let resp = match req {
         StorageWorkerRequest::Ping => {
-            log::trace!("[{WORKER_NAME}] ping");
+            tracing::trace!("[{WORKER_NAME}] ping");
             loop {
                 let state = INIT_STATE.with(|s| s.borrow().clone());
                 match state {
                     InitState::Ready => {
-                        log::trace!("[{WORKER_NAME}] pong");
+                        tracing::trace!("[{WORKER_NAME}] pong");
                         kick_processor();
                         return Ok(StorageWorkerResponse::Pong);
                     }
                     InitState::Failed(msg) => {
-                        log::debug!("[{WORKER_NAME}] ping -> init failed");
+                        tracing::debug!("[{WORKER_NAME}] ping -> init failed");
                         return Ok(StorageWorkerResponse::Error(msg));
                     }
                     InitState::Pending => {}
@@ -185,19 +206,19 @@ pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerRes
             }
         }
         StorageWorkerRequest::SyncState => {
-            log::trace!("[{WORKER_NAME}] get current sync");
+            tracing::trace!("[{WORKER_NAME}] get current sync");
             let state = with_storage!(s => s.get_sync_metadata()?)?;
             let resp = StorageWorkerResponse::SyncState(state);
-            log::trace!("[{WORKER_NAME}] sending current sync");
+            tracing::trace!("[{WORKER_NAME}] sending current sync");
             resp
         }
         StorageWorkerRequest::SaveEvents(events_data) => {
-            log::trace!(
+            tracing::trace!(
                 "[{WORKER_NAME}] saving {} raw contract events",
                 events_data.events.len()
             );
             with_storage_mut!(s => s.save_events_batch(&events_data)?)?;
-            log::trace!(
+            tracing::trace!(
                 "[{WORKER_NAME}] sending {} raw contract events to process",
                 events_data.events.len()
             );
@@ -208,7 +229,7 @@ pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerRes
             metadata,
             fully_indexed,
         } => {
-            log::trace!(
+            tracing::trace!(
                 "[{WORKER_NAME}] saving bulk sync progress for {} contracts (fully_indexed={fully_indexed})",
                 metadata.len()
             );
@@ -216,24 +237,31 @@ pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerRes
             StorageWorkerResponse::Saved
         }
         StorageWorkerRequest::ClearIndexingCursors => {
-            log::trace!("[{WORKER_NAME}] clearing indexing cursors for RPC handoff");
+            tracing::trace!("[{WORKER_NAME}] clearing indexing cursors for RPC handoff");
             with_storage_mut!(s => s.clear_indexing_cursors()?)?;
             StorageWorkerResponse::Saved
         }
         StorageWorkerRequest::DeriveSaveUserKeys(address, signature, network_context) => {
-            log::trace!("[{WORKER_NAME}] deriving and saving user keys for the account {address}");
+            tracing::trace!(
+                "[{WORKER_NAME}] deriving and saving user keys for the account {}",
+                Sensitive(&address)
+            );
             let (note_keypair, encryption_keypair) =
                 derive_encryption_and_note_keypairs(signature.clone())?;
             let membership_blinding = derive_membership_blinding(&signature, &network_context)?;
             with_storage_mut!(s => s.save_encryption_and_note_keypairs(&address, &note_keypair, &encryption_keypair, &membership_blinding)?)?;
-            log::trace!(
-                "[{WORKER_NAME}] saved notes, encryption keys, and ASP secret for the account {address}"
+            tracing::trace!(
+                "[{WORKER_NAME}] saved notes, encryption keys, and ASP secret for the account {}",
+                Sensitive(&address)
             );
             kick_processor();
             StorageWorkerResponse::Saved
         }
         StorageWorkerRequest::DisclaimerState(address) => {
-            log::trace!("[{WORKER_NAME}] disclaimer state for account {address}");
+            tracing::trace!(
+                "[{WORKER_NAME}] disclaimer state for account {}",
+                Sensitive(&address)
+            );
             let state = with_storage_mut!(s => s.get_disclaimer_state(&address)?)?;
             StorageWorkerResponse::DisclaimerState(DisclaimerStatePayload {
                 disclaimer_text_md: state.disclaimer_text_md,
@@ -242,32 +270,40 @@ pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerRes
             })
         }
         StorageWorkerRequest::AcceptDisclaimer(address, disclaimer_hash_hex) => {
-            log::trace!("[{WORKER_NAME}] accept disclaimer for account {address}");
+            tracing::trace!(
+                "[{WORKER_NAME}] accept disclaimer for account {}",
+                Sensitive(&address)
+            );
             with_storage_mut!(s => s.accept_current_disclaimer(&address, &disclaimer_hash_hex)?)?;
             StorageWorkerResponse::Saved
         }
         StorageWorkerRequest::GetSetting(key) => {
-            log::trace!("[{WORKER_NAME}] fetch setting {key}");
+            tracing::trace!("[{WORKER_NAME}] fetch setting {key}");
             let value_json = with_storage!(s => s.get_setting_json::<serde_json::Value>(&key)?)?
                 .map(|value| value.to_string());
             StorageWorkerResponse::Setting(value_json)
         }
         StorageWorkerRequest::SetSetting { key, value_json } => {
-            log::trace!("[{WORKER_NAME}] set setting {key}");
+            tracing::trace!("[{WORKER_NAME}] set setting {key}");
             let value: serde_json::Value = serde_json::from_str(&value_json)?;
             with_storage_mut!(s => s.set_setting_json(&key, &value)?)?;
             StorageWorkerResponse::Saved
         }
         StorageWorkerRequest::UserKeys(address) => {
-            log::trace!("[{WORKER_NAME}] fetch user keys for the account {address}");
+            tracing::trace!(
+                "[{WORKER_NAME}] fetch user keys for the account {}",
+                Sensitive(&address)
+            );
             let opt = with_storage!(s => s.get_user_keys(&address)?)?;
             if opt.is_some() {
-                log::trace!(
-                    "[{WORKER_NAME}] fetched notes and encryption keys for the account {address}"
+                tracing::trace!(
+                    "[{WORKER_NAME}] fetched notes and encryption keys for the account {}",
+                    Sensitive(&address)
                 );
             } else {
-                log::trace!(
-                    "[{WORKER_NAME}] not found notes and encryption keys for the account {address}"
+                tracing::trace!(
+                    "[{WORKER_NAME}] not found notes and encryption keys for the account {}",
+                    Sensitive(&address)
                 );
             }
             StorageWorkerResponse::UserKeys(opt.map(|keys| UserKeys {
@@ -280,23 +316,33 @@ pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerRes
             }))
         }
         StorageWorkerRequest::AspSecret(address) => {
-            log::trace!("[{WORKER_NAME}] fetch ASP secret for the account {address}");
+            tracing::trace!(
+                "[{WORKER_NAME}] fetch ASP secret for the account {}",
+                Sensitive(&address)
+            );
             let opt = with_storage!(s => s.get_user_keys(&address)?)?;
             StorageWorkerResponse::AspSecret(opt.map(|keys| AspSecret {
                 membership_blinding: keys.membership_blinding,
             }))
         }
         StorageWorkerRequest::UserNotes(address, limit) => {
-            log::trace!("[{WORKER_NAME}] list user notes for the account {address}");
+            tracing::trace!(
+                "[{WORKER_NAME}] list user notes for the account {}",
+                Sensitive(&address)
+            );
             let list = with_storage!(s => s.list_user_notes(&address, limit)?)?;
-            log::trace!(
-                "[{WORKER_NAME}] fetched {} notes for the account {address}",
-                list.len()
+            tracing::trace!(
+                "[{WORKER_NAME}] fetched {} notes for the account {}",
+                list.len(),
+                Sensitive(&address)
             );
             StorageWorkerResponse::UserNotes(list)
         }
         StorageWorkerRequest::PortfolioBalances(address) => {
-            log::trace!("[{WORKER_NAME}] list portfolio balances for the account {address}");
+            tracing::trace!(
+                "[{WORKER_NAME}] list portfolio balances for the account {}",
+                Sensitive(&address)
+            );
             // Load the contract config from the embedded deployment JSON rather than
             // receiving it over the worker bridge: ContractConfig contains the
             // internally-tagged `AssetDescriptor` enum, which the bincode worker codec
@@ -337,15 +383,17 @@ pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerRes
             user_address,
             pool_contract_id,
         } => {
-            log::trace!(
-                "[{WORKER_NAME}] list all unspent notes for the account {user_address} in pool {pool_contract_id}"
+            tracing::trace!(
+                "[{WORKER_NAME}] list all unspent notes for the account {} in pool {pool_contract_id}",
+                Sensitive(&user_address)
             );
             let list = with_storage!(s =>
                 s.list_unspent_user_notes(&pool_contract_id, &user_address)?
             )?;
-            log::trace!(
-                "[{WORKER_NAME}] fetched {} unspent notes for the account {user_address}",
-                list.len()
+            tracing::trace!(
+                "[{WORKER_NAME}] fetched {} unspent notes for the account {}",
+                list.len(),
+                Sensitive(&user_address)
             );
             StorageWorkerResponse::UserNotes(list)
         }
@@ -353,15 +401,17 @@ pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerRes
             user_address,
             pool_contract_id,
         } => {
-            log::trace!(
-                "[{WORKER_NAME}] list all notes for the account {user_address} in pool {pool_contract_id}"
+            tracing::trace!(
+                "[{WORKER_NAME}] list all notes for the account {} in pool {pool_contract_id}",
+                Sensitive(&user_address)
             );
             let list = with_storage!(s =>
                 s.list_pool_user_notes(&pool_contract_id, &user_address)?
             )?;
-            log::trace!(
-                "[{WORKER_NAME}] fetched {} notes for the account {user_address}",
-                list.len()
+            tracing::trace!(
+                "[{WORKER_NAME}] fetched {} notes for the account {}",
+                list.len(),
+                Sensitive(&user_address)
             );
             StorageWorkerResponse::UserNotes(list)
         }
@@ -369,7 +419,10 @@ pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerRes
             address,
             public_key_registry_contract_id,
         } => {
-            log::trace!("[{WORKER_NAME}] lookup public keys for {address}");
+            tracing::trace!(
+                "[{WORKER_NAME}] lookup public keys for {}",
+                Sensitive(&address)
+            );
             let lookup = with_storage!(s =>
                 s.recipient_lookup(&address, &public_key_registry_contract_id)?
             )?;
@@ -380,7 +433,7 @@ pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerRes
             asp_membership_contract_id,
             public_key_registry_contract_id,
         } => {
-            log::trace!("[{WORKER_NAME}] fetch operational feed");
+            tracing::trace!("[{WORKER_NAME}] fetch operational feed");
             let list = with_storage!(s =>
                 s.get_operational_feed(
                     limit,
@@ -391,7 +444,7 @@ pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerRes
             StorageWorkerResponse::OperationalFeed(list)
         }
         StorageWorkerRequest::DisclosureInputs(req) => {
-            log::trace!(
+            tracing::trace!(
                 "[{WORKER_NAME}] build selective disclosure inputs for {}",
                 req.user_address
             );
@@ -409,13 +462,13 @@ pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerRes
             membership_blinding,
             pubkey,
         }) => {
-            log::trace!("[{WORKER_NAME}] derive user leaf from the pubkey for the admin");
+            tracing::trace!("[{WORKER_NAME}] derive user leaf from the pubkey for the admin");
             let user_leaf = asp_membership_leaf(&pubkey, &membership_blinding)?;
-            log::trace!("[{WORKER_NAME}] derived user leaf from the pubkey for the admin");
+            tracing::trace!("[{WORKER_NAME}] derived user leaf from the pubkey for the admin");
             StorageWorkerResponse::DeriveASPleaf(user_leaf)
         }
         StorageWorkerRequest::Transact(req) => {
-            log::trace!("[{WORKER_NAME}] transact");
+            tracing::trace!("[{WORKER_NAME}] transact");
             with_storage_mut!(storage => match build_transact_params(storage, &req)? {
                 BuildTransactParams::Ready(params) => StorageWorkerResponse::TransactParams(*params),
                 BuildTransactParams::MembershipSync(status) => {
@@ -438,7 +491,7 @@ fn kick_processor() {
 async fn run_processor_loop(mut rx: mpsc::Receiver<()>) {
     while let Some(()) = rx.next().await {
         if let Err(e) = process_until_empty().await {
-            log::error!("[{WORKER_NAME}] events processing failed: {e:#}");
+            tracing::error!("[{WORKER_NAME}] events processing failed: {e:#}");
         }
     }
 }
@@ -477,8 +530,13 @@ impl StorageBridge {
         req: StorageWorkerRequest,
         timeout_ms: u32,
     ) -> anyhow::Result<StorageWorkerResponse> {
+        let correlated_req = CorrelatedRequest {
+            correlation_id: crate::correlation::current_correlation_id()
+                .unwrap_or_else(|| "-".to_string()),
+            payload: req,
+        };
         let mut bridge = self.bridge.fork();
-        let fut = bridge.run(req).fuse();
+        let fut = bridge.run(correlated_req).fuse();
         let timeout = TimeoutFuture::new(timeout_ms).fuse();
 
         futures::pin_mut!(fut, timeout);

--- a/sdk/witness/Cargo.toml
+++ b/sdk/witness/Cargo.toml
@@ -17,6 +17,8 @@ ark-circom = { workspace = true }
 num-bigint = { workspace = true }
 # JSON parsing
 serde_json = { workspace = true, default-features = false, features = ["alloc", "std"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # external

--- a/sdk/witness/Cargo.toml
+++ b/sdk/witness/Cargo.toml
@@ -8,6 +8,9 @@ publish.workspace = true
 description = "Browser WASM module for Circom witness generation using ark-circom"
 
 [dependencies]
+# workspace
+types = { workspace = true }
+
 # external
 anyhow = { workspace = true }
 # Arkworks
@@ -18,7 +21,7 @@ num-bigint = { workspace = true }
 # JSON parsing
 serde_json = { workspace = true, default-features = false, features = ["alloc", "std"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+web-time = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # external

--- a/sdk/witness/src/lib.rs
+++ b/sdk/witness/src/lib.rs
@@ -9,6 +9,7 @@ use ark_circom::{WitnessCalculator as ArkWitnessCalculator, circom::R1CSFile};
 use num_bigint::{BigInt, Sign};
 // These are part of the reduced STD that is browser compatible
 use std::{collections::HashMap, io::Cursor, string::String, vec::Vec};
+use types::correlation_id_or_new;
 use wasmer::{Module, Store};
 
 /// BN254 scalar field modulus
@@ -39,7 +40,10 @@ impl WitnessCalculator {
     /// # Arguments
     /// * `circuit_wasm` - The compiled circuit WASM bytes
     /// * `r1cs_bytes` - The R1CS constraint system bytes
+    #[tracing::instrument(name = "witness_calculator_new", skip_all, fields(correlation_id = %correlation_id_or_new(), wasm_len = circuit_wasm.len(), r1cs_len = r1cs_bytes.len()))]
     pub fn new(circuit_wasm: &[u8], r1cs_bytes: &[u8]) -> Result<WitnessCalculator> {
+        tracing::debug!("creating witness calculator");
+
         // Parse R1CS from bytes
         let cursor = Cursor::new(r1cs_bytes);
         let r1cs_file: R1CSFile<Fr> = R1CSFile::new(cursor).context("Failed to parse R1CS")?;
@@ -49,11 +53,30 @@ impl WitnessCalculator {
 
         // Create wasmer store and load circuit module from bytes
         let mut store = Store::default();
-        let module = Module::new(&store, circuit_wasm).context("Failed to load circuit WASM")?;
 
-        // Create witness calculator from module
-        let calculator = ArkWitnessCalculator::from_module(&mut store, module)
-            .map_err(|e| anyhow::anyhow!("Failed to init witness calc: {e}"))?;
+        // Compile and instantiate the circuit WASM module (the expensive part)
+        let start = web_time::Instant::now();
+        tracing::debug!("compiling circuit WASM module");
+        let calculator = (|| -> Result<ArkWitnessCalculator> {
+            let module =
+                Module::new(&store, circuit_wasm).context("Failed to load circuit WASM")?;
+            ArkWitnessCalculator::from_module(&mut store, module)
+                .map_err(|e| anyhow::anyhow!("Failed to init witness calc: {e}"))
+        })();
+        let calculator = match calculator {
+            Ok(calculator) => calculator,
+            Err(e) => {
+                tracing::debug!(
+                    elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+                    "circuit WASM compile/instantiate failed"
+                );
+                return Err(e);
+            }
+        };
+        tracing::debug!(
+            elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "circuit WASM compiled and instantiated"
+        );
 
         Ok(WitnessCalculator {
             store,
@@ -71,13 +94,17 @@ impl WitnessCalculator {
     ///
     /// # Returns
     /// * Witness as Little-Endian bytes (32 bytes per field element)
+    #[tracing::instrument(skip_all, fields(correlation_id = %correlation_id_or_new(), inputs_json_len = inputs_json.len(), input_keys = tracing::field::Empty))]
     pub fn compute_witness(&mut self, inputs_json: &str) -> Result<Vec<u8>> {
         use serde_json::Value;
+
+        tracing::debug!("computing witness");
 
         // Parse JSON inputs
         let inputs: Value = serde_json::from_str(inputs_json).context("Invalid JSON")?;
 
         let inputs_map = inputs.as_object().context("Inputs must be a JSON object")?;
+        tracing::Span::current().record("input_keys", inputs_map.len());
 
         // Convert to HashMap<String, Vec<BigInt>> by flattening nested structures
         let mut inputs_hashmap: HashMap<String, Vec<BigInt>> = HashMap::new();
@@ -87,10 +114,25 @@ impl WitnessCalculator {
         }
 
         // Calculate witness
+        let start = web_time::Instant::now();
         let witness = self
             .calculator
             .calculate_witness(&mut self.store, inputs_hashmap, false)
-            .map_err(|e| anyhow::anyhow!("Witness calculation failed: {e}"))?;
+            .map_err(|e| anyhow::anyhow!("Witness calculation failed: {e}"));
+        let witness = match witness {
+            Ok(witness) => witness,
+            Err(e) => {
+                tracing::debug!(
+                    elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+                    "witness calculation failed"
+                );
+                return Err(e);
+            }
+        };
+        tracing::debug!(
+            elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "witness calculation completed"
+        );
 
         // Convert to Little-Endian bytes
         Ok(witness_to_bytes(&witness))

--- a/tools/ceremony-cli/Cargo.toml
+++ b/tools/ceremony-cli/Cargo.toml
@@ -24,7 +24,7 @@ clap.workspace = true
 getrandom.workspace = true
 glob = "0.3.3"
 shlex = "1.3.0"
-zeroize = "1.8.2"
+zeroize.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
- Add docs/src/privacy-tradeoffs.md covering:
  - protocol-inherent transaction correlation via ExtData and synchronous events
  - opt-in PublicKeyRegistry address-to-key binding trade-off
  - privacy classification table for all six contract events
- Link the new doc from docs/src/SUMMARY.md
- Update onboarding-wizard UI copy to disclose that key registration publishes an on-chain address-to-key binding event
- Add exact-shape regression tests for contract events:
  - pool: NewCommitmentEvent, NewNullifierEvent
  - asp-membership: LeafAddedEvent
  - asp-non-membership: LeafInsertedEvent, LeafDeletedEvent
  - public-key-registry: PublicKeyEvent