### PR TITLE
feat(admin): link ASP contract IDs and state to the block explorer

### DIFF
--- a/app/admin.html
+++ b/app/admin.html
@@ -93,11 +93,17 @@
                     <!-- Contracts -->
                     <div class="rounded-2xl border border-white/8 bg-ink-900/70 p-5 space-y-4">
                         <div>
-                            <label class="text-xs font-medium uppercase tracking-[0.22em] text-slate-500" for="membershipContract">ASP Membership Contract ID</label>
+                            <div class="flex items-center justify-between gap-2">
+                                <label class="text-xs font-medium uppercase tracking-[0.22em] text-slate-500" for="membershipContract">ASP Membership Contract ID</label>
+                                <a id="membershipContractLink" href="#" target="_blank" rel="noopener noreferrer" title="Open in block explorer" class="shrink-0 text-[10px] font-medium uppercase tracking-wide text-cyan-300/80 transition hover:text-cyan-100 hover:underline">View &#8599;</a>
+                            </div>
                             <input class="mt-2 w-full rounded-xl border border-white/10 bg-ink-950 px-4 py-3 font-mono text-sm text-slate-100 outline-none transition focus:border-cyan-300/40" id="membershipContract" type="text" placeholder="C..." autocomplete="off" spellcheck="false" />
                         </div>
                         <div>
-                            <label class="text-xs font-medium uppercase tracking-[0.22em] text-slate-500" for="nonMembershipContract">ASP Non-Membership Contract ID</label>
+                            <div class="flex items-center justify-between gap-2">
+                                <label class="text-xs font-medium uppercase tracking-[0.22em] text-slate-500" for="nonMembershipContract">ASP Non-Membership Contract ID</label>
+                                <a id="nonMembershipContractLink" href="#" target="_blank" rel="noopener noreferrer" title="Open in block explorer" class="shrink-0 text-[10px] font-medium uppercase tracking-wide text-cyan-300/80 transition hover:text-cyan-100 hover:underline">View &#8599;</a>
+                            </div>
                             <input class="mt-2 w-full rounded-xl border border-white/10 bg-ink-950 px-4 py-3 font-mono text-sm text-slate-100 outline-none transition focus:border-cyan-300/40" id="nonMembershipContract" type="text" placeholder="C..." autocomplete="off" spellcheck="false" />
                         </div>
                     </div>
@@ -106,19 +112,19 @@
                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                         <div class="rounded-2xl border border-white/8 bg-ink-900/70 p-4">
                             <div class="text-[10px] uppercase tracking-wide text-slate-500">Membership Root</div>
-                            <div class="mt-1 font-mono text-xs text-cyan-200/80 break-all" id="membershipRoot">--</div>
+                            <a class="mt-1 block font-mono text-xs text-cyan-200/80 break-all transition hover:text-cyan-100 hover:underline" id="membershipRoot" href="#" target="_blank" rel="noopener noreferrer" title="View stored data on block explorer">--</a>
                         </div>
                         <div class="rounded-2xl border border-white/8 bg-ink-900/70 p-4">
                             <div class="text-[10px] uppercase tracking-wide text-slate-500">Membership Levels</div>
-                            <div class="mt-1 font-mono text-xs text-cyan-200/80" id="membershipLevels">--</div>
+                            <a class="mt-1 block font-mono text-xs text-cyan-200/80 transition hover:text-cyan-100 hover:underline" id="membershipLevels" href="#" target="_blank" rel="noopener noreferrer" title="View stored data on block explorer">--</a>
                         </div>
                         <div class="rounded-2xl border border-white/8 bg-ink-900/70 p-4">
                             <div class="text-[10px] uppercase tracking-wide text-slate-500">Membership Next Index</div>
-                            <div class="mt-1 font-mono text-xs text-cyan-200/80" id="membershipNextIndex">--</div>
+                            <a class="mt-1 block font-mono text-xs text-cyan-200/80 transition hover:text-cyan-100 hover:underline" id="membershipNextIndex" href="#" target="_blank" rel="noopener noreferrer" title="View stored data on block explorer">--</a>
                         </div>
                         <div class="rounded-2xl border border-white/8 bg-ink-900/70 p-4">
                             <div class="text-[10px] uppercase tracking-wide text-slate-500">Non-Membership Root</div>
-                            <div class="mt-1 font-mono text-xs text-cyan-200/80 break-all" id="nonMembershipRoot">--</div>
+                            <a class="mt-1 block font-mono text-xs text-cyan-200/80 break-all transition hover:text-cyan-100 hover:underline" id="nonMembershipRoot" href="#" target="_blank" rel="noopener noreferrer" title="View stored data on block explorer">--</a>
                         </div>
                     </div>
                 </div>

--- a/app/js/admin.js
+++ b/app/js/admin.js
@@ -3,6 +3,7 @@ import { client, initializeRuntime, bootnodeRequired, ensureStorage, deriveAspUs
 import { connectWallet, getWalletNetwork, signWalletAuthEntry, signWalletTransaction } from './wallet.js';
 import { isDbLockedError, showDbLockedModal } from './db-locked.js';
 import { friendlyErrorMessage } from './facade-errors.js';
+import { App, Utils } from './ui/core.js';
 
 // DOM element references
 const statusEl = document.getElementById('status');
@@ -18,6 +19,8 @@ const toastTemplate = document.getElementById('tpl-toast');
 // Contract/state display
 const membershipContractInput = document.getElementById('membershipContract');
 const nonMembershipContractInput = document.getElementById('nonMembershipContract');
+const membershipContractLinkEl = document.getElementById('membershipContractLink');
+const nonMembershipContractLinkEl = document.getElementById('nonMembershipContractLink');
 const membershipRootEl = document.getElementById('membershipRoot');
 const membershipLevelsEl = document.getElementById('membershipLevels');
 const membershipNextIndexEl = document.getElementById('membershipNextIndex');
@@ -213,6 +216,24 @@ async function ensureCryptoReady() {
 }
 
 // -----------------------------
+// Block explorer links
+// -----------------------------
+async function loadExplorerSetting() {
+  try {
+    const storage = await ensureStorage();
+    const explorerSetting = await storage.getExplorerSetting();
+    App.state.settings.explorerBaseUrl = explorerSetting?.baseUrl || Utils.defaultExplorerBaseUrl;
+  } catch {
+    // Keep the default explorer base URL if storage isn't available yet.
+  }
+}
+
+function updateContractLink(linkEl, contractId) {
+  if (!linkEl) return;
+  linkEl.href = contractId ? Utils.explorerContractUrl(contractId) : '#';
+}
+
+// -----------------------------
 // Wallet actions
 // -----------------------------
 async function connect() {
@@ -295,12 +316,25 @@ async function refreshState() {
 
     if (membershipContractInput) membershipContractInput.value = membershipState.contractId;
     if (nonMembershipContractInput) nonMembershipContractInput.value = nonMembershipState.contractId;
+    updateContractLink(membershipContractLinkEl, membershipState.contractId);
+    updateContractLink(nonMembershipContractLinkEl, nonMembershipState.contractId);
+
+    const membershipStorageUrl = membershipState.contractId
+      ? Utils.explorerContractStorageUrl(membershipState.contractId)
+      : '#';
+    const nonMembershipStorageUrl = nonMembershipState.contractId
+      ? Utils.explorerContractStorageUrl(nonMembershipState.contractId)
+      : '#';
 
     membershipRootEl.textContent = membershipState.root || '--';
+    membershipRootEl.href = membershipStorageUrl;
     membershipLevelsEl.textContent = membershipState.levels ?? '--';
+    membershipLevelsEl.href = membershipStorageUrl;
     membershipNextIndexEl.textContent = membershipState.nextIndex ?? '--';
+    membershipNextIndexEl.href = membershipStorageUrl;
     updateAdminInsertOnlyDisplay(membershipState.adminInsertOnly);
     nonMembershipRootEl.textContent = nonMembershipState.root || '--';
+    nonMembershipRootEl.href = nonMembershipStorageUrl;
 
     setStatus('State loaded', 'ok');
   } catch (err) {
@@ -512,8 +546,16 @@ addToAllowlistBtn.addEventListener('click', insertMembershipLeaf);
 addToBlocklistBtn.addEventListener('click', insertNonMembershipLeaf);
 removeFromBlocklistBtn.addEventListener('click', removeNonMembershipLeaf);
 
+membershipContractInput?.addEventListener('input', () => {
+  updateContractLink(membershipContractLinkEl, membershipContractInput.value.trim());
+});
+nonMembershipContractInput?.addEventListener('input', () => {
+  updateContractLink(nonMembershipContractLinkEl, nonMembershipContractInput.value.trim());
+});
+
 async function init() {
   setStatus('Initializing...', 'info');
+  await loadExplorerSetting();
   await ensureCryptoReady();
   await refreshState();
   setStatus('Ready', 'ok');

--- a/app/js/admin.js
+++ b/app/js/admin.js
@@ -223,8 +223,8 @@ async function loadExplorerSetting() {
     const storage = await ensureStorage();
     const explorerSetting = await storage.getExplorerSetting();
     App.state.settings.explorerBaseUrl = explorerSetting?.baseUrl || Utils.defaultExplorerBaseUrl;
-  } catch {
-    // Keep the default explorer base URL if storage isn't available yet.
+  } catch (err) {
+    console.warn('Explorer setting unavailable, using default explorer:', err);
   }
 }
 

--- a/app/js/ui/core.js
+++ b/app/js/ui/core.js
@@ -112,6 +112,10 @@ export const Utils = {
         return `${this.explorerBaseUrl()}/contract/${contractId}`;
     },
 
+    explorerContractStorageUrl(contractId) {
+        return `${this.explorerContractUrl(contractId)}/storage`;
+    },
+
     async copyToClipboard(text) {
         try {
             await navigator.clipboard.writeText(text);


### PR DESCRIPTION
---
👋 External Contributor PR

Use this template when contributing from a fork.

---
🚀 What's this PR do?

Makes the ASP contract IDs and on-chain state values on the admin page (admin.html) clickable links to the configured block explorer, instead of plain text with no way to inspect them.

- Contract ID fields → link to the contract's overview page.
- Membership Root / Levels / Next Index / Non-Membership Root → link to the contract's storage tab, where the actual stored value is visible on-chain.

---
📎 Related issues (optional)

Closes #390 

---
🧠 Context

Reuses the app's existing Utils.explorer*Url() helpers (app/js/ui/core.js) already used for links elsewhere in the app (dashboard, balances, tx toasts) — added one new explorerContractStorageUrl() helper following the same pattern. Since the two contract-ID fields are editable inputs (not static text), their "View" link updates live as the value is typed, so it never points at a stale contract.

No new tests added — this is DOM wiring in admin.js/admin.html with no existing test coverage to extend.

---
✅ Required Checklist

- [ ] I've read the contributing guide.
- [ ] I've mentioned this PR in the project LinkedIn group (required for review so maintainers can see a human behind the contribution).
- [ ] I've tested this locally, run .githooks/pre-push and provided test instructions for maintainers if needed
- [ ] I've added relevant docs or comments
- [ ] I've updated or created tests if needed