### PR TITLE
fix: installing old release now points to latest config from repo

### DIFF
--- a/cli/src/config/mod.rs
+++ b/cli/src/config/mod.rs
@@ -21,6 +21,9 @@ pub const DEFAULT_DEPLOYMENT_JSON: &str =
 
 pub const EMBEDDED_DEPLOYMENT_LABEL: &str = "embedded:testnet";
 
+/// Deployment config provisioned into the data dir by `scripts/install.sh`.
+pub const DEPLOYMENT_FILE_NAME: &str = "deployments.json";
+
 /// CLI flag overrides used to build a [`CliConfig`].
 #[derive(Debug, Default)]
 pub struct CliConfigOverrides {
@@ -79,7 +82,8 @@ impl CliConfig {
         let stellar_config_dir =
             stellar_config_dir.or(file.defaults.stellar_config_dir.map(toml::expand_path));
 
-        let (deployment_source, deployment) = load_deployment(deployment_path.as_deref())?;
+        let (deployment_source, deployment) =
+            load_deployment(deployment_path.as_deref(), &data_dir)?;
         // Network name: --network > config default > the deployment's network
         // (which matches a Stellar CLI built-in like `testnet`).
         let network = network
@@ -148,21 +152,29 @@ pub fn default_circuits_dir(data_dir: &Path) -> PathBuf {
     }
 }
 
-fn load_deployment(path: Option<&Path>) -> Result<(String, ContractConfig)> {
-    match path {
-        Some(path) => {
-            let raw = std::fs::read_to_string(path)
-                .with_context(|| format!("read deployment file {}", path.display()))?;
-            let deployment = serde_json::from_str(&raw)
-                .with_context(|| format!("parse deployment file {}", path.display()))?;
-            Ok((path.display().to_string(), deployment))
-        }
-        None => {
-            let deployment = serde_json::from_str(DEFAULT_DEPLOYMENT_JSON)
-                .context("parse embedded testnet deployment")?;
-            Ok((EMBEDDED_DEPLOYMENT_LABEL.to_string(), deployment))
-        }
+/// Resolve the deployment config: `--deployment` > the copy provisioned into
+/// the data dir by `scripts/install.sh` > [`DEFAULT_DEPLOYMENT_JSON`].
+fn load_deployment(path: Option<&Path>, data_dir: &Path) -> Result<(String, ContractConfig)> {
+    if let Some(path) = path {
+        return read_deployment_file(path);
     }
+    let provisioned = data_dir.join(DEPLOYMENT_FILE_NAME);
+    if provisioned.is_file() {
+        return read_deployment_file(&provisioned);
+    }
+    let deployment = serde_json::from_str(DEFAULT_DEPLOYMENT_JSON)
+        .context("parse embedded testnet deployment")?;
+    Ok((EMBEDDED_DEPLOYMENT_LABEL.to_string(), deployment))
+}
+
+fn read_deployment_file(path: &Path) -> Result<(String, ContractConfig)> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("read deployment file {}", path.display()))?;
+
+    // A schema mismatch here usually means the file is newer than this binary
+    let deployment = serde_json::from_str(&raw)
+        .with_context(|| format!("parse deployment file {}", path.display()))?;
+    Ok((path.display().to_string(), deployment))
 }
 
 pub fn validate_pool(pool: &str, deployment: &ContractConfig) -> Result<()> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -187,7 +187,7 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     logging::init(cli.verbose, cli.json);
     let json = cli.json;
-    let config_flag = cli.config.clone();
+    let config_flag = cli.config;
 
     let config_path = resolve_config_path(config_flag.clone());
     let file_config = match config_path.as_deref() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,13 +4,14 @@
 #   curl -fsSL https://nethermindeth.github.io/stellar-private-payments/install.sh | sh
 #
 # Picks the release binary for this platform, installs it, and provisions the
-# data dir (circuits, policy proving keys, license/notice texts) that the CLI reads at
-# runtime.
+# data dir (circuits, policy proving keys, license/notice texts, deployment
+# config) that the CLI reads at runtime.
 #
 # Environment overrides:
 #   SPP_VERSION    release tag to install (default: latest non-prerelease)
 #   SPP_BIN_DIR    where to install the `spp` binary (default: $HOME/.local/bin)
 #   SPP_DATA_DIR   data dir root (default: $HOME/.local/share/stellar-private-payments)
+#   SPP_DEPLOYMENT_REF git ref to take deployments.json from main
 # Flags:
 #   --pre          allow installing the latest prerelease
 #   --version TAG  same as SPP_VERSION=TAG
@@ -22,6 +23,7 @@ BIN_DIR="${SPP_BIN_DIR:-$HOME/.local/bin}"
 DATA_DIR="${SPP_DATA_DIR:-$HOME/.local/share/stellar-private-payments}"
 VERSION="${SPP_VERSION:-}"
 ALLOW_PRE="${SPP_PRERELEASE:-0}"
+DEPLOYMENT_REF="${SPP_DEPLOYMENT_REF:-main}"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -29,7 +31,7 @@ while [ $# -gt 0 ]; do
     --version) VERSION="${2:-}"; shift ;;
     --version=*) VERSION="${1#--version=}" ;;
     -h|--help)
-      sed -n '2,20p' "$0"
+      sed -n '2,17p' "$0"
       exit 0
       ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
@@ -124,9 +126,20 @@ fetch_verified "dist.tar.gz"
 mkdir -p "$DATA_DIR"
 tar -xzf "$tmp/dist.tar.gz" -C "$DATA_DIR"
 
+# --- deployment config ------------------------------------------------------
+deployment_url="https://raw.githubusercontent.com/$REPO/$DEPLOYMENT_REF/deployments/testnet/deployments.json"
+deployment_status="$DEPLOYMENT_REF"
+if dl "$deployment_url" "$tmp/deployments.json"; then
+  mv "$tmp/deployments.json" "$DATA_DIR/deployments.json"
+else
+  deployment_status="unavailable"
+  echo "warning: could not download deployment config from $deployment_url" >&2
+fi
+
 echo "Installed:"
 echo "  binary: $BIN_DIR/spp"
 echo "  data:   $DATA_DIR"
+echo "  config: $deployment_status"
 case ":$PATH:" in
   *":$BIN_DIR:"*) : ;;
   *) echo "note: $BIN_DIR is not on your PATH; add it, e.g. export PATH=\"$BIN_DIR:\$PATH\"" ;;


### PR DESCRIPTION
## 👋 External Contributor PR

Use this template when contributing from a fork.

---

## 🚀 What’s this PR do?

- Anyone installing the old release now gets the latest config in `script/install.sh` from repo. install.sh fetches the config from main independently of the release, and binaries built from this change onward read it
- Modified the config/mod.rs so now `load_deployment()` receives both the path and `data_dir` as arguments and decides which to read depending on if path is located or not.
- Also, noticed an unnecessary `clone()` in main.rs while reading through it. Will revert if this change is not required.
---

### 📎 Related issues (optional)

Closes #432

---

## 🧠 Context

Right now the CLI release bakes in the deployment.json configuration into the compiled binary. This means someone installing an old release, will be getting an old configuration.

---

## ✅ Required Checklist

- [X] I’ve read the [contributing guide](../CONTRIBUTING.md).
- [ ] I’ve mentioned this PR in the project LinkedIn group (required for review so maintainers can see a human behind the contribution).
- [X] I’ve tested this locally, run .githooks/pre-push and provided test instructions for maintainers if needed
- [X] I’ve added relevant docs or comments
- [ ] I’ve updated or created tests if needed
