### PR TITLE
Fix admin home link on GitHub Pages sub-path, add 404 page

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -46,6 +46,7 @@ cp -R sdk/web/dist/. "$SDK/dist/"
 
 # Static files
 cp app/admin.html "$TRUNK_STAGING_DIR/" 2>/dev/null || true
+cp app/404.html "$TRUNK_STAGING_DIR/" 2>/dev/null || true
 
 # Top-level legal files (NOTICE, LICENSE, circuits/NOTICE for footer links).
 sh deployments/scripts/stage-dist-legal.sh "$TRUNK_STAGING_DIR"

--- a/app/404.html
+++ b/app/404.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Page not found." />
+    <meta name="author" content="Stellar Private Payments" />
+    <meta name="robots" content="noindex" />
+
+    <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
+
+    <title>Stellar Private Payments | Page Not Found</title>
+
+    <link rel="stylesheet" href="css/app.css" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+</head>
+
+<body class="min-h-screen bg-ink-950 font-sans text-slate-100 antialiased">
+    <div class="pointer-events-none fixed inset-0 overflow-hidden">
+        <div class="absolute inset-x-0 top-0 h-[32rem] bg-[radial-gradient(circle_at_top,rgba(88,166,255,0.28),transparent_58%)]"></div>
+        <div class="absolute -left-24 top-44 h-72 w-72 rounded-full bg-cyan-400/10 blur-3xl"></div>
+        <div class="absolute right-0 top-24 h-96 w-96 rounded-full bg-blue-500/10 blur-3xl"></div>
+    </div>
+
+    <main class="relative mx-auto flex min-h-screen max-w-[720px] flex-col items-center justify-center px-6 text-center">
+        <p class="text-[11px] font-semibold uppercase tracking-[0.34em] text-cyan-200/70">Error 404</p>
+        <h1 class="mt-3 text-5xl font-semibold tracking-tight text-white sm:text-6xl">Page Not Found</h1>
+        <p class="mt-4 max-w-md text-sm leading-relaxed text-slate-400">
+            The page you're looking for doesn't exist or may have moved.
+        </p>
+
+        <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+            <a href="index.html" class="inline-flex items-center justify-center rounded-full bg-[linear-gradient(135deg,#74c5ff,#2f6dff)] px-5 py-3 text-sm font-semibold text-ink-950 shadow-[0_12px_30px_rgba(63,138,255,0.45)] transition hover:brightness-110">
+                Go to Home
+            </a>
+            <a href="admin.html" class="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-medium text-slate-200 transition hover:border-cyan-300/30 hover:text-cyan-100">
+                Open Admin
+            </a>
+        </div>
+    </main>
+</body>
+</html>

--- a/app/admin.html
+++ b/app/admin.html
@@ -43,7 +43,7 @@
         <header class="rounded-[28px] border border-white/8 bg-white/[0.03] px-5 py-4 shadow-[0_20px_80px_rgba(0,0,0,0.35)] backdrop-blur-xl">
             <div class="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
                 <div class="flex items-center gap-4 xl:flex-1">
-                    <a href="/" title="Go to Home" class="cursor-pointer text-2xl font-semibold tracking-tight text-white transition hover:opacity-80">
+                    <a href="index.html" title="Go to Home" class="cursor-pointer text-2xl font-semibold tracking-tight text-white transition hover:opacity-80">
                         Stellar Private Payments <span class="text-cyan-300 font-normal tracking-normal ml-1">Admin</span>
                     </a>
                 </div>


### PR DESCRIPTION
## Summary

- Change the admin header link from `href="/"` to `href="index.html"` so it resolves correctly under the GitHub Pages sub-path (`nethermindeth.github.io/stellar-private-payments/`) as well as on localhost.
- Add `app/404.html`, a styled fallback page that GitHub Pages serves automatically for unknown paths. Wire it into the trunk staging hook so it ships in `dist/`.

Fixes #391.

## Why

The absolute `/` resolved to `nethermindeth.github.io/` on the deployed site, which has no landing page for the project — clicking the header 404'd. A relative href resolves against the current path and works in both environments.

## Test plan

- [x] `PUBLIC_URL=/stellar-private-payments/ make serve` — trunk builds and serves under the sub-path.
- [x] Load `http://localhost:8000/stellar-private-payments/admin.html`, click the "Stellar Private Payments Admin" header → navigates to `/stellar-private-payments/index.html` (HTTP 200).
- [x] Load `http://localhost:8000/stellar-private-payments/404.html` → styled 404 page renders with links back to Home and Admin.
- [ ] Verify on a GitHub Pages preview that unknown paths render `404.html` (GitHub Pages serves `404.html` with an actual 404 status; trunk's dev server SPA-falls-back to `index.html`, so this only exercises fully on Pages).