### PR TITLE
Optimize SDK wasm with pinned wasm-opt -Os

### DIFF
--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -51,6 +51,14 @@ jobs:
       - name: Install SDK npm dependencies
         run: npm ci --prefix sdk/web
 
+      # On a miss build.sh downloads and sha256-verifies binaryen itself; this
+      # only persists the extracted tree between runs.
+      - name: Cache binaryen
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: target/tmp/binaryen/binaryen-version_131
+          key: binaryen-version_131-${{ runner.os }}-${{ runner.arch }}
+
       - name: Build npm package
         run: npm run build --prefix sdk/web
 

--- a/sdk/web/scripts/build.sh
+++ b/sdk/web/scripts/build.sh
@@ -33,6 +33,71 @@ if [[ "${installed_version}" != "${WASM_BINDGEN_VERSION}" ]]; then
   exit 1
 fi
 
+WASM_OPT_VERSION="${WASM_OPT_VERSION:-version_131}"
+BINARYEN_DIR="$ROOT/target/tmp/binaryen/binaryen-$WASM_OPT_VERSION"
+
+# sha256 of the pinned binaryen release tarballs, per platform. Only valid for
+# the default WASM_OPT_VERSION above — bumping it means refreshing all four
+# (see the .sha256 sidecars on the GitHub release).
+binaryen_platform=""
+binaryen_sha256=""
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64)
+    binaryen_platform="x86_64-linux"
+    binaryen_sha256="b5bf1f0eaf17c63ee588ff7a5954dc8f6ce2c26989051c66f24dfe9ece3e46db" ;;
+  Linux-aarch64 | Linux-arm64)
+    binaryen_platform="aarch64-linux"
+    binaryen_sha256="ba991f677edd9a21d2bc96c0144bc8ac5b112d4d98a3eb266e075e22e557df2a" ;;
+  Darwin-x86_64)
+    binaryen_platform="x86_64-macos"
+    binaryen_sha256="d209fadd8a894bdaf3bd3612a23c32a0af184d2f4a979b8c789e6e4f6a4de883" ;;
+  Darwin-arm64)
+    binaryen_platform="arm64-macos"
+    binaryen_sha256="e441b48dc22163d209b4f05e44dc7210909b01237642b6c9ae48fd710a3ef83e" ;;
+esac
+
+# Escape hatch for platforms with no prebuilt release (Windows, *BSD, Nix, ...)
+# and for a locally built binaryen: point WASM_OPT at a wasm-opt binary and the
+# download is skipped. The version gate below still applies.
+WASM_OPT="${WASM_OPT:-$BINARYEN_DIR/bin/wasm-opt}"
+
+sha256_check() {
+  # macOS ships shasum rather than GNU coreutils' sha256sum.
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c -
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c -
+  else
+    echo "error: need sha256sum or shasum to verify the binaryen download" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -x "$WASM_OPT" ]]; then
+  if [[ -z "$binaryen_platform" ]]; then
+    echo "error: no prebuilt binaryen for $(uname -s)-$(uname -m)" >&2
+    echo "  install binaryen ${WASM_OPT_VERSION#version_} and set WASM_OPT=/path/to/wasm-opt" >&2
+    exit 1
+  fi
+  if [[ "$WASM_OPT_VERSION" != "version_131" ]]; then
+    echo "error: no pinned sha256 for binaryen $WASM_OPT_VERSION" >&2
+    echo "  install it yourself and set WASM_OPT=/path/to/wasm-opt" >&2
+    exit 1
+  fi
+  echo "==> Downloading binaryen $WASM_OPT_VERSION ($binaryen_platform)..."
+  mkdir -p "$ROOT/target/tmp/binaryen"
+  tmp_tar="$ROOT/target/tmp/binaryen/binaryen-$WASM_OPT_VERSION-$binaryen_platform.tar.gz"
+  curl -sSfL -o "$tmp_tar" \
+    "https://github.com/WebAssembly/binaryen/releases/download/$WASM_OPT_VERSION/binaryen-$WASM_OPT_VERSION-$binaryen_platform.tar.gz"
+  echo "$binaryen_sha256  $tmp_tar" | sha256_check
+  tar xzf "$tmp_tar" -C "$ROOT/target/tmp/binaryen"
+  rm -f "$tmp_tar"
+fi
+
+installed_opt="$("$WASM_OPT" --version | awk '{print $3}')"
+[[ "$installed_opt" == "${WASM_OPT_VERSION#version_}" ]] || {
+  echo "error: wasm-opt $installed_opt; need ${WASM_OPT_VERSION#version_}" >&2; exit 1; }
+
 MAIN_WASM="$ARTIFACTS/${WASM_OUT_NAME}.wasm"
 STORAGE_WASM="$ARTIFACTS/storage-worker.wasm"
 PROVER_WASM="$ARTIFACTS/prover-worker.wasm"

--- a/sdk/web/scripts/build.sh
+++ b/sdk/web/scripts/build.sh
@@ -113,6 +113,21 @@ wasm-bindgen --target web --out-dir "$WEB/dist" --out-name "$WASM_OUT_NAME" "$MA
 wasm-bindgen --target web --out-dir "$WEB/dist/workers" --out-name storage-worker-module "$STORAGE_WASM"
 wasm-bindgen --target web --out-dir "$WEB/dist/workers" --out-name prover-worker-module "$PROVER_WASM"
 
+echo "==> Running wasm-opt -Os on shipped wasm modules..."
+for wasm in \
+  "$WEB/dist/${WASM_OUT_NAME}_bg.wasm" \
+  "$WEB/dist/workers/storage-worker-module_bg.wasm" \
+  "$WEB/dist/workers/prover-worker-module_bg.wasm"; do
+  "$WASM_OPT" -Os \
+    --enable-bulk-memory \
+    --enable-reference-types \
+    --enable-multivalue \
+    --enable-sign-ext \
+    --enable-nontrapping-float-to-int \
+    --enable-mutable-globals \
+    "$wasm" -o "$wasm"
+done
+
 write_worker_loader() {
   local name="$1"
   cat >"$WEB/dist/workers/${name}.js" <<EOF


### PR DESCRIPTION
After wasm-bindgen, run the pinned binaryen wasm-opt -Os on each of the three shipped *_bg.wasm files in-place. Enables the six feature flags binary 131 requires for wasm-bindgen 0.2.126 output.

Addresses #48 