### PR TITLE
Gvk new memo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,11 +62,16 @@ ark-std = { version = "0.6.0", default-features = false, features = ["std"] }
 async-trait = { version = "0.1.91", default-features = false }
 base64 = { version = "0.22", default-features = false, features = ["alloc"] }
 cfg-if = { version = "1", default-features = false }
-clap = { version = "4.6.3", default-features = false, features = ["std", "color",
-  "help",
-  "usage",
-  "error-context",
-  "suggestions", "derive", "env"] }
+clap = { version = "4.6.3", default-features = false, features = [
+    "std",
+    "color",
+    "help",
+    "usage",
+    "error-context",
+    "suggestions",
+    "derive",
+    "env",
+] }
 console_error_panic_hook = { version = "0.1.7", default-features = false }
 futures = { version = "0.3.33", default-features = false, features = ["async-await"] }
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
@@ -88,13 +93,13 @@ sqlite-wasm-rs = { version = "0.5.5", default-features = false }
 sqlite-wasm-vfs = { version = "0.2.0", default-features = false }
 thiserror = { version = "2", default-features = false }
 tokio = { version = "1", default-features = false }
+tracing = { version = "0.1", default-features = false, features = ["std", "release_max_level_info", "attributes"] }
+tracing-log = { version = "0.2", default-features = false, features = ["log-tracer", "std"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 uint = { version = "0.10", default-features = false }
 wasm-bindgen = { version = "0.2", default-features = false, features = ["serde-serialize"] }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
 wasm-bindgen-test = { version = "0.3", default-features = false, features = ["std"] }
-tracing = { version = "0.1", default-features = false, features = ["std", "release_max_level_info", "attributes"] }
-tracing-log = { version = "0.2", default-features = false, features = ["log-tracer", "std"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 # see also https://github.com/NethermindEth/stellar-private-payments/issues/192
 wasmer = { version = "7.2", default-features = false }
 web-sys = { version = "0.3", features = ["console", "WorkerGlobalScope", "Response", "Request", "RequestInit", "RequestMode", "Window", "Event", "Cache", "CacheStorage"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,9 +19,6 @@ anyhow.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 log.workspace = true
-tracing = { workspace = true, features = ["attributes"] }
-tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }
-tracing-log = { workspace = true }
 # Not referenced directly, but pulls in reqwest's rustls TLS backend for the
 # binary (the `stellar` crate depends on reqwest without a TLS feature).
 reqwest = { workspace = true, features = ["rustls"] }
@@ -29,6 +26,9 @@ serde.workspace = true
 serde_json.workspace = true
 stellar-private-payments-sdk.workspace = true
 toml = "0.8"
+tracing = { workspace = true, features = ["attributes"] }
+tracing-log = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }
 types.workspace = true
 
 [lints]

--- a/sdk/client/Cargo.toml
+++ b/sdk/client/Cargo.toml
@@ -15,13 +15,13 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 disclosure = { workspace = true }
 futures = { workspace = true }
-tracing = { workspace = true }
 prover = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 state = { workspace = true }
 stellar = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 tx-planner = { workspace = true }
 types = { workspace = true, features = ["rusqlite"] }
 witness = { workspace = true }

--- a/sdk/state/Cargo.toml
+++ b/sdk/state/Cargo.toml
@@ -16,10 +16,10 @@ types = { workspace = true, features = ["rusqlite"] }
 # external
 anyhow = { workspace = true }
 hex = { workspace = true }
-tracing = { workspace = true }
 rusqlite_migration = { version = "2.6.0", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }
+tracing = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # external

--- a/sdk/stellar/Cargo.toml
+++ b/sdk/stellar/Cargo.toml
@@ -17,7 +17,6 @@ base64 = { workspace = true }
 ed25519-dalek = { version = "2.2", default-features = false, features = ["digest", "zeroize"] }
 futures = { workspace = true, features = ["executor"] }
 http = "1.4.2"
-tracing = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde-aux = "4.7.0"
@@ -27,6 +26,7 @@ sha3 = { version = "0.11", default-features = false }
 stellar-strkey = "0.0.18"
 stellar-xdr = { version = "27.0.0", features = ["serde", "base64", "std", "alloc"] }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = { workspace = true }

--- a/sdk/tests/Cargo.toml
+++ b/sdk/tests/Cargo.toml
@@ -15,8 +15,8 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 stellar-private-payments-sdk = { workspace = true }
-tracing-subscriber = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 types = { workspace = true, features = ["rusqlite"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/sdk/types/Cargo.toml
+++ b/sdk/types/Cargo.toml
@@ -22,9 +22,9 @@ uint = { workspace = true }
 zeroize = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tracing-subscriber = { workspace = true }
 # external
 rusqlite = { workspace = true, optional = true, features = ["bundled"] }
+tracing-subscriber = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # external

--- a/sdk/types/src/gvk.rs
+++ b/sdk/types/src/gvk.rs
@@ -60,14 +60,24 @@ pub enum GlobalViewKeyMode {
 ///
 /// # Note ordering vs. the circuit
 ///
-/// The circuit's own public outputs (`GvkNotes` in
-/// `circuits/src/globalViewKey.circom`) are a single flat array ordered
-/// inputs-first-then-outputs, with per-note index `idx = k` for input `k` and
-/// `idx = nIns + k` for output `k`. This type deliberately splits that flat
-/// array back into two independently-indexed fields (`inputs`, `outputs`)
-/// for clarity. Code that talks to the circuit's public inputs/outputs
-/// directly must re-flatten using that same `idx` formula rather than assume
-/// a 1:1 array layout with this struct.
+/// The circuit (`GvkNotes` in `circuits/src/globalViewKey.circom`)
+/// binds every note's keystream to a per-note encryption index `idx` that is
+/// **always** `idx = k` for input `k` and `idx = nIns + k` for output `k`,
+/// regardless of mode. Its *public output array*, however, is laid out
+/// differently per mode, and does not always match `idx`:
+///
+/// - Traceable (`encryptInputs == 1`): the array holds `nIns + nOuts`
+///   entries, inputs first, so array position equals `idx` exactly.
+/// - View-only (`encryptInputs == 0`): the array holds only `nOuts`
+///   entries — output `k` sits at array position `k`, even though its `idx`
+///   is still `nIns + k`. There is no input segment at all.
+///
+/// This type deliberately splits the circuit's array back into two
+/// independently `0..N`-indexed fields (`inputs`, `outputs`), which follow
+/// the *position* convention above, not the `idx` one. Code that talks to
+/// the circuit's public inputs/outputs directly must re-derive `idx` with
+/// the formula above rather than read it off the array position, since the
+/// two coincide only in traceable mode.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct GlobalViewKeyMemo {

--- a/sdk/types/src/gvk.rs
+++ b/sdk/types/src/gvk.rs
@@ -1,0 +1,436 @@
+//! Global View Key (GVK) memo types.
+//!
+//! Data structures + serialization for the off-chain memo a pool
+//! administrator uses to audit notes, mirroring the in-circuit encryption in
+//! `circuits/src/globalViewKey.circom`. No encryption/decryption logic lives
+//! here. See `circuits/src/test/utils/global_view_key.rs` for that.
+
+use crate::{Field, PolicyFlags};
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+
+/// Current `GlobalViewKeyMemo` schema version.
+pub const GLOBAL_VIEW_KEY_MEMO_VERSION: u32 = 1;
+
+/// A Baby JubJub curve point.
+///
+/// Baby JubJub's base field equals BN254's scalar field, so coordinates are
+/// represented with the existing [`Field`] type. This struct does not
+/// validate that `(x, y)` lies on the curve; that check requires curve
+/// arithmetic this crate does not depend on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct BabyJubJubPoint {
+    pub x: Field,
+    pub y: Field,
+}
+
+/// One note's GVK ciphertext: the ephemeral pubkey and the three encrypted
+/// fields: `(R, c1, c2, c3)`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GlobalViewKeyCiphertext {
+    /// Ephemeral public key `R = r * G`.
+    pub r: BabyJubJubPoint,
+    /// Encrypted note public key.
+    pub c1: Field,
+    /// Encrypted note amount.
+    pub c2: Field,
+    /// Encrypted note blinding.
+    pub c3: Field,
+}
+
+/// Which notes a [`GlobalViewKeyMemo`] carries ciphertexts for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GlobalViewKeyMode {
+    /// Output notes only.
+    ViewOnly,
+    /// Input and output notes.
+    Traceable,
+}
+
+/// The Global View Key memo for a single transaction.
+///
+/// Bundles the GVK ciphertexts for every note in the transaction under a
+/// shared `nonce`. `outputs` always has one entry per output slot, in output
+/// order. `inputs` is `Some` (one entry per input slot, in input order) iff
+/// `mode` is [`GlobalViewKeyMode::Traceable`], and `None` for
+/// [`GlobalViewKeyMode::ViewOnly`].
+///
+/// # Note ordering vs. the circuit
+///
+/// The circuit's own public outputs (`GvkNotes` in
+/// `circuits/src/globalViewKey.circom`) are a single flat array ordered
+/// inputs-first-then-outputs, with per-note index `idx = k` for input `k` and
+/// `idx = nIns + k` for output `k`. This type deliberately splits that flat
+/// array back into two independently-indexed fields (`inputs`, `outputs`)
+/// for clarity. Code that talks to the circuit's public inputs/outputs
+/// directly must re-flatten using that same `idx` formula rather than assume
+/// a 1:1 array layout with this struct.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GlobalViewKeyMemo {
+    /// Memo schema version.
+    pub version: u32,
+    /// View-only vs. traceable, see field docs on [`GlobalViewKeyMemo`].
+    pub mode: GlobalViewKeyMode,
+    /// The administrator Baby JubJub public key `D` this memo claims to be
+    /// encrypted under.
+    ///
+    /// This is informational only and is not verified by
+    /// [`GlobalViewKeyMemo::validate`]: the memo is a portable artifact that may be
+    /// inspected apart from live pool configuration. Callers that need the
+    /// security guarantee must cross-check this value against the pool's registered GVK authority
+    /// key themselves.
+    pub admin_pub_key: BabyJubJubPoint,
+    /// Per-transaction nonce bound into every ciphertext in this memo.
+    pub nonce: Field,
+    /// Output-note ciphertexts, one per output slot, in output order.
+    pub outputs: Vec<GlobalViewKeyCiphertext>,
+    /// Input-note ciphertexts, one per input slot, in input order. `Some`
+    /// iff `mode == GlobalViewKeyMode::Traceable`.
+    pub inputs: Option<Vec<GlobalViewKeyCiphertext>>,
+}
+
+impl GlobalViewKeyMemo {
+    /// Validates schema-level invariants: version, output/input slot counts
+    /// against the transaction's actual note counts, and `mode`/`inputs`
+    /// consistency. Does not verify any cryptographic material.
+    pub fn validate(&self, n_inputs: usize, n_outputs: usize) -> Result<()> {
+        if self.version != GLOBAL_VIEW_KEY_MEMO_VERSION {
+            return Err(anyhow!("Unsupported global view key memo version"));
+        }
+        if self.outputs.len() != n_outputs {
+            return Err(anyhow!("Outputs length does not match n_outputs"));
+        }
+        match (self.mode, &self.inputs) {
+            (GlobalViewKeyMode::ViewOnly, None) => Ok(()),
+            (GlobalViewKeyMode::ViewOnly, Some(_)) => {
+                Err(anyhow!("View-only memo must not carry input ciphertexts"))
+            }
+            (GlobalViewKeyMode::Traceable, None) => {
+                Err(anyhow!("Traceable memo must carry input ciphertexts"))
+            }
+            (GlobalViewKeyMode::Traceable, Some(inputs)) => {
+                if inputs.len() != n_inputs {
+                    return Err(anyhow!("Inputs length does not match n_inputs"));
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Pool-level Global View Key configuration.
+///
+/// Orthogonal to [`PolicyFlags`] rather than a bit on it: view-only and
+/// traceable are mutually exclusive (unlike allowlist/blocklist, which can be
+/// combined). See [`gvk_circuit_stem`] for how the two combine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GvkMode {
+    /// No Global View Key encryption. Pool uses the vanila policy-transact circuits.
+    #[default]
+    Off,
+    /// Output notes only.
+    ViewOnly,
+    /// Input and output notes.
+    Traceable,
+}
+
+impl GvkMode {
+    /// Word used in circuit stems for this mode. `None` for [`GvkMode::Off`],
+    /// which contributes no suffix at all (see [`gvk_circuit_stem`]).
+    fn stem_word(self) -> Option<&'static str> {
+        match self {
+            GvkMode::Off => None,
+            GvkMode::ViewOnly => Some("viewonly"),
+            GvkMode::Traceable => Some("traceable"),
+        }
+    }
+
+    fn from_stem_word(word: &str) -> Result<Self> {
+        match word {
+            "viewonly" => Ok(GvkMode::ViewOnly),
+            "traceable" => Ok(GvkMode::Traceable),
+            _ => Err(anyhow!("Unknown GVK circuit mode word: {word}")),
+        }
+    }
+}
+
+/// Circuit artifact stem prefix for GVK-composed policy-transact circuits,
+/// e.g. `policy_tx_gvk_2_2_A_viewonly`.
+const POLICY_TX_GVK_2_2: &str = "policy_tx_gvk_2_2";
+
+/// Composes [`PolicyFlags`] and [`GvkMode`] into a circuit artifact stem.
+///
+/// `GvkMode::Off` maps to `policy_flags.circuit_stem()` unchanged.
+///  Non-GVK pools are untouched by this function.
+/// `ViewOnly`/`Traceable` produce one of the 8 stems registered in
+/// `circuits/build.rs` as `POLICY_GLOBAL_VIEW_KEY_CIRCUITS`, of the shape
+/// `policy_tx_gvk_2_2[_{A|B|AB}]_{viewonly|traceable}`.
+pub fn gvk_circuit_stem(policy_flags: PolicyFlags, gvk_mode: GvkMode) -> String {
+    let Some(mode_word) = gvk_mode.stem_word() else {
+        return policy_flags.circuit_stem();
+    };
+
+    let suffix = policy_flags.circuit_suffix();
+    if suffix.is_empty() {
+        format!("{POLICY_TX_GVK_2_2}_{mode_word}")
+    } else {
+        format!("{POLICY_TX_GVK_2_2}_{suffix}_{mode_word}")
+    }
+}
+
+/// Parses a GVK circuit stem produced by [`gvk_circuit_stem`] back into its
+/// [`PolicyFlags`]/[`GvkMode`] components.
+///
+/// Only accepts stems with a GVK mode word. Use [`PolicyFlags::from_stem`]
+/// for plain (non-GVK) stems.
+pub fn parse_gvk_circuit_stem(stem: &str) -> Result<(PolicyFlags, GvkMode)> {
+    let rest = stem
+        .strip_prefix(POLICY_TX_GVK_2_2)
+        .ok_or_else(|| anyhow!("Not a GVK policy transact stem: {stem}"))?;
+
+    let (suffix, mode_word) = match rest.strip_prefix('_') {
+        Some(rest) => match rest.split_once('_') {
+            Some((suffix, mode_word)) => (suffix, mode_word),
+            None => ("", rest),
+        },
+        None => return Err(anyhow!("Not a GVK policy transact stem: {stem}")),
+    };
+
+    let mode = GvkMode::from_stem_word(mode_word)?;
+    let flags = if suffix.is_empty() {
+        PolicyFlags::EMPTY
+    } else {
+        PolicyFlags::from_stem(&format!("policy_tx_2_2_{suffix}"))?
+    };
+
+    Ok((flags, mode))
+}
+
+/// All 8 GVK circuit stems registered in `circuits/build.rs` as
+/// `POLICY_GLOBAL_VIEW_KEY_CIRCUITS`: every [`PolicyFlags`] combination
+/// crossed with [`GvkMode::ViewOnly`] and [`GvkMode::Traceable`].
+pub fn all_gvk_circuit_stems() -> Vec<String> {
+    PolicyFlags::all_flags()
+        .into_iter()
+        .flat_map(|flags| {
+            [GvkMode::ViewOnly, GvkMode::Traceable]
+                .into_iter()
+                .map(move |mode| gvk_circuit_stem(flags, mode))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    // Small fixed offsets over test seeds cannot overflow.
+    #![allow(clippy::arithmetic_side_effects)]
+
+    use super::*;
+
+    fn field(value: u64) -> Field {
+        Field(crate::U256::from(value))
+    }
+
+    fn point(x: u64, y: u64) -> BabyJubJubPoint {
+        BabyJubJubPoint {
+            x: field(x),
+            y: field(y),
+        }
+    }
+
+    fn ciphertext(seed: u64) -> GlobalViewKeyCiphertext {
+        GlobalViewKeyCiphertext {
+            r: point(seed, seed + 1),
+            c1: field(seed + 2),
+            c2: field(seed + 3),
+            c3: field(seed + 4),
+        }
+    }
+
+    fn view_only_memo() -> GlobalViewKeyMemo {
+        GlobalViewKeyMemo {
+            version: GLOBAL_VIEW_KEY_MEMO_VERSION,
+            mode: GlobalViewKeyMode::ViewOnly,
+            admin_pub_key: point(1, 2),
+            nonce: field(3),
+            outputs: vec![ciphertext(10), ciphertext(20)],
+            inputs: None,
+        }
+    }
+
+    fn traceable_memo() -> GlobalViewKeyMemo {
+        GlobalViewKeyMemo {
+            inputs: Some(vec![ciphertext(30), ciphertext(40)]),
+            ..view_only_memo_with_mode(GlobalViewKeyMode::Traceable)
+        }
+    }
+
+    fn view_only_memo_with_mode(mode: GlobalViewKeyMode) -> GlobalViewKeyMemo {
+        GlobalViewKeyMemo {
+            mode,
+            ..view_only_memo()
+        }
+    }
+
+    #[test]
+    fn view_only_memo_round_trips_and_validates() -> Result<()> {
+        let memo = view_only_memo();
+        let json = serde_json::to_string(&memo)?;
+        let parsed: GlobalViewKeyMemo = serde_json::from_str(&json)?;
+
+        assert_eq!(parsed, memo);
+        parsed.validate(2, 2)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn traceable_memo_round_trips_and_validates() -> Result<()> {
+        let memo = traceable_memo();
+        let json = serde_json::to_string(&memo)?;
+        let parsed: GlobalViewKeyMemo = serde_json::from_str(&json)?;
+
+        assert_eq!(parsed, memo);
+        parsed.validate(2, 2)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn fields_serialize_as_0x_hex_not_decimal() -> Result<()> {
+        let memo = view_only_memo();
+        let json = serde_json::to_string(&memo)?;
+
+        assert!(
+            json.contains(&format!("\"nonce\":\"{}\"", field(3).to_0x_hex_be())),
+            "nonce should serialize as 0x-hex, got: {json}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn memo_rejects_unknown_fields() {
+        let json = r#"{
+            "version": 1,
+            "unexpected": true,
+            "mode": "viewOnly",
+            "adminPubKey": {"x": "0x0000000000000000000000000000000000000000000000000000000000000001", "y": "0x0000000000000000000000000000000000000000000000000000000000000002"},
+            "nonce": "0x0000000000000000000000000000000000000000000000000000000000000003",
+            "outputs": [],
+            "inputs": null
+        }"#;
+
+        assert!(serde_json::from_str::<GlobalViewKeyMemo>(json).is_err());
+    }
+
+    #[test]
+    fn ciphertext_rejects_unknown_fields() {
+        let json = r#"{
+            "r": {"x": "0x0000000000000000000000000000000000000000000000000000000000000001", "y": "0x0000000000000000000000000000000000000000000000000000000000000002"},
+            "c1": "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "c2": "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "c3": "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "unexpected": true
+        }"#;
+
+        assert!(serde_json::from_str::<GlobalViewKeyCiphertext>(json).is_err());
+    }
+
+    #[test]
+    fn point_rejects_unknown_fields() {
+        let json = r#"{
+            "x": "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "y": "0x0000000000000000000000000000000000000000000000000000000000000002",
+            "unexpected": true
+        }"#;
+
+        assert!(serde_json::from_str::<BabyJubJubPoint>(json).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_unsupported_version() {
+        let mut memo = view_only_memo();
+        memo.version = 2;
+
+        assert!(memo.validate(2, 2).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_output_count_mismatch() {
+        let memo = view_only_memo();
+
+        assert!(memo.validate(2, 3).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_view_only_with_inputs_present() {
+        let memo = GlobalViewKeyMemo {
+            inputs: Some(vec![ciphertext(30)]),
+            ..view_only_memo()
+        };
+
+        assert!(memo.validate(2, 2).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_traceable_with_missing_inputs() {
+        let memo = view_only_memo_with_mode(GlobalViewKeyMode::Traceable);
+
+        assert!(memo.validate(2, 2).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_traceable_input_count_mismatch() {
+        let memo = traceable_memo();
+
+        assert!(memo.validate(3, 2).is_err());
+    }
+
+    #[test]
+    fn gvk_off_matches_plain_policy_stem_for_all_flag_combos() {
+        for flags in crate::PolicyFlags::all_flags() {
+            assert_eq!(gvk_circuit_stem(flags, GvkMode::Off), flags.circuit_stem());
+        }
+    }
+
+    #[test]
+    fn gvk_circuit_stem_matches_known_stems_and_round_trips() {
+        let expected = [
+            "policy_tx_gvk_2_2_viewonly",
+            "policy_tx_gvk_2_2_traceable",
+            "policy_tx_gvk_2_2_A_viewonly",
+            "policy_tx_gvk_2_2_A_traceable",
+            "policy_tx_gvk_2_2_B_viewonly",
+            "policy_tx_gvk_2_2_B_traceable",
+            "policy_tx_gvk_2_2_AB_viewonly",
+            "policy_tx_gvk_2_2_AB_traceable",
+        ];
+
+        let stems = all_gvk_circuit_stems();
+        assert_eq!(
+            stems, expected,
+            "stems must match circuits/build.rs exactly"
+        );
+
+        for stem in &stems {
+            let (flags, mode) = parse_gvk_circuit_stem(stem).expect("parse known stem");
+            assert_eq!(gvk_circuit_stem(flags, mode), *stem);
+        }
+    }
+
+    #[test]
+    fn parse_gvk_circuit_stem_rejects_non_gvk_stem() {
+        assert!(parse_gvk_circuit_stem("policy_tx_2_2_A").is_err());
+    }
+
+    #[test]
+    fn parse_gvk_circuit_stem_rejects_unknown_mode_word() {
+        assert!(parse_gvk_circuit_stem("policy_tx_gvk_2_2_A_bogus").is_err());
+    }
+}

--- a/sdk/types/src/gvk.rs
+++ b/sdk/types/src/gvk.rs
@@ -81,8 +81,8 @@ pub struct GlobalViewKeyMemo {
     /// This is informational only and is not verified by
     /// [`GlobalViewKeyMemo::validate`]: the memo is a portable artifact that may be
     /// inspected apart from live pool configuration. Callers that need the
-    /// security guarantee must cross-check this value against the pool's registered GVK authority
-    /// key themselves.
+    /// security guarantee must cross-check this value against the pool's
+    /// registered GVK authority key themselves.
     pub admin_pub_key: BabyJubJubPoint,
     /// Per-transaction nonce bound into every ciphertext in this memo.
     pub nonce: Field,
@@ -130,7 +130,8 @@ impl GlobalViewKeyMemo {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum GvkMode {
-    /// No Global View Key encryption. Pool uses the vanila policy-transact circuits.
+    /// No Global View Key encryption. Pool uses the vanilla policy-transact
+    /// circuits.
     #[default]
     Off,
     /// Output notes only.

--- a/sdk/types/src/gvk.rs
+++ b/sdk/types/src/gvk.rs
@@ -66,11 +66,11 @@ pub enum GlobalViewKeyMode {
 /// regardless of mode. Its *public output array*, however, is laid out
 /// differently per mode, and does not always match `idx`:
 ///
-/// - Traceable (`encryptInputs == 1`): the array holds `nIns + nOuts`
-///   entries, inputs first, so array position equals `idx` exactly.
-/// - View-only (`encryptInputs == 0`): the array holds only `nOuts`
-///   entries — output `k` sits at array position `k`, even though its `idx`
-///   is still `nIns + k`. There is no input segment at all.
+/// - Traceable (`encryptInputs == 1`): the array holds `nIns + nOuts` entries,
+///   inputs first, so array position equals `idx` exactly.
+/// - View-only (`encryptInputs == 0`): the array holds only `nOuts` entries —
+///   output `k` sits at array position `k`, even though its `idx` is still
+///   `nIns + k`. There is no input segment at all.
 ///
 /// This type deliberately splits the circuit's array back into two
 /// independently `0..N`-indexed fields (`inputs`, `outputs`), which follow

--- a/sdk/types/src/lib.rs
+++ b/sdk/types/src/lib.rs
@@ -50,6 +50,13 @@ pub struct PoolConfigEntry {
     pub asset: AssetDescriptor,
     /// ASP policy flags for transact proofs.
     pub policy_flags: PolicyFlags,
+    /// Global View Key mode for this pool. Defaults to [`GvkMode::Off`] for backwards compatibility
+    #[serde(default)]
+    pub gvk_mode: GvkMode,
+    /// Pool administrator's Baby JubJub public key `D`, informational only
+    /// not verified. `None` when `gvk_mode` is [`GvkMode::Off`].
+    #[serde(default)]
+    pub gvk_authority_pub_key: Option<BabyJubJubPoint>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/sdk/types/src/lib.rs
+++ b/sdk/types/src/lib.rs
@@ -2,12 +2,14 @@ mod amounts;
 mod chain_data;
 mod disclosure;
 mod ext_data;
+mod gvk;
 mod policy_tx;
 pub use amounts::*;
 use anyhow::{Result, anyhow};
 pub use chain_data::*;
 pub use disclosure::*;
 pub use ext_data::*;
+pub use gvk::*;
 pub use policy_tx::*;
 
 use serde::{Deserialize, Serialize};

--- a/sdk/types/src/lib.rs
+++ b/sdk/types/src/lib.rs
@@ -50,7 +50,8 @@ pub struct PoolConfigEntry {
     pub asset: AssetDescriptor,
     /// ASP policy flags for transact proofs.
     pub policy_flags: PolicyFlags,
-    /// Global View Key mode for this pool. Defaults to [`GvkMode::Off`] for backwards compatibility
+    /// Global View Key mode for this pool. Defaults to [`GvkMode::Off`] for
+    /// backwards compatibility
     #[serde(default)]
     pub gvk_mode: GvkMode,
     /// Pool administrator's Baby JubJub public key `D`, informational only
@@ -549,3 +550,94 @@ impl_byte_wrapper!(EncryptionPrivateKey);
 impl_byte_wrapper!(EncryptionPublicKey);
 impl_byte_wrapper!(NotePrivateKey);
 impl_byte_wrapper!(NotePublicKey);
+
+#[cfg(test)]
+mod pool_config_gvk_tests {
+    use super::*;
+
+    /// A snapshot of a real pre-GVK deployment config
+    const LEGACY_PRE_GVK_DEPLOYMENTS: &str = r#"{
+        "network": "testnet",
+        "deployer": "GCBU2YCJGVLRSPPFK3ADYNUEH2W6ZFNNJLX6IHCEZT54VOHZZNYNHXDG",
+        "admin": "GCBU2YCJGVLRSPPFK3ADYNUEH2W6ZFNNJLX6IHCEZT54VOHZZNYNHXDG",
+        "asp_membership": "CDEFDJPNVWDWUUHGHGGZ56FEPSSJHQLGRKS6OWIRKGRYRWSBNMLW7J5K",
+        "asp_non_membership": "CBEPJBHP6X4K7KWLRPFUGPRS3OM6HWXTWIVN3M2LCGZZHCCTHHSYAAF3",
+        "verifiers": {
+            "B": "CCNOLQUUPEZTPNZ7LMS3PYE5NVYNNTKTHJP7HDK4NJMH4JPKFP7HOHD4",
+            "AB": "CACW63UB56MYFBPEOU2HSWLUH6ZME3CGFIZNK6AZYGVUHDNR3Q3TTK3L"
+        },
+        "public_key_registry": "CDK75EQA2G4E4N34CWY7ALJ4EIQMNVBOFMHAVIF3BBY7IUDNHKHNDA36",
+        "pools": [
+            {
+                "poolContractId": "CAWCZ6EO4PM5EZOH5K7XSW3R46DGLOT3XSEH36OA5EOZUSJ5XS7BX6XI",
+                "tokenContractId": "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+                "deploymentLedger": 3773948,
+                "enabled": true,
+                "policyFlags": ["blocklist"],
+                "asset": {"kind": "native"}
+            },
+            {
+                "poolContractId": "CAJJT5YV4BMFTHEOO5FGO2G56TEJKM4G4FW7FS4DYBLLLLHSAYUZWT74",
+                "tokenContractId": "CCUUDM434BMZMYWYDITHFXHDMIVTGGD6T2I5UKNX5BSLXLW7HVR4MCGZ",
+                "deploymentLedger": 3773952,
+                "enabled": true,
+                "policyFlags": ["allowlist", "blocklist"],
+                "asset": {
+                    "kind": "classic",
+                    "code": "EURC",
+                    "issuer": "GB3Q6QDZYTHWT7E5PVS3W7FUT5GVAFC5KSZFFLPU25GO7VTC3NM2ZTVO"
+                }
+            }
+        ]
+    }"#;
+
+    #[test]
+    fn legacy_pre_gvk_deployments_json_parses_with_gvk_off() -> Result<()> {
+        let config: ContractConfig = serde_json::from_str(LEGACY_PRE_GVK_DEPLOYMENTS)?;
+
+        assert!(
+            !config.pools.is_empty(),
+            "fixture must have pools to be a meaningful test"
+        );
+        for pool in &config.pools {
+            assert_eq!(pool.gvk_mode, GvkMode::Off);
+            assert_eq!(pool.gvk_authority_pub_key, None);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn pool_config_entry_round_trips_with_gvk_fields_set() -> Result<()> {
+        let json = r#"{
+            "poolContractId": "CPOOL",
+            "tokenContractId": "CTOKEN",
+            "deploymentLedger": 1,
+            "enabled": true,
+            "asset": {"kind": "native"},
+            "policyFlags": [],
+            "gvkMode": "traceable",
+            "gvkAuthorityPubKey": {
+                "x": "0x0000000000000000000000000000000000000000000000000000000000000001",
+                "y": "0x0000000000000000000000000000000000000000000000000000000000000002"
+            }
+        }"#;
+
+        let pool: PoolConfigEntry = serde_json::from_str(json)?;
+        assert_eq!(pool.gvk_mode, GvkMode::Traceable);
+        assert_eq!(
+            pool.gvk_authority_pub_key,
+            Some(BabyJubJubPoint {
+                x: Field(U256::from(1)),
+                y: Field(U256::from(2)),
+            })
+        );
+
+        let round_tripped = serde_json::to_string(&pool)?;
+        let parsed: PoolConfigEntry = serde_json::from_str(&round_tripped)?;
+        assert_eq!(parsed.gvk_mode, pool.gvk_mode);
+        assert_eq!(parsed.gvk_authority_pub_key, pool.gvk_authority_pub_key);
+
+        Ok(())
+    }
+}

--- a/sdk/types/src/lib.rs
+++ b/sdk/types/src/lib.rs
@@ -60,7 +60,7 @@ pub struct PoolConfigEntry {
     pub gvk_mode: GvkMode,
     /// Pool administrator's Baby JubJub public key `D`, informational only
     /// not verified. `None` when `gvk_mode` is [`GvkMode::Off`].
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gvk_authority_pub_key: Option<BabyJubJubPoint>,
 }
 
@@ -595,58 +595,6 @@ impl_byte_wrapper!(NotePublicKey);
 #[cfg(test)]
 mod pool_config_gvk_tests {
     use super::*;
-
-    /// A snapshot of a real pre-GVK deployment config
-    const LEGACY_PRE_GVK_DEPLOYMENTS: &str = r#"{
-        "network": "testnet",
-        "deployer": "GCBU2YCJGVLRSPPFK3ADYNUEH2W6ZFNNJLX6IHCEZT54VOHZZNYNHXDG",
-        "admin": "GCBU2YCJGVLRSPPFK3ADYNUEH2W6ZFNNJLX6IHCEZT54VOHZZNYNHXDG",
-        "asp_membership": "CDEFDJPNVWDWUUHGHGGZ56FEPSSJHQLGRKS6OWIRKGRYRWSBNMLW7J5K",
-        "asp_non_membership": "CBEPJBHP6X4K7KWLRPFUGPRS3OM6HWXTWIVN3M2LCGZZHCCTHHSYAAF3",
-        "verifiers": {
-            "B": "CCNOLQUUPEZTPNZ7LMS3PYE5NVYNNTKTHJP7HDK4NJMH4JPKFP7HOHD4",
-            "AB": "CACW63UB56MYFBPEOU2HSWLUH6ZME3CGFIZNK6AZYGVUHDNR3Q3TTK3L"
-        },
-        "public_key_registry": "CDK75EQA2G4E4N34CWY7ALJ4EIQMNVBOFMHAVIF3BBY7IUDNHKHNDA36",
-        "pools": [
-            {
-                "poolContractId": "CAWCZ6EO4PM5EZOH5K7XSW3R46DGLOT3XSEH36OA5EOZUSJ5XS7BX6XI",
-                "tokenContractId": "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
-                "deploymentLedger": 3773948,
-                "enabled": true,
-                "policyFlags": ["blocklist"],
-                "asset": {"kind": "native"}
-            },
-            {
-                "poolContractId": "CAJJT5YV4BMFTHEOO5FGO2G56TEJKM4G4FW7FS4DYBLLLLHSAYUZWT74",
-                "tokenContractId": "CCUUDM434BMZMYWYDITHFXHDMIVTGGD6T2I5UKNX5BSLXLW7HVR4MCGZ",
-                "deploymentLedger": 3773952,
-                "enabled": true,
-                "policyFlags": ["allowlist", "blocklist"],
-                "asset": {
-                    "kind": "classic",
-                    "code": "EURC",
-                    "issuer": "GB3Q6QDZYTHWT7E5PVS3W7FUT5GVAFC5KSZFFLPU25GO7VTC3NM2ZTVO"
-                }
-            }
-        ]
-    }"#;
-
-    #[test]
-    fn legacy_pre_gvk_deployments_json_parses_with_gvk_off() -> Result<()> {
-        let config: ContractConfig = serde_json::from_str(LEGACY_PRE_GVK_DEPLOYMENTS)?;
-
-        assert!(
-            !config.pools.is_empty(),
-            "fixture must have pools to be a meaningful test"
-        );
-        for pool in &config.pools {
-            assert_eq!(pool.gvk_mode, GvkMode::Off);
-            assert_eq!(pool.gvk_authority_pub_key, None);
-        }
-
-        Ok(())
-    }
 
     #[test]
     fn pool_config_entry_round_trips_with_gvk_fields_set() -> Result<()> {

--- a/sdk/web/Cargo.toml
+++ b/sdk/web/Cargo.toml
@@ -34,9 +34,9 @@ serde = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }
 sha2 = { workspace = true }
+tracing = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
-tracing = { workspace = true }
 web-sys = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -47,12 +47,12 @@ sqlite-wasm-vfs = { workspace = true }
 sha2 = { workspace = true }
 types = { workspace = true }
 
+[dev-dependencies]
+wasm-bindgen-test = { workspace = true }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
 tracing-subscriber = { workspace = true }
-
-[dev-dependencies]
-wasm-bindgen-test = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Small PR to support the new encrypted memos required by global view key support:
- Creates new `sdk/types/gvk.rs`.
- Supports view-only and traceable memos.
- It's backward compatible with all previous policy configurations.

Closes #219 #277 #278 #279