### PR TITLE
Bootnode sealed empty tip healing

### DIFF
--- a/tools/bootnode/Cargo.lock
+++ b/tools/bootnode/Cargo.lock
@@ -3427,10 +3427,14 @@ name = "types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "getrandom 0.2.17",
  "hex",
  "serde",
  "serde_json",
+ "tracing",
+ "tracing-subscriber",
  "uint",
+ "zeroize",
 ]
 
 [[package]]
@@ -3969,6 +3973,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/tools/bootnode/Cargo.lock
+++ b/tools/bootnode/Cargo.lock
@@ -839,11 +839,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/tools/bootnode/src/compressor.rs
+++ b/tools/bootnode/src/compressor.rs
@@ -40,12 +40,13 @@ impl EmptyPageCompressor {
             .ledger_tip
             .load(Ordering::Relaxed)
             .max(kv.ledger_tip);
-        let day = ledgers_per_day(self.state.cfg.ledger_seconds);
-        let through_ledger = tip.saturating_sub(day);
-        if through_ledger == 0 {
+        if tip == 0 {
             return Ok(());
         }
-        if kv.last_empty_compress_ledger >= through_ledger {
+
+        let day = ledgers_per_day(self.state.cfg.ledger_seconds);
+        let through_ledger = tip.saturating_sub(day);
+        if through_ledger == 0 || kv.last_empty_compress_ledger >= through_ledger {
             return Ok(());
         }
 

--- a/tools/bootnode/src/rpc.rs
+++ b/tools/bootnode/src/rpc.rs
@@ -121,6 +121,22 @@ impl BootnodeRpc {
                 // cached page. Mid-history quiet gaps still have a next page
                 // and must return 200 so clients can keep walking the chain.
                 if tip_known && self.is_terminal_empty(cursor, &result, in_sync).await? {
+                    if result.latest_ledger < cutoff_ledger {
+                        // Sealed below cutoff: persist bump, return empty so the
+                        // wallet advances; the next request handoffs.
+                        self.state
+                            .storage
+                            .bump_empty_latest_ledger(cursor, cutoff_ledger)
+                            .await
+                            .map_err(|e| {
+                                counter!("bootnode_handler_errors_total").increment(1);
+                                internal_error(e)
+                            })?;
+                        counter!("bootnode_cache_hits_total").increment(1);
+                        let mut page = result;
+                        page.latest_ledger = cutoff_ledger;
+                        return Ok(page);
+                    }
                     counter!("bootnode_handoffs_total").increment(1);
                     return Err(retention_handoff(cutoff_ledger));
                 }

--- a/tools/bootnode/src/storage/in_memory.rs
+++ b/tools/bootnode/src/storage/in_memory.rs
@@ -300,6 +300,25 @@ impl Storage for InMemory {
         }
         self.with_deployment_mut(|state| apply_compress_plan(state, &plan))
     }
+
+    async fn bump_empty_latest_ledger(&self, cursor_in: &str, latest_ledger: u32) -> Result<()> {
+        self.with_deployment_mut(|state| {
+            let Some(page) = state
+                .pages
+                .iter_mut()
+                .find(|p| p.meta.cursor_in.as_deref() == Some(cursor_in))
+            else {
+                return;
+            };
+            if page.meta.last_event_ledger.is_some() {
+                return;
+            }
+            page.meta.latest_ledger = latest_ledger;
+            page.result.latest_ledger = latest_ledger;
+            rebuild_indexes(state);
+        });
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/tools/bootnode/src/storage/mod.rs
+++ b/tools/bootnode/src/storage/mod.rs
@@ -85,6 +85,9 @@ pub trait Storage: Send + Sync {
     /// [`Err`] so the compressor retries on the next tick.
     async fn compress_empty_pages(&self, cutoff_ledger: u32) -> Result<CompressStats>;
 
+    /// Set `latest_ledger` on the empty page keyed by `cursor_in`.
+    async fn bump_empty_latest_ledger(&self, cursor_in: &str, latest_ledger: u32) -> Result<()>;
+
     async fn mark_caught_up(&self, cursor: &str, latest_ledger: u32) -> Result<()> {
         self.update_cursor(cursor).await?;
         self.set_last_fully_indexed_ledger(latest_ledger).await?;

--- a/tools/bootnode/src/storage/postgres.rs
+++ b/tools/bootnode/src/storage/postgres.rs
@@ -548,4 +548,35 @@ WHERE id = $4 AND deployment_id = $5 AND last_event_ledger IS NULL
         tx.commit().await?;
         Ok(plan.stats())
     }
+
+    async fn bump_empty_latest_ledger(&self, cursor_in: &str, latest_ledger: u32) -> Result<()> {
+        let latest =
+            i32::try_from(latest_ledger).context("latest_ledger exceeds postgres INTEGER range")?;
+        let client = self.pool.get().await?;
+        let row = client
+            .query_opt(
+                "SELECT result FROM get_events_pages WHERE deployment_id = $1 AND cursor_in = $2 AND last_event_ledger IS NULL LIMIT 1",
+                &[&self.deployment_id(), &cursor_in],
+            )
+            .await?;
+        let Some(row) = row else {
+            return Ok(());
+        };
+        let Json(mut result): Json<GetEventsResponse> = row.get(0);
+        result.latest_ledger = latest_ledger;
+        let updated = client
+            .execute(
+                r#"
+UPDATE get_events_pages
+SET result = $1, latest_ledger = $2
+WHERE deployment_id = $3 AND cursor_in = $4 AND last_event_ledger IS NULL
+"#,
+                &[&Json(result), &latest, &self.deployment_id(), &cursor_in],
+            )
+            .await?;
+        if updated != 1 {
+            bail!("bump empty page missed cursor_in={cursor_in}");
+        }
+        Ok(())
+    }
 }


### PR DESCRIPTION
Fix a client-stuck scenario: a terminal empty page (tip self-loop, indexer in sync) whose `latest_ledger` is below the retention cutoff used to hand off immediately. Wallets that advance sync position `from latest_ledger` on empty pages could not progress. The fix introduces a two-step flow: heal once, then hand off.
