### PR TITLE
Fix app/admin allowlist derive user leaf

### DIFF
--- a/app/ARCHITECTURE.md
+++ b/app/ARCHITECTURE.md
@@ -41,7 +41,7 @@ The WASM layer exposes four JS handles with different scope:
 | **`Account`** | Wallet session (address + signer) | `portfolio`, `userPublicKeys`, `aspSecret`, `userNotes`, `isRegistered`, `deriveAspUserLeaf`, `registerPublicKeys`, `pool()` |
 | **`PrivatePool`** | One pool contract + user session | `deposit`, `transfer`, `withdraw`, `transact`, `disclose`, `balance`, `notes` |
 
-`Client` is the long-lived deployment shell; `Account` is created when the wallet binds; `PrivatePool` is created per active pool when the user transacts.
+`Client` is the long-lived deployment shell; `Account` is created when the wallet binds; `PrivatePool` is created per active pool when the user transacts. Free helpers such as `deriveAspUserLeaf(notePublicKey, membershipBlinding)` need neither wallet nor storage.
 
 **JS UI (main thread)**
 

--- a/app/js/admin.js
+++ b/app/js/admin.js
@@ -1,5 +1,5 @@
 import { contract } from '@stellar/stellar-sdk';
-import { client, initializeRuntime, bootnodeRequired, ensureStorage } from './wasm-facade.js';
+import { client, initializeRuntime, bootnodeRequired, ensureStorage, deriveAspUserLeaf } from './wasm-facade.js';
 import { connectWallet, getWalletNetwork, signWalletAuthEntry, signWalletTransaction } from './wallet.js';
 import { isDbLockedError, showDbLockedModal } from './db-locked.js';
 
@@ -373,11 +373,15 @@ async function insertMembershipLeaf() {
     const contractId = membershipContractInput.value.trim();
     if (!contractId) throw new Error('Membership contract ID is required');
 
-    const notePublicKey = parseBigIntInput(allowlistPublicKeyInput.value, 'Public key');
-    if (notePublicKey === null) throw new Error('User note public key is required');
+    const notePublicKey = allowlistPublicKeyInput.value.trim();
+    if (parseBigIntInput(notePublicKey, 'Public key') === null) {
+      throw new Error('User note public key is required');
+    }
 
-    const aspSecret = parseBigIntInput(allowlistAspSecretInput.value, 'ASP secret');
-    if (aspSecret === null) throw new Error('ASP secret is required');
+    const aspSecret = allowlistAspSecretInput.value.trim();
+    if (parseBigIntInput(aspSecret, 'ASP secret') === null) {
+      throw new Error('ASP secret is required');
+    }
 
     addToAllowlistBtn.disabled = true;
     addToAllowlistBtn.textContent = 'Processing...';
@@ -385,10 +389,7 @@ async function insertMembershipLeaf() {
     setStatus('Computing and submitting allowlist insert transaction...', 'info');
     await ensureCryptoReady();
 
-    const leafHex = await client().account().deriveAspUserLeaf({
-        membershipBlinding: aspSecret,
-        notePublicKey,
-    });
+    const leafHex = await deriveAspUserLeaf(notePublicKey, aspSecret);
     const leafValue = BigInt(leafHex);
 
     const mClient = await getMembershipClient(contractId);

--- a/app/js/wasm-facade.js
+++ b/app/js/wasm-facade.js
@@ -13,6 +13,7 @@ import init, {
   FreighterSigner,
   Storage,
   bootnodeRequired as sdkBootnodeRequired,
+  deriveAspUserLeaf as sdkDeriveAspUserLeaf,
   verifySelectiveDisclosure as sdkVerifySelectiveDisclosure,
 } from 'stellar-private-payments-sdk-web';
 
@@ -85,7 +86,7 @@ function wrapSdkClient(sdk) {
                 userNotes: (limit) => boundAccount.userNotes(limit),
                 isRegistered: () => boundAccount.isRegistered(),
                 registerPublicKeys: (options) => boundAccount.registerPublicKeys(options ?? {}),
-                deriveAspUserLeaf: (options) => boundAccount.deriveAspUserLeaf(options),
+                deriveAspUserLeaf: () => boundAccount.deriveAspUserLeaf(),
                 pool: (options) => boundAccount.pool(options),
             };
         },
@@ -174,6 +175,17 @@ export async function initializeRuntime(rpcUrl, { bootnodeUrl } = {}) {
     }
 
     return client();
+}
+
+/**
+ * Derive the ASP membership leaf from explicit public inputs (no account session).
+ * @param {string} notePublicKey `0x`-prefixed 32-byte hex
+ * @param {string} membershipBlinding `0x`-prefixed 32-byte hex field
+ * @returns {Promise<string>} leaf as `0x` hex
+ */
+export async function deriveAspUserLeaf(notePublicKey, membershipBlinding) {
+    await ensureWasmInit();
+    return sdkDeriveAspUserLeaf(notePublicKey, membershipBlinding);
 }
 
 /**

--- a/sdk/client/README.md
+++ b/sdk/client/README.md
@@ -93,7 +93,8 @@ Method names mirror the async API; each call runs on an internal Tokio runtime.
 | `KEY_DERIVATION_MESSAGE` | Wallet message to sign for key derivation (**native / CLI** — browser apps use `Client.account()`, which signs this internally) |
 | `Account::user_public_keys()` | Note + encryption public keys for the bound account |
 | `Account::asp_secret()` | ASP membership blinding for the bound account |
-| `Account::derive_asp_user_leaf(...)` | ASP membership tree leaf |
+| `Account::derive_asp_user_leaf()` | ASP membership tree leaf from stored keys |
+| `crypto::derive_asp_user_leaf(note, blinding)` | Same leaf from explicit inputs (no session) |
 
 Private note/encryption keys stay in storage and are not exposed through the SDK.
 

--- a/sdk/client/src/account.rs
+++ b/sdk/client/src/account.rs
@@ -2,8 +2,6 @@ use types::{
     ContractConfig, EncryptionPublicKey, Field, NotePublicKey, PortfolioBalance, UserNoteSummary,
 };
 
-use prover::crypto::asp_membership_leaf;
-
 use stellar::{Limits, ReadXdr, StateFetcher, TransactionEnvelope, submit_tx};
 
 use crate::{
@@ -91,20 +89,10 @@ impl<S: Storage> Account<S> {
     }
 
     /// Derive the ASP membership tree leaf for this account's note public key.
-    pub async fn derive_asp_user_leaf(
-        &self,
-        note_public_key: Option<NotePublicKey>,
-        membership_blinding: Option<Field>,
-    ) -> Result<Field, Error> {
-        let note = match note_public_key {
-            Some(note) => note,
-            None => self.storage.user_public_keys(&self.user_address).await?.0,
-        };
-        let blinding = match membership_blinding {
-            Some(blinding) => blinding,
-            None => self.storage.asp_secret(&self.user_address).await?,
-        };
-        asp_membership_leaf(&note, &blinding).map_err(|e| Error::Other(e.to_string()))
+    pub async fn derive_asp_user_leaf(&self) -> Result<Field, Error> {
+        let note = self.storage.user_public_keys(&self.user_address).await?.0;
+        let blinding = self.storage.asp_secret(&self.user_address).await?;
+        crate::crypto::derive_asp_user_leaf(&note, &blinding)
     }
 
     /// Notes for this account across all pools (newest first).

--- a/sdk/client/src/blocking/account.rs
+++ b/sdk/client/src/blocking/account.rs
@@ -50,15 +50,8 @@ impl Account {
         block_on(self.inner.asp_secret())
     }
 
-    pub fn derive_asp_user_leaf(
-        &self,
-        note_public_key: Option<NotePublicKey>,
-        membership_blinding: Option<Field>,
-    ) -> Result<Field, Error> {
-        block_on(
-            self.inner
-                .derive_asp_user_leaf(note_public_key, membership_blinding),
-        )
+    pub fn derive_asp_user_leaf(&self) -> Result<Field, Error> {
+        block_on(self.inner.derive_asp_user_leaf())
     }
 
     pub fn user_notes(&self, limit: u32) -> Result<Vec<UserNoteSummary>, Error> {

--- a/sdk/client/src/crypto.rs
+++ b/sdk/client/src/crypto.rs
@@ -1,0 +1,18 @@
+//! Client-facing crypto helpers that do not require a wallet session.
+
+use prover::crypto::asp_membership_leaf;
+use types::{Field, NotePublicKey};
+
+use crate::Error;
+
+/// Derive the ASP membership tree leaf for a note public key and membership
+/// blinding.
+///
+/// `leaf = poseidon2_hash2(note_pubkey, membership_blinding, domain=1)`
+pub fn derive_asp_user_leaf(
+    note_public_key: &NotePublicKey,
+    membership_blinding: &Field,
+) -> Result<Field, Error> {
+    asp_membership_leaf(note_public_key, membership_blinding)
+        .map_err(|e| Error::Other(e.to_string()))
+}

--- a/sdk/client/src/lib.rs
+++ b/sdk/client/src/lib.rs
@@ -88,6 +88,7 @@ mod account;
 pub mod blocking;
 mod client;
 mod core;
+pub mod crypto;
 mod error;
 mod handle;
 mod plan;

--- a/sdk/web/README.md
+++ b/sdk/web/README.md
@@ -93,9 +93,17 @@ const chain = await client.allContractsData();
 | `aspSecret()` | ASP membership blinding |
 | `userNotes(limit)` | Notes across pools (newest first) |
 | `isRegistered()` | On-chain public key registry entry exists |
-| `deriveAspUserLeaf({ notePublicKey?, membershipBlinding? })` | ASP membership tree leaf |
+| `deriveAspUserLeaf()` | ASP membership tree leaf from stored keys |
 | `registerPublicKeys(options?)` | On-chain key registry |
 | `pool({ poolContract })` | Open a `PrivatePool` session |
+
+### Free functions
+
+| Function | Description |
+|----------|-------------|
+| `deriveAspUserLeaf(notePublicKey, membershipBlinding)` | ASP membership leaf from explicit hex inputs |
+| `bootnodeRequired(rpcUrl, storage)` | Whether historical-sync bootnode is needed |
+| `verifySelectiveDisclosure(...)` | Walletless disclosure verification |
 
 ### `PrivatePool`
 

--- a/sdk/web/js/index.js
+++ b/sdk/web/js/index.js
@@ -3,6 +3,7 @@ import init, {
   PrivatePool,
   Storage as WasmStorage,
   bootnodeRequired as wasmBootnodeRequired,
+  deriveAspUserLeaf as wasmDeriveAspUserLeaf,
   verifySelectiveDisclosure as wasmVerifySelectiveDisclosure,
 } from '../dist/stellar_private_payments_sdk_web.js';
 
@@ -29,6 +30,16 @@ async function bootnodeRequired(rpcUrl, storage) {
   return wasmBootnodeRequired(rpcUrl, storage);
 }
 
+/**
+ * Derive the ASP membership leaf from explicit public inputs.
+ * @param {string} notePublicKey `0x`-prefixed 32-byte hex
+ * @param {string} membershipBlinding `0x`-prefixed 32-byte hex field
+ * @returns {string} leaf as `0x` hex
+ */
+function deriveAspUserLeaf(notePublicKey, membershipBlinding) {
+  return wasmDeriveAspUserLeaf(notePublicKey, membershipBlinding);
+}
+
 function wrapAccount(wasmAccount) {
   return {
     get userAddress() {
@@ -39,7 +50,7 @@ function wrapAccount(wasmAccount) {
     aspSecret: () => wasmAccount.aspSecret(),
     userNotes: (limit) => wasmAccount.userNotes(limit),
     isRegistered: () => wasmAccount.isRegistered(),
-    deriveAspUserLeaf: (options) => wasmAccount.deriveAspUserLeaf(options),
+    deriveAspUserLeaf: () => wasmAccount.deriveAspUserLeaf(),
     registerPublicKeys: (options) => wasmAccount.registerPublicKeys(options),
     pool: (options) => wasmAccount.pool(options),
   };
@@ -117,6 +128,6 @@ export const Client = {
   new: newClient,
   contractConfig: WasmClient.contractConfig,
 };
-export { PrivatePool, bootnodeRequired, verifySelectiveDisclosure };
+export { PrivatePool, bootnodeRequired, deriveAspUserLeaf, verifySelectiveDisclosure };
 export { default } from '../dist/stellar_private_payments_sdk_web.js';
 export { FreighterSigner } from './freighter.js';

--- a/sdk/web/js/types/index.d.ts
+++ b/sdk/web/js/types/index.d.ts
@@ -49,14 +49,9 @@ export interface AccountClient {
   aspSecret(): Promise<string>;
   userNotes(limit: number): Promise<unknown>;
   isRegistered(): Promise<boolean>;
-  deriveAspUserLeaf(options?: DeriveAspUserLeafOptions | null): Promise<string>;
+  deriveAspUserLeaf(): Promise<string>;
   registerPublicKeys(options?: RegisterPublicKeysOptions | null): Promise<string>;
   pool(options: PoolOptions): Promise<PrivatePool>;
-}
-
-export interface DeriveAspUserLeafOptions {
-  notePublicKey?: string;
-  membershipBlinding?: string;
 }
 
 /** Deployment runtime returned by {@link Client.new}. */
@@ -83,6 +78,16 @@ export declare function bootnodeRequired(
   rpcUrl: string,
   storage: Storage,
 ): Promise<boolean>;
+
+/**
+ * Derive the ASP membership leaf from explicit public inputs.
+ * @param notePublicKey `0x`-prefixed 32-byte hex
+ * @param membershipBlinding `0x`-prefixed 32-byte hex field
+ */
+export declare function deriveAspUserLeaf(
+  notePublicKey: string,
+  membershipBlinding: string,
+): string;
 
 /** Walletless selective-disclosure verification (no storage / Client). */
 export declare function verifySelectiveDisclosure(

--- a/sdk/web/src/client/account.rs
+++ b/sdk/web/src/client/account.rs
@@ -2,12 +2,10 @@
 
 use std::rc::Rc;
 
-use std::str::FromStr;
-
 use serde::{Deserialize, Serialize};
 use stellar_private_payments_sdk::{
     Account as NativeAccount,
-    types::{EncryptionPublicKey, Field, NotePublicKey},
+    types::{EncryptionPublicKey, NotePublicKey},
 };
 
 use wasm_bindgen::prelude::*;
@@ -28,13 +26,6 @@ struct UserPublicKeysOut {
 struct RegisterPublicKeysOptions {
     note_public_key_hex: Option<String>,
     encryption_public_key_hex: Option<String>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct DeriveAspUserLeafOptions {
-    note_public_key: Option<String>,
-    membership_blinding: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -93,31 +84,13 @@ impl Account {
         Ok(secret.to_string())
     }
 
-    /// Derive the ASP membership tree leaf for this account's note public key.
+    /// Derive the ASP membership tree leaf for this account's stored keys.
+    ///
+    /// For explicit inputs without a session, use the free
+    /// [`derive_asp_user_leaf`](super::derive_asp_user_leaf) export.
     #[wasm_bindgen(js_name = deriveAspUserLeaf)]
-    pub async fn derive_asp_user_leaf(&self, options: JsValue) -> Result<String, JsError> {
-        let opts: DeriveAspUserLeafOptions = if options.is_null() || options.is_undefined() {
-            DeriveAspUserLeafOptions::default()
-        } else {
-            serde_wasm_bindgen::from_value(options)?
-        };
-
-        let note_public_key = match opts.note_public_key {
-            Some(raw) => {
-                Some(NotePublicKey::parse(&raw).map_err(|e| JsError::new(&e.to_string()))?)
-            }
-            None => None,
-        };
-        let membership_blinding = match opts.membership_blinding {
-            Some(raw) => Some(Field::from_str(&raw).map_err(|e| JsError::new(&e.to_string()))?),
-            None => None,
-        };
-
-        let leaf = self
-            .inner
-            .derive_asp_user_leaf(note_public_key, membership_blinding)
-            .await
-            .map_err(pool_err)?;
+    pub async fn derive_asp_user_leaf(&self) -> Result<String, JsError> {
+        let leaf = self.inner.derive_asp_user_leaf().await.map_err(pool_err)?;
         Ok(leaf.to_string())
     }
 

--- a/sdk/web/src/client/mod.rs
+++ b/sdk/web/src/client/mod.rs
@@ -6,13 +6,14 @@ mod execute;
 mod pool;
 mod transact;
 
-use std::rc::Rc;
+use std::{rc::Rc, str::FromStr};
 
 use serde::Deserialize;
 use stellar_private_payments_sdk::{
     Account as NativeAccount, BackgroundSyncStop, Client as NativeClient, Error, Handle,
     chain::{RpcClient, StateFetcher},
-    types::{DisclosureReceipt, KeyDerivationSignature},
+    crypto::derive_asp_user_leaf as derive_asp_user_leaf_native,
+    types::{DisclosureReceipt, Field, KeyDerivationSignature, NotePublicKey},
     verify_disclosure_receipt,
 };
 use wasm_bindgen::prelude::*;
@@ -266,6 +267,21 @@ impl Drop for Client {
             stop.request();
         }
     }
+}
+
+/// Derive the ASP membership tree leaf from explicit public inputs.
+#[wasm_bindgen(js_name = deriveAspUserLeaf)]
+pub fn derive_asp_user_leaf(
+    note_public_key: String,
+    membership_blinding: String,
+) -> Result<String, JsError> {
+    crate::wasm_start();
+
+    let note = NotePublicKey::parse(&note_public_key).map_err(|e| JsError::new(&e.to_string()))?;
+    let blinding =
+        Field::from_str(&membership_blinding).map_err(|e| JsError::new(&e.to_string()))?;
+    let leaf = derive_asp_user_leaf_native(&note, &blinding).map_err(pool_err)?;
+    Ok(leaf.to_string())
 }
 
 /// Verify a selective-disclosure receipt with no wallet, no local storage,

--- a/sdk/web/src/lib.rs
+++ b/sdk/web/src/lib.rs
@@ -18,7 +18,9 @@ pub(crate) mod artifact_hashes {
 pub(crate) const DEPLOYMENT: &str = include_str!("../../../deployments/testnet/deployments.json");
 
 pub use bootnode::bootnode_required_js as bootnode_required;
-pub use client::{Account, Client, PrivatePool, verify_selective_disclosure_standalone};
+pub use client::{
+    Account, Client, PrivatePool, derive_asp_user_leaf, verify_selective_disclosure_standalone,
+};
 pub use storage::Storage;
 
 pub(crate) fn wasm_start() {


### PR DESCRIPTION
derive-asp-user-leaf was gated behind SDK's client account. On admin page, we were trying to access that fn, but the account wasn't opened yet.
Instead of opening the account, we can just provide the fn as a free fn.
Also makes `Account::derive_asp_user_leaf` just operate on `self`.
