### PR TITLE
Fix witness panic on out-of-range inputs, add unit tests (#340)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -712,6 +721,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -2123,7 +2138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2385,6 +2400,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -2392,7 +2419,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
 ]
@@ -2977,7 +3004,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3142,7 +3169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
 dependencies = [
  "ascii-canvas",
- "bit-set",
+ "bit-set 0.5.3",
  "diff",
  "ena",
  "is-terminal",
@@ -3489,7 +3516,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3963,6 +3990,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.13.1",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax 0.8.11",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prover"
 version = "0.1.0"
 dependencies = [
@@ -4011,6 +4057,12 @@ version = "0.1.0"
 dependencies = [
  "soroban-sdk",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -4066,7 +4118,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4077,6 +4129,12 @@ checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -4100,8 +4158,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4126,12 +4194,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4147,6 +4234,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4447,7 +4543,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4504,7 +4600,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4530,6 +4626,18 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ruzstd"
@@ -4995,7 +5103,7 @@ dependencies = [
  "num-traits",
  "p256",
  "rand 0.8.7",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2 0.10.9",
  "sha3 0.10.9",
@@ -5483,7 +5591,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5898,6 +6006,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6007,6 +6121,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6030,6 +6153,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -6448,7 +6580,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6640,6 +6772,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "witness"
 version = "0.1.0"
 dependencies = [
@@ -6647,6 +6785,7 @@ dependencies = [
  "ark-bn254 0.6.0",
  "ark-circom",
  "num-bigint",
+ "proptest",
  "serde_json",
  "wasmer",
 ]

--- a/sdk/witness/Cargo.toml
+++ b/sdk/witness/Cargo.toml
@@ -29,5 +29,9 @@ wasmer = { workspace = true, features = ["cranelift"] }
 ark-circom = { workspace = true }
 wasmer = { workspace = true, features = ["js", "js-default"] }
 
+[dev-dependencies]
+# Property-based testing of field-element conversion
+proptest = "1"
+
 [lints]
 workspace = true

--- a/sdk/witness/src/lib.rs
+++ b/sdk/witness/src/lib.rs
@@ -111,7 +111,11 @@ impl WitnessCalculator {
 /// Negative numbers are converted to p - |value| where p is the field modulus.
 /// Relevant for ZK proof computation. For on-chain token transfer
 /// we use a I256 passed to the contract.
-fn to_field_element(bi: BigInt) -> BigInt {
+///
+/// # Errors
+/// Returns an error if the value (or its absolute value, for negatives) is not
+/// less than the BN254 scalar field modulus.
+fn to_field_element(bi: BigInt) -> Result<BigInt> {
     let modulus =
         BigInt::parse_bytes(BN254_FIELD_MODULUS.as_bytes(), 10).expect("Invalid field modulus");
 
@@ -121,20 +125,20 @@ fn to_field_element(bi: BigInt) -> BigInt {
             .expect("Overflow in getting the abs value"); // Get absolute value
 
         // Check absolute value must be less than the field modulus
-        assert!(
+        anyhow::ensure!(
             abs_value < modulus,
             "Negative value {} exceeds field modulus",
             bi
         );
 
         // For negative n: field_element = p - |n|
-        modulus
+        Ok(modulus
             .checked_sub(&abs_value)
-            .expect("Overflow in field element computation")
+            .expect("Overflow in field element computation"))
     } else {
         // Validate: positive value must be less than the field modulus
-        assert!(bi < modulus, "Value {} exceeds field modulus", bi);
-        bi
+        anyhow::ensure!(bi < modulus, "Value {} exceeds field modulus", bi);
+        Ok(bi)
     }
 }
 
@@ -188,7 +192,7 @@ fn flatten_input(
                 inputs
                     .entry(current_key)
                     .or_default()
-                    .push(to_field_element(bi));
+                    .push(to_field_element(bi)?);
             }
             Value::String(s) => {
                 let bi = if let Some(hex) = s.strip_prefix("0x") {
@@ -201,7 +205,7 @@ fn flatten_input(
                 inputs
                     .entry(current_key)
                     .or_default()
-                    .push(to_field_element(bi));
+                    .push(to_field_element(bi)?);
             }
             Value::Array(arr) => {
                 // Pure arrays get flattened to a single key as in
@@ -267,7 +271,7 @@ fn flatten_pure_array(
                     inputs
                         .entry(key.to_string())
                         .or_default()
-                        .push(to_field_element(bi));
+                        .push(to_field_element(bi)?);
                 }
                 Value::String(s) => {
                     let bi = if let Some(hex) = s.strip_prefix("0x") {
@@ -279,7 +283,7 @@ fn flatten_pure_array(
                     inputs
                         .entry(key.to_string())
                         .or_default()
-                        .push(to_field_element(bi));
+                        .push(to_field_element(bi)?);
                 }
                 Value::Array(arr) => {
                     if !arr.is_empty() {
@@ -351,4 +355,285 @@ fn witness_to_bytes(witness: &[BigInt]) -> Vec<u8> {
     }
 
     bytes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Parse the BN254 scalar field modulus the same way production code does.
+    fn modulus() -> BigInt {
+        BigInt::parse_bytes(BN254_FIELD_MODULUS.as_bytes(), 10).expect("Invalid field modulus")
+    }
+
+    /// Flatten a single JSON value under the key "root".
+    fn flatten(value: serde_json::Value) -> Result<HashMap<String, Vec<BigInt>>> {
+        let mut inputs = HashMap::new();
+        flatten_input("root", &value, &mut inputs)?;
+        Ok(inputs)
+    }
+
+    // --- to_field_element: boundary values ---
+
+    #[test]
+    fn to_field_element_accepts_modulus_minus_one() {
+        let p = modulus();
+        let result = to_field_element(p.clone() - 1).expect("p - 1 must be accepted");
+        assert_eq!(result, p - 1);
+    }
+
+    #[test]
+    fn to_field_element_rejects_exact_modulus() {
+        let err = to_field_element(modulus()).expect_err("p must be rejected");
+        assert!(err.to_string().contains("exceeds field modulus"));
+    }
+
+    #[test]
+    fn to_field_element_rejects_modulus_plus_one() {
+        let err = to_field_element(modulus() + 1).expect_err("p + 1 must be rejected");
+        assert!(err.to_string().contains("exceeds field modulus"));
+    }
+
+    // --- to_field_element: negative encoding ---
+
+    #[test]
+    fn to_field_element_maps_minus_one_to_modulus_minus_one() {
+        let p = modulus();
+        let result = to_field_element(BigInt::from(-1)).expect("-1 must be accepted");
+        assert_eq!(result, p - 1);
+    }
+
+    #[test]
+    fn to_field_element_maps_negated_modulus_minus_one_to_one() {
+        let p = modulus();
+        let result = to_field_element(-(p - BigInt::from(1))).expect("-(p - 1) must be accepted");
+        assert_eq!(result, BigInt::from(1));
+    }
+
+    #[test]
+    fn to_field_element_rejects_negative_modulus() {
+        let err = to_field_element(-modulus()).expect_err("-p must be rejected");
+        assert!(err.to_string().contains("Negative value"));
+        assert!(err.to_string().contains("exceeds field modulus"));
+    }
+
+    #[test]
+    fn to_field_element_accepts_zero() {
+        let result = to_field_element(BigInt::from(0)).expect("0 must be accepted");
+        assert_eq!(result, BigInt::from(0));
+    }
+
+    // --- flatten_input: structure flattening ---
+
+    #[test]
+    fn flatten_input_flattens_nested_pure_arrays_row_major() {
+        let inputs = flatten(json!([[1, 2], [3, 4]])).expect("flattening must succeed");
+        assert_eq!(
+            inputs["root"],
+            vec![
+                BigInt::from(1),
+                BigInt::from(2),
+                BigInt::from(3),
+                BigInt::from(4)
+            ]
+        );
+    }
+
+    #[test]
+    fn flatten_input_uses_indexed_keys_for_arrays_of_objects() {
+        let inputs = flatten(json!([{"x": 1}, {"x": 2}])).expect("flattening must succeed");
+        assert_eq!(inputs["root[0].x"], vec![BigInt::from(1)]);
+        assert_eq!(inputs["root[1].x"], vec![BigInt::from(2)]);
+    }
+
+    #[test]
+    fn flatten_input_uses_dotted_keys_for_objects() {
+        let inputs = flatten(json!({"a": {"b": 5}})).expect("flattening must succeed");
+        assert_eq!(inputs["root.a.b"], vec![BigInt::from(5)]);
+    }
+
+    // --- flatten_input: scalar coercion and string parsing ---
+
+    #[test]
+    fn flatten_input_parses_decimal_strings() {
+        let inputs = flatten(json!("123")).expect("decimal string must parse");
+        assert_eq!(inputs["root"], vec![BigInt::from(123)]);
+    }
+
+    #[test]
+    fn flatten_input_parses_hex_strings() {
+        let inputs = flatten(json!("0x10")).expect("hex string must parse");
+        assert_eq!(inputs["root"], vec![BigInt::from(16)]);
+    }
+
+    #[test]
+    fn flatten_input_rejects_malformed_strings() {
+        flatten(json!("not_a_number")).expect_err("malformed string must error");
+    }
+
+    #[test]
+    fn flatten_input_coerces_bools_and_null() {
+        let inputs = flatten(json!([true, false, null])).expect("coercion must succeed");
+        assert_eq!(
+            inputs["root"],
+            vec![BigInt::from(1), BigInt::from(0), BigInt::from(0)]
+        );
+    }
+
+    #[test]
+    fn flatten_input_accepts_large_u64_numbers() {
+        let inputs = flatten(json!(u64::MAX)).expect("u64::MAX fits in the field");
+        assert_eq!(inputs["root"], vec![BigInt::from(u64::MAX)]);
+    }
+
+    // --- flatten_input / flatten_pure_array: out-of-range returns Err, never
+    // panics ---
+
+    #[test]
+    fn flatten_input_out_of_range_string_returns_err() {
+        let err =
+            flatten(json!(modulus().to_string())).expect_err("p as a string must be rejected");
+        assert!(err.to_string().contains("exceeds field modulus"));
+    }
+
+    #[test]
+    fn flatten_input_out_of_range_negative_string_returns_err() {
+        let err =
+            flatten(json!(format!("-{}", modulus()))).expect_err("-p as a string must be rejected");
+        assert!(err.to_string().contains("exceeds field modulus"));
+    }
+
+    #[test]
+    fn flatten_pure_array_out_of_range_returns_err() {
+        let err = flatten(json!([1, modulus().to_string()]))
+            .expect_err("p inside a pure array must be rejected");
+        assert!(err.to_string().contains("exceeds field modulus"));
+    }
+
+    // --- is_pure_array ---
+
+    #[test]
+    fn is_pure_array_accepts_nested_primitive_arrays() {
+        assert!(is_pure_array(&json!([1, "two", [true, null]])));
+    }
+
+    #[test]
+    fn is_pure_array_rejects_arrays_containing_objects() {
+        assert!(!is_pure_array(&json!([1, {"a": 2}])));
+        assert!(!is_pure_array(&json!([1, [{"a": 2}]])));
+    }
+
+    // --- witness_to_bytes: little-endian 32-byte encoding ---
+
+    #[test]
+    fn witness_to_bytes_encodes_zero_as_all_zeroes() {
+        let bytes = witness_to_bytes(&[BigInt::from(0)]);
+        assert_eq!(bytes, vec![0u8; 32]);
+    }
+
+    #[test]
+    fn witness_to_bytes_encodes_one_in_least_significant_byte() {
+        // Little-endian: the value 1 lands in the first byte, the rest are zero.
+        let bytes = witness_to_bytes(&[BigInt::from(1)]);
+        assert_eq!(bytes.len(), 32);
+        assert_eq!(bytes[0], 1);
+        assert!(bytes[1..].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn witness_to_bytes_encodes_256_across_two_bytes_little_endian() {
+        // 256 == 0x0100; little-endian => byte[0] = 0x00, byte[1] = 0x01.
+        let bytes = witness_to_bytes(&[BigInt::from(256)]);
+        assert_eq!(bytes[0], 0);
+        assert_eq!(bytes[1], 1);
+        assert!(bytes[2..].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn witness_to_bytes_emits_one_32_byte_chunk_per_element() {
+        let witness = vec![BigInt::from(1), BigInt::from(2), BigInt::from(3)];
+        let bytes = witness_to_bytes(&witness);
+        assert_eq!(bytes.len(), 3 * 32);
+        // Each element occupies its own little-endian 32-byte chunk, in order.
+        assert_eq!(bytes[0], 1);
+        assert_eq!(bytes[32], 2);
+        assert_eq!(bytes[64], 3);
+    }
+
+    #[test]
+    fn witness_to_bytes_roundtrips_full_width_modulus_minus_one() {
+        // p - 1 is the largest valid field element and fills all 32 bytes.
+        let value = modulus() - BigInt::from(1);
+        let bytes = witness_to_bytes(std::slice::from_ref(&value));
+        assert_eq!(bytes.len(), 32);
+        // Reinterpreting the little-endian bytes must recover the original value.
+        let recovered = BigInt::from_bytes_le(Sign::Plus, &bytes);
+        assert_eq!(recovered, value);
+    }
+
+    #[test]
+    fn witness_to_bytes_of_empty_witness_is_empty() {
+        let empty: [BigInt; 0] = [];
+        assert!(witness_to_bytes(&empty).is_empty());
+    }
+
+    // --- proptest: to_field_element properties (audit task T15) ---
+
+    mod props {
+        // BigInt arithmetic in property strategies/assertions cannot overflow.
+        #![allow(clippy::arithmetic_side_effects)]
+
+        use super::*;
+        use proptest::prelude::*;
+
+        /// Arbitrary BigInt in [0, p).
+        fn arb_below_modulus() -> impl Strategy<Value = BigInt> {
+            prop::collection::vec(any::<u64>(), 1..=4).prop_map(|limbs| {
+                let mut v = BigInt::from(0);
+                for limb in limbs {
+                    v = (v << 64) + BigInt::from(limb);
+                }
+                v % modulus()
+            })
+        }
+
+        /// Arbitrary BigInt in [1, p).
+        fn arb_below_modulus_nonzero() -> impl Strategy<Value = BigInt> {
+            arb_below_modulus().prop_filter_map("zero", |v| {
+                if v == BigInt::from(0) { None } else { Some(v) }
+            })
+        }
+
+        proptest! {
+            /// Any v in [0, p) is already a field element: conversion is identity.
+            #[test]
+            fn prop_in_range_values_convert_to_themselves(v in arb_below_modulus()) {
+                let result = to_field_element(v.clone()).expect("in-range value must convert");
+                prop_assert_eq!(result, v);
+            }
+
+            /// Any negative v with |v| < p maps to p - |v|, landing in [1, p - 1].
+            #[test]
+            fn prop_negative_in_range_maps_to_modulus_minus_abs(v in arb_below_modulus_nonzero()) {
+                let p = modulus();
+                let result = to_field_element(-v.clone()).expect("in-range negative must convert");
+                prop_assert_eq!(result.clone(), &p - &v);
+                prop_assert!(result >= BigInt::from(1));
+                prop_assert!(result < p);
+            }
+
+            /// Any |v| >= p errors instead of panicking, for both signs.
+            #[test]
+            fn prop_out_of_range_errors_instead_of_panicking(
+                v in arb_below_modulus(),
+                k in 1u32..=4,
+            ) {
+                let p = modulus();
+                let over = &v + &p * BigInt::from(k);
+                prop_assert!(to_field_element(over.clone()).is_err());
+                prop_assert!(to_field_element(-over).is_err());
+            }
+        }
+    }
 }


### PR DESCRIPTION
to_field_element validated user-supplied JSON values against the BN254 scalar field modulus with bare assert!s, so an out-of-range number turned into a WASM trap that killed the browser prover worker instead of surfacing an error. It now returns Result and both flatten functions propagate with ?, so malformed input reaches the frontend as a normal error.

Add the crate's first test coverage: 20 unit tests for the pure functions (p-1/p/p+1 boundaries, negative encoding, row-major flattening, indexed and dotted keys, hex/decimal parsing, bool/null coercion, error paths) plus 3 proptest properties for to_field_element (identity in range, p-|v| encoding, Err instead of panic out of range).

The witness_to_bytes asserts are intentionally untouched: they guard internal invariants on computed output, not user input.

