### PR TITLE
Re-order steps in onboarding

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -484,9 +484,9 @@
 
             <div id="onboarding-steps" class="mt-8 grid gap-3 md:grid-cols-6">
                 <div data-step="disclaimer" class="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3 text-sm">Disclaimer</div>
+                <div data-step="retention" class="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3 text-sm">Retention</div>
                 <div data-step="storage" class="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3 text-sm">Storage</div>
                 <div data-step="keys" class="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3 text-sm">Keys</div>
-                <div data-step="retention" class="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3 text-sm">Retention</div>
                 <div data-step="explorer" class="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3 text-sm">Explorer</div>
                 <div data-step="registration" class="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3 text-sm">Registration</div>
             </div>

--- a/app/js/ui/onboarding-wizard.js
+++ b/app/js/ui/onboarding-wizard.js
@@ -11,7 +11,7 @@ import {
 
 const STORAGE_PERSIST_FLAG = 'poolstellar_storage_persist_prompted';
 const DEFAULT_EXPLORER_BASE_URL = 'https://stellar.expert/explorer/testnet';
-const STEP_ORDER = ['disclaimer', 'storage', 'keys', 'retention', 'explorer', 'registration'];
+const STEP_ORDER = ['disclaimer', 'retention', 'storage', 'keys', 'explorer', 'registration'];
 
 function hasStorageManager() {
     return (
@@ -287,9 +287,9 @@ export async function runOnboardingWizard({
 
     const steps = [
         ...(!disclaimerState?.accepted ? ['disclaimer'] : []),
+        ...(needsNotificationStep || !bootnodeSetting || bootnodeRequired ? ['retention'] : []),
         ...(needsStorageStep ? ['storage'] : []),
         ...(!keysExist ? ['keys'] : []),
-        ...(needsNotificationStep || !bootnodeSetting || bootnodeRequired ? ['retention'] : []),
         [explorerSetting?.baseUrl ? null : 'explorer'].filter(Boolean),
         // Only offer registration when the registry is fully synced AND there's no
         // entry. If the local registry hasn't synced yet, the lookup can't prove the
@@ -578,6 +578,9 @@ export async function runOnboardingWizard({
                             }
                             if (enabled && url && !url.startsWith('https://')) {
                                 throw new Error('Bootnode URL must start with https://');
+                            }
+                            if (enableNotifications && Notification.permission === 'default') {
+                                await requestNotificationPermission();
                             }
                             await storage.setSetting('bootnode_config', { enabled, url });
                             state.bootnode = { enabled, url };


### PR DESCRIPTION
Changes the order in which we onboard the user, with the goal of making Chrome-based browsers grant permanent storage. Chrome automatically handles the permission, but having users allow notifications first can be a helpful hint to prompt the browser to grant the permission.

- Now we ask for retention before asking for storage.
- If the user does not click "Allow Notifications", we force the browser to ask when he clicks "Save retention".