### PR TITLE
CI NPM release fixes

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -77,8 +77,7 @@ jobs:
         if: steps.version_check.outputs.should_publish == 'true'
         uses: actions/setup-node@6a61c0375d66246de94630495909f12cf8dac84d # v4
         with:
-          node-version: "22"
-          registry-url: https://registry.npmjs.org
+          node-version: "24"
           cache: npm
           cache-dependency-path: sdk/web/package-lock.json
 

--- a/sdk/web/package.json
+++ b/sdk/web/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/NethermindEth/stellar-private-payments",
+    "url": "git+https://github.com/NethermindEth/stellar-private-payments.git",
     "directory": "sdk/web"
   },
   "publishConfig": {


### PR DESCRIPTION
First CI failed on this: https://github.com/NethermindEth/stellar-private-payments/actions/runs/30549183998/job/90893080281
Possible fixes included here:
- Dropped registry-url from setup-node (so no empty _authToken line).
- Bumped Node to 24 (npm new enough for OIDC).
- Normalized repository.url to git+https://…git (npm also validates this for GitHub publishes).