### PR TITLE
Opt-in Freighter to `stellar-private-payments/freighter`

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -61,11 +61,14 @@ sed 's|^Source bundle: ./source-bundle.tar.gz$|Source bundle: ../../../../circui
     "$SDK/dist/circuits/NOTICE.txt" > "$SDK/dist/circuits/NOTICE.txt.tmp" \
     && mv "$SDK/dist/circuits/NOTICE.txt.tmp" "$SDK/dist/circuits/NOTICE.txt"
 
-# Bundle SDK JS (inlines @stellar/freighter-api); wasm stays external.
+# Bundle SDK JS; wasm stays external. Freighter is a separate opt-in entry.
 ./app/node_modules/.bin/esbuild sdk/web/js/index.js \
   --bundle --format=esm --minify \
   --outfile="$SDK/js/index.js" \
-  --external:../dist/stellar_private_payments_sdk_web.js \
+  --external:../dist/stellar_private_payments_sdk_web.js
+./app/node_modules/.bin/esbuild sdk/web/js/freighter.js \
+  --bundle --format=esm --minify \
+  --outfile="$SDK/js/freighter.js" \
   --alias:@stellar/freighter-api=./app/node_modules/@stellar/freighter-api/build/index.min.js
 
 # Static files
@@ -84,9 +87,9 @@ cp sdk/web/dist/circuits/source-bundle.tar.gz "$TRUNK_STAGING_DIR/circuits/sourc
 stage = "build"
 command = "sh"
 command_arguments = ["-c", """
-./app/node_modules/.bin/esbuild app/js/ui.js --bundle --minify --external:stellar-private-payments --outfile="$TRUNK_STAGING_DIR/js/ui.js" --format=esm
-./app/node_modules/.bin/esbuild app/js/admin.js --bundle --minify --external:stellar-private-payments --outfile="$TRUNK_STAGING_DIR/js/admin.js" --format=esm
-./app/node_modules/.bin/esbuild app/js/disclosure.js --bundle --minify --external:stellar-private-payments --outfile="$TRUNK_STAGING_DIR/js/disclosure.js" --format=esm
+./app/node_modules/.bin/esbuild app/js/ui.js --bundle --minify --external:stellar-private-payments --external:stellar-private-payments/freighter --outfile="$TRUNK_STAGING_DIR/js/ui.js" --format=esm
+./app/node_modules/.bin/esbuild app/js/admin.js --bundle --minify --external:stellar-private-payments --external:stellar-private-payments/freighter --outfile="$TRUNK_STAGING_DIR/js/admin.js" --format=esm
+./app/node_modules/.bin/esbuild app/js/disclosure.js --bundle --minify --external:stellar-private-payments --external:stellar-private-payments/freighter --outfile="$TRUNK_STAGING_DIR/js/disclosure.js" --format=esm
 
 # Service worker must be served from the root (not bundled with ui.js) so it has full-page scope
 cp app/js/sw.js "$TRUNK_STAGING_DIR/sw.js"

--- a/app/ARCHITECTURE.md
+++ b/app/ARCHITECTURE.md
@@ -188,7 +188,7 @@ Freighter connect/watch/sign UX for the app UI. Distinct from `sdk/web/js/freigh
 
 **Build (Trunk)**
 
-`Trunk.toml` stages `sdk/web/dist/` (WASM, workers, **bundled circuits** under `dist/circuits/`) and bundles `sdk/web/js/index.js` into `js/stellar-private-payments/`. App bundles (`ui.js`, etc.) import `stellar-private-payments` as an external package via import maps in `index.html`.
+`Trunk.toml` stages `sdk/web/dist/` (WASM, workers, **bundled circuits** under `dist/circuits/`) and bundles `sdk/web/js/index.js` plus the opt-in `sdk/web/js/freighter.js` into `js/stellar-private-payments/`. App bundles (`ui.js`, etc.) import `stellar-private-payments` / `stellar-private-payments/freighter` as external packages via import maps in `index.html`.
 
 Root-level `circuits/` in the deployed site holds **legal files only** (`NOTICE.txt`, `source-bundle.tar.gz` for footer links). Proving loads artifacts from the SDK copy via the prover worker loader (`__STELLAR_PRIVATE_PAYMENTS_CIRCUITS_BASE__`).
 

--- a/app/admin.html
+++ b/app/admin.html
@@ -15,7 +15,8 @@
     <script type="importmap">
     {
         "imports": {
-            "stellar-private-payments": "./js/stellar-private-payments/js/index.js"
+            "stellar-private-payments": "./js/stellar-private-payments/js/index.js",
+            "stellar-private-payments/freighter": "./js/stellar-private-payments/js/freighter.js"
         }
     }
     </script>

--- a/app/index.html
+++ b/app/index.html
@@ -23,7 +23,8 @@
     <script type="importmap">
     {
         "imports": {
-            "stellar-private-payments": "./js/stellar-private-payments/js/index.js"
+            "stellar-private-payments": "./js/stellar-private-payments/js/index.js",
+            "stellar-private-payments/freighter": "./js/stellar-private-payments/js/freighter.js"
         }
     }
     </script>

--- a/app/js/ui/navigation.js
+++ b/app/js/ui/navigation.js
@@ -1,5 +1,5 @@
 import { connectWallet, getWalletNetwork, startWalletWatcher } from '../wallet.js';
-import { FreighterSigner } from 'stellar-private-payments';
+import { FreighterSigner } from 'stellar-private-payments/freighter';
 import { DEFAULT_BOOTNODE_URL } from '../app-storage.js';
 import { client, initializeRuntime, disposeClient, bootnodeRequired, ensureStorage, configureTelemetrySettings, dumpTelemetryLogs, debugLogsEnabled, isRuntimeReady } from '../wasm-facade.js';
 import { App, Toast, Utils } from './core.js';

--- a/app/js/ui/onboarding-wizard.js
+++ b/app/js/ui/onboarding-wizard.js
@@ -1,4 +1,4 @@
-import { FreighterSigner } from 'stellar-private-payments';
+import { FreighterSigner } from 'stellar-private-payments/freighter';
 import { DEFAULT_BOOTNODE_URL } from '../app-storage.js';
 import { client } from '../wasm-facade.js';
 import { friendlyErrorMessage } from '../facade-errors.js';

--- a/app/js/wasm-facade.js
+++ b/app/js/wasm-facade.js
@@ -10,7 +10,6 @@
 
 import init, {
   Client,
-  FreighterSigner,
   Storage,
   bootnodeRequired as sdkBootnodeRequired,
   deriveAspUserLeaf as sdkDeriveAspUserLeaf,
@@ -19,6 +18,7 @@ import init, {
   dump_recent_logs,
   debugLogsEnabled as sdkDebugLogsEnabled,
 } from 'stellar-private-payments';
+import { FreighterSigner } from 'stellar-private-payments/freighter';
 
 import { AppStorage } from './app-storage.js';
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -19,7 +19,7 @@
     },
     "../sdk/web": {
       "name": "stellar-private-payments",
-      "version": "0.1.0-alpha.0",
+      "version": "0.1.0-alpha.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.5.4"

--- a/sdk/web/README.md
+++ b/sdk/web/README.md
@@ -12,10 +12,10 @@ Browser SDK for Stellar Private Payments.
 import init, {
   Storage,
   Client,
-  FreighterSigner,
   bootnodeRequired,
   verifySelectiveDisclosure,
 } from 'stellar-private-payments';
+import { FreighterSigner } from 'stellar-private-payments/freighter';
 
 const networkPassphrase = 'Test SDF Network ; September 2015';
 const rpcUrl = 'https://soroban-testnet.stellar.org';
@@ -141,7 +141,8 @@ Matches `stellar_private_payments_sdk::PrivatePool`. Amount parameters and `bala
 
 ### Signer
 
-Bound at `client.account()`. Must implement `signMessage`, `signTransaction`, `signAuthEntry`. See [`FreighterSigner`](./js/freighter.js).
+Bound at `client.account()`. Must implement `signMessage`, `signTransaction`, `signAuthEntry`.
+Optional Freighter adapter: `import { FreighterSigner } from 'stellar-private-payments/freighter'` (requires peer `@stellar/freighter-api`).
 
 ## Logging & Diagnostics
 
@@ -173,11 +174,11 @@ Public types live in [`js/types/`](./js/types/). The package entry (`import { Cl
 import init, {
   Storage,
   Client,
-  FreighterSigner,
   verifySelectiveDisclosure,
   type Account,
   type WalletSigner,
 } from 'stellar-private-payments';
+import { FreighterSigner } from 'stellar-private-payments/freighter';
 ```
 
 After building WASM:

--- a/sdk/web/js/index.js
+++ b/sdk/web/js/index.js
@@ -135,4 +135,3 @@ export const Client = {
 export { PrivatePool, bootnodeRequired, deriveAspUserLeaf, verifySelectiveDisclosure };
 export { configureTelemetry, set_log_level, dump_recent_logs, debugLogsEnabled };
 export { default } from '../dist/stellar_private_payments_sdk_web.js';
-export { FreighterSigner } from './freighter.js';

--- a/sdk/web/js/types/index.d.ts
+++ b/sdk/web/js/types/index.d.ts
@@ -34,8 +34,6 @@ export type {
   WalletSigner,
 } from './signer.js';
 
-export { FreighterSigner } from './freighter.js';
-
 /** Wallet session returned by {@link Client.account}. */
 export interface Account {
   readonly userAddress: string;

--- a/sdk/web/package-lock.json
+++ b/sdk/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stellar-private-payments",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stellar-private-payments",
-      "version": "0.1.0-alpha.0",
+      "version": "0.1.0-alpha.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.5.4"

--- a/sdk/web/package.json
+++ b/sdk/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-private-payments",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "description": "Stellar Private Payments browser SDK (alpha)",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
The main package entry always re-exported `FreighterSigner`, so importing anything from `stellar-private-payments` also loaded `@stellar/freighter-api`.
- That only ships UMD, which breaks under native ESM.
- Now we keep Freighter on the opt-in `stellar-private-payments/freighter` subpath so the core SDK no longer pulls it in by default.