### PR TITLE
Ci/install tools from binaries

### DIFF
--- a/.github/workflows/bootnode-ci.yml
+++ b/.github/workflows/bootnode-ci.yml
@@ -55,7 +55,9 @@ jobs:
           workspaces: tools/bootnode
 
       - name: Install cargo-deny
-        run: which cargo-deny || cargo install cargo-deny --locked --version 0.18.9
+        uses: taiki-e/install-action@541dbe11e2898b05bb65bedbd1d0c4e3092b5bdd # v2
+        with:
+          tool: cargo-deny@0.18.9
 
       - name: Dependency audit
         run: cargo deny check --config ../../deny.toml

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -40,7 +40,10 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@541dbe11e2898b05bb65bedbd1d0c4e3092b5bdd # v2
+        with:
+          tool: cargo-deny@0.18.9
+
       - name: Run audit-check action
-        run: |
-          which cargo-deny || cargo install cargo-deny --locked --version 0.18.9
-          cargo deny check
+        run: cargo deny check

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -31,7 +31,9 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Install mdBook
-        run: cargo install mdbook --no-default-features
+        uses: taiki-e/install-action@541dbe11e2898b05bb65bedbd1d0c4e3092b5bdd # v2
+        with:
+          tool: mdbook@0.5.4
 
       - name: Cache binaryen and wasm-opt output
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -41,10 +43,18 @@ jobs:
             target/tmp/witness-opt-cache
           key: binaryen-${{ runner.os }}-${{ runner.arch }}-version_131-bulk-memory,reference-types,multivalue,sign-ext,nontrapping-float-to-int,mutable-globals
 
-      - name: Install wasm build prerequisites
-        run: |
-          rustup target add wasm32-unknown-unknown
-          cargo install wasm-bindgen-cli --version 0.2.126 --locked --force
+      - name: Install wasm-bindgen-cli
+        uses: taiki-e/install-action@541dbe11e2898b05bb65bedbd1d0c4e3092b5bdd # v2
+        with:
+          tool: wasm-bindgen-cli@0.2.126
+
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Install Trunk
+        uses: taiki-e/install-action@541dbe11e2898b05bb65bedbd1d0c4e3092b5bdd # v2
+        with:
+          tool: trunk@0.21.14
 
       - name: Build app (Trunk)
         run: |
@@ -69,7 +79,7 @@ jobs:
         run: mdbook build docs/
 
       - name: Build API documentation
-        run: cargo doc --no-deps --workspace --release
+        run: cargo doc --no-deps --workspace
 
       - name: Combine outputs
         run: |

--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -39,7 +39,9 @@ jobs:
         run: cargo build -p circuits --release
 
       - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli --version 0.2.126 --locked --force
+        uses: taiki-e/install-action@541dbe11e2898b05bb65bedbd1d0c4e3092b5bdd # v2
+        with:
+          tool: wasm-bindgen-cli@0.2.126
 
       - name: Setup Node.js
         uses: actions/setup-node@6a61c0375d66246de94630495909f12cf8dac84d # v4
@@ -79,7 +81,9 @@ jobs:
         run: npm ci --prefix app
 
       - name: Install Trunk
-        run: cargo install trunk --locked
+        uses: taiki-e/install-action@541dbe11e2898b05bb65bedbd1d0c4e3092b5bdd # v2
+        with:
+          tool: trunk@0.21.14
 
       - name: Smoke-test Trunk app build
         run: trunk build --release --dist /tmp/app-dist
@@ -105,7 +109,9 @@ jobs:
           cache-targets: "true"
 
       - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli --version 0.2.126 --locked --force
+        uses: taiki-e/install-action@541dbe11e2898b05bb65bedbd1d0c4e3092b5bdd # v2
+        with:
+          tool: wasm-bindgen-cli@0.2.126
 
       - name: Run wasm tests
         run: cargo test --target wasm32-unknown-unknown -p stellar

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ RELEASE ?=
 # e.g. `make serve LOGS=1`, `make build LOGS=1`.
 LOGS ?=
 
+# CI is set by most CI runners (including GitHub Actions). Use `npm ci` there for
+# reproducible, faster installs; keep `npm install` for local development.
+NPM_CMD := $(if $(CI),npm ci,npm install)
+
 .PHONY: release
 release: RELEASE := 1
 release: build
@@ -60,8 +64,8 @@ sdk-web-build-debug:
 .PHONY: install
 install:
 	@echo "Installing frontend dependencies..."
-	@npm install --prefix app
-	@npm install --prefix sdk/web
+	@$(NPM_CMD) --prefix app
+	@$(NPM_CMD) --prefix sdk/web
 	@rustup target add wasm32v1-none
 	@command -v trunk >/dev/null 2>&1 || cargo install trunk --locked
 


### PR DESCRIPTION
## Summary

Experimental CI optimization: replace source-compiled Rust tooling with prebuilt binaries and apply a few deployment-job speedups.

## What changes

- Switch `cargo install` steps to `taiki-e/install-action` (binary installs):
  - `wasm-bindgen-cli@0.2.126`
  - `trunk@0.21.14`
  - `mdbook@0.5.4`
  - `cargo-deny@0.18.9`
- Add `trunk` binary install to `deployment.yml` so the `Makefile` no longer falls back to compiling it from source.
- Use `npm ci` instead of `npm install` in CI via the `Makefile` (`CI` env-aware).
- Build API docs without `--release`.

## Why this is an experiment

The goal is to measure whether binary installs and the deployment tweaks materially reduce CI wall time. We should compare the run times of the affected workflows against recent `main` runs before deciding whether to keep these changes.

## Workflows to watch

- `WASM Build`
- `Deployment`
- `Bootnode CI`
- `Dependency security audit`

## Checklist before merging

- [ ] Affected workflows pass.
- [ ] Deployment job still produces a working site and docs.
- [ ] Measured CI time improvement justifies the change.