### PR TITLE
ci(license): remove dependency-review, ban fastrlp

### DIFF
--- a/.github/workflows/js-license-audit.yml
+++ b/.github/workflows/js-license-audit.yml
@@ -1,4 +1,7 @@
 name: JS License Audit
+# JS-only license and dependency checks. Rust/Cargo licensing is enforced by
+# dependency-audit.yml via cargo-deny, which is feature-aware and checks the
+# compiled dependency graph.
 
 on:
   pull_request:
@@ -11,46 +14,6 @@ permissions:
   contents: read
 
 jobs:
-  dependency-review:
-    name: Dependency Review PR Gate
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-
-      - name: Load License Policy
-        id: policy
-        run: |
-          # Parse the shared JS license policy JSON to extract the allowlist for
-          # the dependency-review action, which expects a comma-separated string.
-          # Only allow-licenses is wired; deny-licenses is intentionally omitted
-          # because the two inputs are mutually exclusive upstream.
-          #
-          # IMPORTANT: dependency-review-action's allow-licenses matcher
-          # (@onebeyond/spdx-license-satisfies, via parseLicensesArray) throws
-          # if ANY entry in the list is a compound AND/OR SPDX expression —
-          # and that exception is caught internally and silently treated as
-          # "no match", which would fail EVERY dependency in the PR, not just
-          # the one with a compound license. Filter those entries out here;
-          # the affected package is excused individually below instead via
-          # allow-dependencies-licenses. (Verified against the action's actual
-          # source and its @onebeyond/spdx-license-satisfies@1.0.1 dependency
-          # at the pinned SHA — this is not hypothetical.)
-          ALLOWLIST=$(jq -r '[.allowlist[] | select(test(" AND | OR ") | not)] | join(", ")' .github/js-license-policy.json)
-          echo "allowlist=$ALLOWLIST" >> $GITHUB_OUTPUT
-
-      - name: Dependency Review Action
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
-        with:
-          # Wire allowlist into the action. Any license not on this list fails the PR.
-          allow-licenses: ${{ steps.policy.outputs.allowlist }}
-          # app's sha.js reports the compound license "(MIT AND BSD-3-Clause)",
-          # which cannot be expressed in allow-licenses (see comment above) —
-          # excuse it by package identity instead, which uses a separate code
-          # path unaffected by the same-array conjunction restriction.
-          allow-dependencies-licenses: "pkg:npm/sha.js, pkg:npm/stellar-private-payments"
-
   full-tree-scan:
     name: Full-Tree License Scan
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -77,6 +77,11 @@ wildcards = "deny"
 allow-wildcard-paths = true
 multiple-versions = "warn"
 highlight = "all"
+deny = [
+    # MPL-2.0 crate pulled in by an unused feature gate. Allowed to exist in
+    # Cargo.lock, but must never be part of the compiled dependency graph.
+    { name = "fastrlp", reason = "MPL-2.0; allowed only behind an unused feature gate" }
+]
 
 [bans.workspace-dependencies]
 duplicates = 'deny'


### PR DESCRIPTION
 The dependency-review action in the JS license audit workflow
 duplicated coverage that cargo-deny already provides for Rust/Cargo
 dependencies via dependency-audit.yml. Remove the redundant job and
 add a comment clarifying the split.

 Also deny the MPL-2.0 fastrlp crate in deny.toml; it is only pulled
 in by an unused feature gate and must never be part of the compiled
 dependency graph.