### PR TITLE
Remove nullifier map for presence-only check

### DIFF
--- a/contracts/pool/src/pool.rs
+++ b/contracts/pool/src/pool.rs
@@ -344,21 +344,6 @@ impl PoolContract {
         }
     }
 
-    /// Check if a nullifier has already been spent
-    ///
-    /// # Arguments
-    ///
-    /// * `env` - The Soroban environment
-    /// * `n` - The nullifier to check
-    ///
-    /// # Returns
-    ///
-    /// Returns `true` if the nullifier has been spent, `false` otherwise
-    fn is_spent(env: &Env, n: &U256) -> Result<bool, Error> {
-        let key = DataKey::Nullifier(n.clone());
-        Ok(env.storage().persistent().has(&key))
-    }
-
     /// Mark a nullifier as spent
     ///
     /// # Arguments
@@ -726,6 +711,23 @@ impl PoolContract {
     /// * `root` - Pool Merkle root to check
     pub fn is_known_root(env: &Env, root: &U256) -> Result<bool, Error> {
         Ok(MerkleTreeWithHistory::is_known_root(env, root)?)
+    }
+
+    /// Check whether a nullifier has already been spent.
+    ///
+    /// Presence of the per-nullifier storage key is the spent flag.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment
+    /// * `n` - The nullifier to check
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if the nullifier has been spent, `false` otherwise
+    pub fn is_spent(env: &Env, n: &U256) -> Result<bool, Error> {
+        let key = DataKey::Nullifier(n.clone());
+        Ok(env.storage().persistent().has(&key))
     }
 
     /// Update the contract administrator

--- a/contracts/pool/src/pool.rs
+++ b/contracts/pool/src/pool.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use contract_types::{Groth16Error, Groth16Proof};
 use soroban_sdk::{
-    Address, Bytes, BytesN, Env, I256, Map, U256, Vec, contract, contractclient, contracterror,
+    Address, Bytes, BytesN, Env, I256, U256, Vec, contract, contractclient, contracterror,
     contractevent, contractimpl, contracttype, crypto::bn254::Bn254Fr, token::TokenClient,
     xdr::ToXdr,
 };
@@ -174,8 +174,8 @@ pub(crate) enum DataKey {
     Verifier,
     /// Maximum allowed deposit amount per transaction
     MaximumDepositAmount,
-    /// Map of spent nullifiers (nullifier -> bool)
-    Nullifiers,
+    /// Spent nullifier marker keyed by nullifier (presence-only; value unused).
+    Nullifier(U256),
     /// Address of the ASP Membership contract
     ASPMembership,
     /// Address of the ASP Non-Membership contract
@@ -273,9 +273,6 @@ impl PoolContract {
             .set(&DataKey::MaximumDepositAmount, &maximum_deposit_amount);
         env.storage()
             .persistent()
-            .set(&DataKey::Nullifiers, &Map::<U256, bool>::new(&env));
-        env.storage()
-            .persistent()
             .set(&DataKey::PolicyFlags, &policy_flags);
 
         // Initialize the Merkle tree for commitment storage
@@ -358,8 +355,8 @@ impl PoolContract {
     ///
     /// Returns `true` if the nullifier has been spent, `false` otherwise
     fn is_spent(env: &Env, n: &U256) -> Result<bool, Error> {
-        let nulls = Self::get_nullifiers(env)?;
-        Ok(nulls.get(n.clone()).unwrap_or(false))
+        let key = DataKey::Nullifier(n.clone());
+        Ok(env.storage().persistent().has(&key))
     }
 
     /// Mark a nullifier as spent
@@ -369,9 +366,9 @@ impl PoolContract {
     /// * `env` - The Soroban environment
     /// * `n` - The nullifier to mark as spent
     fn mark_spent(env: &Env, n: &U256) -> Result<(), Error> {
-        let mut nulls = Self::get_nullifiers(env)?;
-        nulls.set(n.clone(), true);
-        Self::set_nullifiers(env, &nulls);
+        let key = DataKey::Nullifier(n.clone());
+        // Presence of the key is the spent flag; value is unused.
+        env.storage().persistent().set(&key, &());
         Ok(())
     }
 
@@ -664,19 +661,6 @@ impl PoolContract {
     }
 
     // ========== Storage Getters and Setters ==========
-
-    /// Get the nullifiers map from storage
-    fn get_nullifiers(env: &Env) -> Result<Map<U256, bool>, Error> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Nullifiers)
-            .ok_or(Error::NotInitialized)
-    }
-
-    /// Save the nullifiers map to storage
-    fn set_nullifiers(env: &Env, m: &Map<U256, bool>) {
-        env.storage().persistent().set(&DataKey::Nullifiers, m);
-    }
 
     /// Get the token contract address
     fn get_token(env: &Env) -> Result<Address, Error> {

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -932,3 +932,57 @@ fn transact_does_not_reject_boundary_canonical_public_input() {
         Err(Ok(Error::NonCanonicalPublicInput))
     ));
 }
+
+#[test]
+fn is_spent_false_for_unseen_nullifier() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
+    );
+    let pool = PoolContractClient::new(&env, &pool_id);
+    let nullifier = U256::from_u32(&env, 0xB1);
+
+    assert!(!pool.is_spent(&nullifier));
+}
+
+#[test]
+fn is_spent_true_after_nullifier_marked() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
+    );
+    let pool = PoolContractClient::new(&env, &pool_id);
+    let spent = U256::from_u32(&env, 0xA1);
+    let other = U256::from_u32(&env, 0xA2);
+
+    assert!(!pool.is_spent(&spent));
+    assert!(!pool.is_spent(&other));
+
+    // mark spent
+    env.as_contract(&pool_id, || {
+        env.storage()
+            .persistent()
+            .set(&crate::pool::DataKey::Nullifier(spent.clone()), &());
+    });
+
+    assert!(pool.is_spent(&spent));
+    assert!(!pool.is_spent(&other));
+
+    // indempotency check
+    env.as_contract(&pool_id, || {
+        env.storage()
+            .persistent()
+            .set(&crate::pool::DataKey::Nullifier(spent.clone()), &());
+    });
+    assert!(pool.is_spent(&spent));
+}


### PR DESCRIPTION
While testing pools with a larger number of transactions, I was able to reach network read limits (at about ~750 txs).
This PR replaces the nullifier map for a presence-only check, avoiding the load of the entire map on both reads and writes.
