### PR TITLE
Pin binaryen version_131 for wasm-opt in sdk build and CI

### DIFF
--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -51,6 +51,14 @@ jobs:
       - name: Install SDK npm dependencies
         run: npm ci --prefix sdk/web
 
+      # On a miss build.sh downloads and sha256-verifies binaryen itself; this
+      # only persists the extracted tree between runs.
+      - name: Cache binaryen
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: target/tmp/binaryen/binaryen-version_131
+          key: binaryen-version_131-${{ runner.os }}-${{ runner.arch }}
+
       - name: Build npm package
         run: npm run build --prefix sdk/web
 

--- a/sdk/web/scripts/build.sh
+++ b/sdk/web/scripts/build.sh
@@ -33,6 +33,71 @@ if [[ "${installed_version}" != "${WASM_BINDGEN_VERSION}" ]]; then
   exit 1
 fi
 
+WASM_OPT_VERSION="${WASM_OPT_VERSION:-version_131}"
+BINARYEN_DIR="$ROOT/target/tmp/binaryen/binaryen-$WASM_OPT_VERSION"
+
+# sha256 of the pinned binaryen release tarballs, per platform. Only valid for
+# the default WASM_OPT_VERSION above — bumping it means refreshing all four
+# (see the .sha256 sidecars on the GitHub release).
+binaryen_platform=""
+binaryen_sha256=""
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64)
+    binaryen_platform="x86_64-linux"
+    binaryen_sha256="b5bf1f0eaf17c63ee588ff7a5954dc8f6ce2c26989051c66f24dfe9ece3e46db" ;;
+  Linux-aarch64 | Linux-arm64)
+    binaryen_platform="aarch64-linux"
+    binaryen_sha256="ba991f677edd9a21d2bc96c0144bc8ac5b112d4d98a3eb266e075e22e557df2a" ;;
+  Darwin-x86_64)
+    binaryen_platform="x86_64-macos"
+    binaryen_sha256="d209fadd8a894bdaf3bd3612a23c32a0af184d2f4a979b8c789e6e4f6a4de883" ;;
+  Darwin-arm64)
+    binaryen_platform="arm64-macos"
+    binaryen_sha256="e441b48dc22163d209b4f05e44dc7210909b01237642b6c9ae48fd710a3ef83e" ;;
+esac
+
+# Escape hatch for platforms with no prebuilt release (Windows, *BSD, Nix, ...)
+# and for a locally built binaryen: point WASM_OPT at a wasm-opt binary and the
+# download is skipped. The version gate below still applies.
+WASM_OPT="${WASM_OPT:-$BINARYEN_DIR/bin/wasm-opt}"
+
+sha256_check() {
+  # macOS ships shasum rather than GNU coreutils' sha256sum.
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c -
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c -
+  else
+    echo "error: need sha256sum or shasum to verify the binaryen download" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -x "$WASM_OPT" ]]; then
+  if [[ -z "$binaryen_platform" ]]; then
+    echo "error: no prebuilt binaryen for $(uname -s)-$(uname -m)" >&2
+    echo "  install binaryen ${WASM_OPT_VERSION#version_} and set WASM_OPT=/path/to/wasm-opt" >&2
+    exit 1
+  fi
+  if [[ "$WASM_OPT_VERSION" != "version_131" ]]; then
+    echo "error: no pinned sha256 for binaryen $WASM_OPT_VERSION" >&2
+    echo "  install it yourself and set WASM_OPT=/path/to/wasm-opt" >&2
+    exit 1
+  fi
+  echo "==> Downloading binaryen $WASM_OPT_VERSION ($binaryen_platform)..."
+  mkdir -p "$ROOT/target/tmp/binaryen"
+  tmp_tar="$ROOT/target/tmp/binaryen/binaryen-$WASM_OPT_VERSION-$binaryen_platform.tar.gz"
+  curl -sSfL -o "$tmp_tar" \
+    "https://github.com/WebAssembly/binaryen/releases/download/$WASM_OPT_VERSION/binaryen-$WASM_OPT_VERSION-$binaryen_platform.tar.gz"
+  echo "$binaryen_sha256  $tmp_tar" | sha256_check
+  tar xzf "$tmp_tar" -C "$ROOT/target/tmp/binaryen"
+  rm -f "$tmp_tar"
+fi
+
+installed_opt="$("$WASM_OPT" --version | awk '{print $3}')"
+[[ "$installed_opt" == "${WASM_OPT_VERSION#version_}" ]] || {
+  echo "error: wasm-opt $installed_opt; need ${WASM_OPT_VERSION#version_}" >&2; exit 1; }
+
 MAIN_WASM="$ARTIFACTS/${WASM_OUT_NAME}.wasm"
 STORAGE_WASM="$ARTIFACTS/storage-worker.wasm"
 PROVER_WASM="$ARTIFACTS/prover-worker.wasm"


### PR DESCRIPTION
build.sh downloads a sha256-verified binaryen tarball into target/tmp/binaryen/ when the pinned wasm-opt is absent (overridable via WASM_OPT_VERSION, mirroring WASM_BINDGEN_VERSION) and hard-gates on version 131. Selects the release asset by uname -s/-m, covering x86_64/aarch64 Linux and x86_64/arm64 macOS, each with its own pinned sha256; unsupported platforms get a clear error with a WASM_OPT escape hatch to point at a manually installed wasm-opt. Checksum verification falls back to shasum where sha256sum isn't available.

The wasm-build CI job caches the extracted tree keyed on runner.os/runner.arch; the separate install step is dropped since build.sh now self-provisions on a cache miss. Enabler for the wasm-opt size passes; no change to build outputs yet.

Addresses #48 