### PR TITLE
fix(ci): bump actions/cache to v6.1.0

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -34,7 +34,7 @@ jobs:
         run: cargo install mdbook --no-default-features
 
       - name: Cache binaryen and wasm-opt output
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             target/tmp/binaryen

--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -54,7 +54,7 @@ jobs:
       # On a miss build.sh downloads and sha256-verifies binaryen itself; this
       # only persists the extracted tree between runs.
       - name: Cache binaryen
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: target/tmp/binaryen/binaryen-version_131
           key: binaryen-version_131-${{ runner.os }}-${{ runner.arch }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,11 +62,16 @@ ark-std = { version = "0.6.0", default-features = false, features = ["std"] }
 async-trait = { version = "0.1.91", default-features = false }
 base64 = { version = "0.22", default-features = false, features = ["alloc"] }
 cfg-if = { version = "1", default-features = false }
-clap = { version = "4.6.3", default-features = false, features = ["std", "color",
-  "help",
-  "usage",
-  "error-context",
-  "suggestions", "derive", "env"] }
+clap = { version = "4.6.3", default-features = false, features = [
+    "std",
+    "color",
+    "help",
+    "usage",
+    "error-context",
+    "suggestions",
+    "derive",
+    "env",
+] }
 console_error_panic_hook = { version = "0.1.7", default-features = false }
 futures = { version = "0.3.33", default-features = false, features = ["async-await"] }
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
@@ -88,13 +93,13 @@ sqlite-wasm-rs = { version = "0.5.5", default-features = false }
 sqlite-wasm-vfs = { version = "0.2.0", default-features = false }
 thiserror = { version = "2", default-features = false }
 tokio = { version = "1", default-features = false }
+tracing = { version = "0.1", default-features = false, features = ["std", "release_max_level_info", "attributes"] }
+tracing-log = { version = "0.2", default-features = false, features = ["log-tracer", "std"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 uint = { version = "0.10", default-features = false }
 wasm-bindgen = { version = "0.2", default-features = false, features = ["serde-serialize"] }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
 wasm-bindgen-test = { version = "0.3", default-features = false, features = ["std"] }
-tracing = { version = "0.1", default-features = false, features = ["std", "release_max_level_info", "attributes"] }
-tracing-log = { version = "0.2", default-features = false, features = ["log-tracer", "std"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 # see also https://github.com/NethermindEth/stellar-private-payments/issues/192
 wasmer = { version = "7.2", default-features = false }
 web-sys = { version = "0.3", features = ["console", "WorkerGlobalScope", "Response", "Request", "RequestInit", "RequestMode", "Window", "Event", "Cache", "CacheStorage"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,9 +19,6 @@ anyhow.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 log.workspace = true
-tracing = { workspace = true, features = ["attributes"] }
-tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }
-tracing-log = { workspace = true }
 # Not referenced directly, but pulls in reqwest's rustls TLS backend for the
 # binary (the `stellar` crate depends on reqwest without a TLS feature).
 reqwest = { workspace = true, features = ["rustls"] }
@@ -29,6 +26,9 @@ serde.workspace = true
 serde_json.workspace = true
 stellar-private-payments-sdk.workspace = true
 toml = "0.8"
+tracing = { workspace = true, features = ["attributes"] }
+tracing-log = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }
 types.workspace = true
 
 [lints]

--- a/sdk/client/Cargo.toml
+++ b/sdk/client/Cargo.toml
@@ -15,13 +15,13 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 disclosure = { workspace = true }
 futures = { workspace = true }
-tracing = { workspace = true }
 prover = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 state = { workspace = true }
 stellar = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 tx-planner = { workspace = true }
 types = { workspace = true, features = ["rusqlite"] }
 witness = { workspace = true }

--- a/sdk/state/Cargo.toml
+++ b/sdk/state/Cargo.toml
@@ -16,10 +16,10 @@ types = { workspace = true, features = ["rusqlite"] }
 # external
 anyhow = { workspace = true }
 hex = { workspace = true }
-tracing = { workspace = true }
 rusqlite_migration = { version = "2.6.0", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }
+tracing = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # external

--- a/sdk/stellar/Cargo.toml
+++ b/sdk/stellar/Cargo.toml
@@ -17,7 +17,6 @@ base64 = { workspace = true }
 ed25519-dalek = { version = "2.2", default-features = false, features = ["digest", "zeroize"] }
 futures = { workspace = true, features = ["executor"] }
 http = "1.4.2"
-tracing = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde-aux = "4.7.0"
@@ -27,6 +26,7 @@ sha3 = { version = "0.11", default-features = false }
 stellar-strkey = "0.0.18"
 stellar-xdr = { version = "27.0.0", features = ["serde", "base64", "std", "alloc"] }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = { workspace = true }

--- a/sdk/tests/Cargo.toml
+++ b/sdk/tests/Cargo.toml
@@ -15,8 +15,8 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 stellar-private-payments-sdk = { workspace = true }
-tracing-subscriber = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 types = { workspace = true, features = ["rusqlite"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/sdk/types/Cargo.toml
+++ b/sdk/types/Cargo.toml
@@ -22,9 +22,9 @@ uint = { workspace = true }
 zeroize = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tracing-subscriber = { workspace = true }
 # external
 rusqlite = { workspace = true, optional = true, features = ["bundled"] }
+tracing-subscriber = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # external

--- a/sdk/web/Cargo.toml
+++ b/sdk/web/Cargo.toml
@@ -34,9 +34,9 @@ serde = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }
 sha2 = { workspace = true }
+tracing = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
-tracing = { workspace = true }
 web-sys = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -48,12 +48,12 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 types = { workspace = true }
 
+[dev-dependencies]
+wasm-bindgen-test = { workspace = true }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
 tracing-subscriber = { workspace = true }
-
-[dev-dependencies]
-wasm-bindgen-test = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
- GitHub rejected the pinned v4.0.2 SHA (0c45773b) in.yml as a deprecated actions/cache version. Update both deployment.yml and wasm-build.yml to the v6.1.0 SHA (5a3ec84e). Only the stable path/key inputs are used, which are unchanged across v4 → v6, and the runner (2.336.0) meets the v5+ minimum requirement.

- Run cargo sort