### PR TITLE
test(e2e): cover graph.bin witness -> Groth16 prove/verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,6 +1200,7 @@ dependencies = [
  "parser",
  "program_structure",
  "regex",
+ "serde_json",
  "type_analysis",
  "types",
  "wast",
@@ -2276,6 +2277,7 @@ dependencies = [
  "asp-non-membership",
  "circom-groth16-verifier",
  "circuits",
+ "contract-types",
  "num-bigint",
  "pool",
  "prover",
@@ -2283,6 +2285,7 @@ dependencies = [
  "soroban-utils",
  "tx-planner",
  "types",
+ "witness",
  "zkhash",
 ]
 

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -19,6 +19,7 @@ std = [
     "ark-std",
     "num-bigint",
     "num-integer",
+    "serde_json",
 ]
 # Enables circom-witness-rs C++ graph generation (`make witness-graphs`).
 regen-graph = ["dep:circom-witness-rs"]
@@ -40,6 +41,7 @@ ark-snark = { workspace = true, optional = true }
 ark-std = { workspace = true, optional = true }
 num-bigint = { workspace = true, optional = true }
 num-integer = { workspace = true, optional = true }
+serde_json = { workspace = true, default-features = false, features = ["alloc", "std"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # external

--- a/circuits/src/test/utils/circom_tester.rs
+++ b/circuits/src/test/utils/circom_tester.rs
@@ -123,6 +123,88 @@ impl Inputs {
     pub fn iter(&self) -> impl Iterator<Item = (&String, &InputValue)> {
         self.inner.iter()
     }
+
+    /// Serialize the inputs as the flat JSON object that the
+    /// `circom-witness-rs` graph evaluator accepts (`witness::WitnessCalculator
+    /// ::compute_witness`).
+    ///
+    /// Keys keep their Circom signal path (`membershipProofs[0][0].leaf`),
+    /// because the graph input mapping hashes that exact name. Single values
+    /// become decimal strings and arrays become arrays of decimal strings;
+    /// multi-dimensional signals must already be flattened row-major, which is
+    /// how the WASM path pushes them too.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a value is negative. The graph evaluator only
+    /// accepts field elements in `[0, p)`.
+    pub fn to_witness_json(&self) -> Result<String> {
+        let mut map = serde_json::Map::with_capacity(self.inner.len());
+        for (key, value) in &self.inner {
+            let json = match value {
+                InputValue::Single(v) => serde_json::Value::String(decimal_string(key, v)?),
+                InputValue::Array(arr) => serde_json::Value::Array(
+                    arr.iter()
+                        .map(|v| Ok(serde_json::Value::String(decimal_string(key, v)?)))
+                        .collect::<Result<Vec<_>>>()?,
+                ),
+            };
+            map.insert(key.clone(), json);
+        }
+        serde_json::to_string(&serde_json::Value::Object(map))
+            .context("failed to serialize circuit inputs as JSON")
+    }
+}
+
+/// Render one input value as a decimal string, rejecting negative values.
+fn decimal_string(key: &str, value: &BigInt) -> Result<String> {
+    if value.sign() == num_bigint::Sign::Minus {
+        return Err(anyhow!("input signal {key} is negative: {value}"));
+    }
+    Ok(value.to_str_radix(10))
+}
+
+#[cfg(test)]
+mod witness_json_tests {
+    use super::*;
+
+    #[test]
+    fn to_witness_json_emits_decimal_strings() {
+        let mut inputs = Inputs::new();
+        inputs.set("root", BigInt::from(5u32));
+        inputs.set(
+            "inPathElements",
+            vec![BigInt::from(7u32), BigInt::from(11u32)],
+        );
+        inputs.set_key(
+            &SignalKey::new("membershipProofs")
+                .idx(0)
+                .idx(0)
+                .field("leaf"),
+            BigInt::from(9u32),
+        );
+
+        let json: serde_json::Value =
+            serde_json::from_str(&inputs.to_witness_json().expect("serialize")).expect("parse");
+
+        assert_eq!(json["root"], serde_json::json!("5"));
+        assert_eq!(json["inPathElements"], serde_json::json!(["7", "11"]));
+        assert_eq!(json["membershipProofs[0][0].leaf"], serde_json::json!("9"));
+    }
+
+    #[test]
+    fn to_witness_json_rejects_negative_values() {
+        let mut inputs = Inputs::new();
+        inputs.set("root", BigInt::from(-1i32));
+
+        let err = inputs
+            .to_witness_json()
+            .expect_err("negative values are not field elements");
+        assert!(
+            err.to_string().contains("root"),
+            "error should name the signal: {err:#}"
+        );
+    }
 }
 
 /// Represents a single Circom input value

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -14,12 +14,14 @@ circom-groth16-verifier = { workspace = true }
 # Circuit dependencies
 circuits = { workspace = true, features = ["std"] }
 # Contract dependencies
+contract-types = { workspace = true }
 pool = { workspace = true }
 # Shared deps
 prover = { workspace = true }
 soroban-utils = { workspace = true }
 tx-planner = { workspace = true }
 types = { workspace = true }
+witness = { workspace = true }
 zkhash = { workspace = true }
 
 # external

--- a/e2e-tests/src/tests/e2e_pool_2_in_2_out.rs
+++ b/e2e-tests/src/tests/e2e_pool_2_in_2_out.rs
@@ -1,269 +1,336 @@
-//! End-to-end tests for Pool contract with real Groth16 proofs
+//! End-to-end tests for the Pool contract with real Groth16 proofs.
 //!
-//! These tests generate actual Groth16 proofs using the circuit crate
-//! and verify them through the Pool contract. This demonstrates a complete
-//! integration from proof generation to on-chain verification.
-//!
-//! It bridges the gap between the different crates and versions.
+//! Every case is 2 inputs and 2 outputs. The witness comes from the committed
+//! `*.graph.bin` graph, the proof from the `prover` crate, and the verification
+//! from the pool contract. That is the pipeline the CLI, the SDK and the
+//! browser use.
 use super::utils::{
-    LEVELS, NonMembership, build_membership_trees, bytes32_to_bigint, deploy_contracts,
-    generate_proof, non_membership_overrides_from_pubs, scalar_to_u256, test_env, u256_to_scalar,
-    wrap_groth16_proof,
+    DeployedContracts, LEVELS, NonMembership, POOL_ZERO_LEAF, TRANSACT_STEMS,
+    build_membership_trees, build_policy_inputs, bytes32_to_bigint, deploy_contracts,
+    generate_proof, prove_with_graph, scalar_to_u256, sync_contract_state, test_env,
+    u256_to_scalar, wrap_groth16_proof,
 };
 use anyhow::Result;
-use asp_membership::ASPMembershipClient;
-use asp_non_membership::ASPNonMembershipClient;
 use circuits::test::utils::{
-    general::{poseidon2_hash2, scalar_to_bigint},
+    circom_tester::Inputs,
+    general::scalar_to_bigint,
     keypair::derive_public_key,
     transaction::{commitment, prepopulated_leaves},
     transaction_case::{InputNote, OutputNote, TxCase, prepare_transaction_witness},
 };
-use pool::{ExtData, PoolContractClient, Proof, hash_ext_data};
-use soroban_sdk::{Address, Bytes, I256, U256, Vec as SorobanVec, testutils::Address as _};
+use contract_types::Groth16Error;
+use pool::{Error, ExtData, PoolContractClient, Proof, hash_ext_data};
+use soroban_sdk::{
+    Address, Bytes, I256, InvokeError, U256, Vec as SorobanVec, testutils::Address as _,
+};
+use types::PolicyFlags;
 use zkhash::fields::bn256::FpBN256 as Scalar;
 
-/// Full E2E test: Generate a real proof, deploy contracts, and call transact
-/// which verifies the zk-proof
+/// Result of `PoolContractClient::try_transact`.
 ///
-/// This test demonstrates a complete integration:
-/// 1. Creates a transaction case (2 inputs, 2 outputs)
-/// 2. Generates a real Groth16 proof using the policy circuit
-/// 3. Deploys all contracts (Pool, ASP Membership, ASP Non-Membership,
-///    Verifier) and syncs the state
-/// 4. Initializes the verifier with the real verification key from proof
-///    generation
-/// 5. Calls the `transact` function on the pool contract
-#[test]
-#[cfg_attr(miri, ignore)]
-fn test_e2e_transact_with_real_proof() -> Result<()> {
-    // Create ExtData and compute its hash
+/// The outer error holds the contract error, and the inner one holds a return
+/// value conversion error.
+type TransactOutcome =
+    Result<Result<(), soroban_sdk::ConversionError>, Result<Error, soroban_sdk::InvokeError>>;
+
+/// A pool transaction that is ready for `transact`, with its proof made from
+/// the committed witness graph.
+struct TransactFixture {
+    env: soroban_sdk::Env,
+    contracts: DeployedContracts,
+    proof: Proof,
+    ext_data: ExtData,
+}
+
+impl TransactFixture {
+    /// Send the transaction to the pool contract.
+    fn transact(&self) -> TransactOutcome {
+        let sender = Address::generate(&self.env);
+        PoolContractClient::new(&self.env, &self.contracts.pool).try_transact(
+            &self.proof,
+            &self.ext_data,
+            &sender,
+        )
+    }
+}
+
+/// Build a 2-in/2-out pool transaction and prove it from the witness graph.
+///
+/// The amounts must balance: `inputs + ext_amount = outputs`. A positive
+/// `ext_amount` is a deposit, and zero is a private transfer.
+fn transact_fixture(
+    in_amounts: [u64; 2],
+    out_amounts: [u64; 2],
+    ext_amount: i32,
+) -> Result<TransactFixture> {
+    assert!(ext_amount >= 0, "this fixture only covers deposits");
     let env = test_env();
-    let temp_recipient = Address::generate(&env);
+    let recipient = Address::generate(&env);
 
     let ext_data = ExtData {
-        recipient: temp_recipient.clone(),
-        ext_amount: I256::from_i32(&env, 0),
+        recipient,
+        ext_amount: I256::from_i32(&env, ext_amount),
         encrypted_output0: Bytes::new(&env),
         encrypted_output1: Bytes::new(&env),
     };
-
-    // Compute ext_data_hash as the contract would
     let ext_data_hash_bytes = hash_ext_data(&env, &ext_data);
     let ext_data_hash_bigint = bytes32_to_bigint(&ext_data_hash_bytes);
 
-    // Create transaction case
-    // Private transfer: 13 units from one input to one output
     let case = TxCase::new(
         vec![
             InputNote {
                 leaf_index: 0,
                 priv_key: Scalar::from(101u64),
                 blinding: Scalar::from(201u64),
-                amount: Scalar::from(0u64), // Dummy input (amount = 0)
+                amount: Scalar::from(in_amounts[0]),
             },
             InputNote {
                 leaf_index: 1,
                 priv_key: Scalar::from(102u64),
                 blinding: Scalar::from(211u64),
-                amount: Scalar::from(13u64), // Real input
+                amount: Scalar::from(in_amounts[1]),
             },
         ],
         vec![
             OutputNote {
                 pub_key: Scalar::from(501u64),
                 blinding: Scalar::from(601u64),
-                amount: Scalar::from(13u64), // Real output
+                amount: Scalar::from(out_amounts[0]),
             },
             OutputNote {
                 pub_key: Scalar::from(502u64),
                 blinding: Scalar::from(602u64),
-                amount: Scalar::from(0u64), // Dummy output
+                amount: Scalar::from(out_amounts[1]),
             },
         ],
     );
 
-    // Prepare merkle tree leaves (Pool state)
+    // Pool state. The last leaf pair stays empty, so the tree is not full.
     let mut leaves = prepopulated_leaves(
         LEVELS,
         0xDEAD_BEEFu64,
         &[case.inputs[0].leaf_index, case.inputs[1].leaf_index],
         24,
     );
-    // Leave the last 2 position empty (zero value in Merkle tree)
-    // Otherwise when the verification succeeds, the pool will revert the
-    // transaction because the Merkle tree would be full.
-    let zero = U256::from_be_bytes(
-        &env,
-        &Bytes::from_array(
-            &env,
-            &[
-                37, 48, 34, 136, 219, 153, 53, 3, 68, 151, 65, 131, 206, 49, 13, 99, 181, 58, 187,
-                158, 240, 248, 87, 87, 83, 238, 211, 110, 1, 24, 249, 206,
-            ],
-        ),
-    );
-    let len = leaves.len();
-    leaves[len - 2] = u256_to_scalar(&zero);
-    leaves[len - 1] = u256_to_scalar(&zero);
+    let zero = U256::from_be_bytes(&env, &Bytes::from_array(&env, &POOL_ZERO_LEAF));
+    let last_pair = leaves
+        .len()
+        .checked_sub(2)
+        .expect("pool needs at least two leaves");
+    leaves[last_pair] = u256_to_scalar(&zero);
+    leaves[last_pair.checked_add(1).expect("last leaf index")] = u256_to_scalar(&zero);
 
-    // Build membership and non-membership trees
     let membership_trees = build_membership_trees(&case, |j| 0xFEED_FACEu64 ^ ((j as u64) << 40));
-    let keys = vec![
-        NonMembership {
-            key_non_inclusion: scalar_to_bigint(derive_public_key(case.inputs[0].priv_key)),
-        },
-        NonMembership {
-            key_non_inclusion: scalar_to_bigint(derive_public_key(case.inputs[1].priv_key)),
-        },
-    ];
+    let keys = case
+        .inputs
+        .iter()
+        .map(|input| NonMembership {
+            key_non_inclusion: scalar_to_bigint(derive_public_key(input.priv_key)),
+        })
+        .collect::<Vec<_>>();
 
-    // Generate the Groth16 proof using Circom
-    println!("Prepare transaction witness...");
     let witness = prepare_transaction_witness(&case, leaves.clone(), LEVELS)?;
-
-    println!("Generating Groth16 proof...");
+    let public_amount = Scalar::from(u64::try_from(ext_amount).expect("non-negative ext amount"));
     let result = generate_proof(
         &case,
         leaves.clone(),
-        Scalar::from(0u64),
+        public_amount,
         &membership_trees,
         &keys,
         Some(ext_data_hash_bigint),
     )?;
     assert!(result.verified, "Proof should verify locally");
-    // Deploy contracts. Including the verifier with the real verification key
+
     env.mock_all_auths();
     let contracts = deploy_contracts(&env);
-    println!("Contracts deployed!");
-
-    // Sync on-chain state with off-chain proof data
-    // Since contracts were just deployed, their merkle trees are basically empty.
-    // We need to insert leaves into them to have an state equivalent to what we
-    // used to generate the proof off-chain. Insert membership leaves into ASP
-    // Membership contract
-    let asp_membership_client = ASPMembershipClient::new(&env, &contracts.asp_membership);
-    let asp_non_membership_client =
-        ASPNonMembershipClient::new(&env, &contracts.asp_non_membership);
-    // For membership
-    let mut memb_leaves = membership_trees[0].leaves;
-    memb_leaves[membership_trees[0].index] = poseidon2_hash2(
-        witness.public_keys[0],
-        membership_trees[0].blinding,
-        Some(Scalar::from(1u64)),
-    );
-    memb_leaves[membership_trees[1].index] = poseidon2_hash2(
-        witness.public_keys[1],
-        membership_trees[1].blinding,
-        Some(Scalar::from(1u64)),
-    );
-    for leaf in memb_leaves {
-        let leaf_u256 = scalar_to_u256(&env, leaf);
-        asp_membership_client.insert_leaf(&leaf_u256);
-    }
-    // For non-membership
-    let overrides = non_membership_overrides_from_pubs(&witness.public_keys);
-    for (key, value) in overrides {
-        let key_bytes = key.to_bytes_be().1;
-        let mut padded_key = [0u8; 32];
-        let start = padded_key.len().saturating_sub(key_bytes.len());
-        padded_key[start..].copy_from_slice(&key_bytes);
-
-        let value_bytes = value.to_bytes_be().1;
-        let mut padded_value = [0u8; 32];
-        let start = padded_value.len().saturating_sub(value_bytes.len());
-        padded_value[start..].copy_from_slice(&value_bytes);
-        asp_non_membership_client.insert_leaf(
-            &U256::from_be_bytes(&env, &Bytes::from_array(&env, &padded_key)),
-            &U256::from_be_bytes(&env, &Bytes::from_array(&env, &padded_value)),
-        );
-    }
-    // For the main pool contract
-    // Ensure the pool contract matches the proof's merkle root
-    let pool_client = PoolContractClient::new(&env, &contracts.pool);
-    // Modify leaves as generate_proof does
-    for note in &case.inputs {
-        let pk = derive_public_key(note.priv_key);
-        let cm = commitment(note.amount, pk, note.blinding);
-        leaves[note.leaf_index] = cm;
-    }
-    // Ensure leaves is even as we insert leaves directly in pairs
-    assert_eq!(leaves.len() % 2, 0, "Leaves should be even for this test");
-    // Insert leaves directly into th Pool contract
-    for (i, leaf) in leaves.iter().enumerate().take(len - 2).step_by(2) {
-        let leaf_1 = scalar_to_u256(&env, *leaf);
-        let leaf_2 = scalar_to_u256(&env, leaves[i + 1]);
-        env.as_contract(&contracts.pool, || {
-            let _ = pool::merkle_with_history::MerkleTreeWithHistory::insert_two_leaves(
-                &env, leaf_1, leaf_2,
-            );
-        });
-    }
-    // Check if roots match
-    let circuit_root = scalar_to_u256(&env, witness.root);
-    let pool_root = pool_client.get_root();
-    assert_eq!(
-        circuit_root, pool_root,
-        "Pool root should match circuit root. Otherwise, the verification will fail"
+    let roots = sync_contract_state(
+        &env,
+        &contracts,
+        &case,
+        &mut leaves,
+        &membership_trees,
+        &witness,
     );
 
-    // Get ASP roots from deployed contracts
-    let asp_membership_root = asp_membership_client.get_root();
-    let asp_non_membership_root = asp_non_membership_client.get_root();
-
-    let groth16_proof = wrap_groth16_proof(&env, result);
-
-    // Build input nullifiers
     let mut input_nullifiers: SorobanVec<U256> = SorobanVec::new(&env);
-    for nul in &witness.nullifiers {
-        input_nullifiers.push_back(scalar_to_u256(&env, *nul));
+    for nullifier in &witness.nullifiers {
+        input_nullifiers.push_back(scalar_to_u256(&env, *nullifier));
     }
 
-    // Build output commitments
-    let output_commitment0 = scalar_to_u256(
-        &env,
-        commitment(
-            case.outputs[0].amount,
-            case.outputs[0].pub_key,
-            case.outputs[0].blinding,
-        ),
-    );
-    let output_commitment1 = scalar_to_u256(
-        &env,
-        commitment(
-            case.outputs[1].amount,
-            case.outputs[1].pub_key,
-            case.outputs[1].blinding,
-        ),
-    );
-
-    // Build the complete Proof struct
     let proof = Proof {
-        proof: groth16_proof,
-        root: circuit_root,
+        proof: wrap_groth16_proof(&env, result),
+        root: roots.pool_root,
         input_nullifiers,
-        output_commitment0,
-        output_commitment1,
-        public_amount: U256::from_u32(&env, 0),
+        output_commitment0: scalar_to_u256(&env, output_commitment(&case, 0)),
+        output_commitment1: scalar_to_u256(&env, output_commitment(&case, 1)),
+        public_amount: U256::from_u32(
+            &env,
+            u32::try_from(ext_amount).expect("non-negative ext amount"),
+        ),
         ext_data_hash: ext_data_hash_bytes,
-        asp_membership_root,
-        asp_non_membership_root,
+        asp_membership_root: roots.asp_membership_root,
+        asp_non_membership_root: roots.asp_non_membership_root,
     };
 
-    // Call transact
-    println!("Calling transact method");
-    let sender = Address::generate(&env);
-    let transact_result = pool_client.try_transact(&proof, &ext_data, &sender);
+    Ok(TransactFixture {
+        env,
+        contracts,
+        proof,
+        ext_data,
+    })
+}
 
-    match transact_result {
-        Ok(_) => {
-            println!("Transaction succeeded!");
-        }
-        Err(e) => {
-            println!("Transaction failed with error: {e:?}");
-            panic!("Transaction failed");
+/// Commitment of one output note of a case.
+fn output_commitment(case: &TxCase, index: usize) -> Scalar {
+    commitment(
+        case.outputs[index].amount,
+        case.outputs[index].pub_key,
+        case.outputs[index].blinding,
+    )
+}
+
+/// Keep only the signals that a circuit with these policy flags declares.
+///
+/// `policy_tx_2_2` has no ASP proofs, `_A` has the allowlist only and `_B` has
+/// the blocklist only. The graph rejects a signal that its circuit does not
+/// declare, so the shared input set must be reduced per stem.
+fn inputs_for_flags(all: &Inputs, flags: PolicyFlags) -> Inputs {
+    let mut out = Inputs::new();
+    for (key, value) in all.iter() {
+        let keep = if key.starts_with("nonMembership") {
+            flags.requires_non_membership_proofs()
+        } else if key.starts_with("membership") {
+            flags.requires_membership_proofs()
+        } else {
+            true
+        };
+        if keep {
+            out.set(key.clone(), value.clone());
         }
     }
+    out
+}
 
+/// A private transfer of 13 units. The public amount stays zero, so no value
+/// enters or leaves the pool.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn transact_transfer_succeeds() -> Result<()> {
+    let fixture = transact_fixture([0, 13], [13, 0], 0)?;
+    assert!(fixture.transact().is_ok(), "transfer should succeed");
+    Ok(())
+}
+
+/// A deposit moves value into the pool, so `publicAmount` is not zero.
+///
+/// `transact_transfer_succeeds` keeps `publicAmount` at zero, so this case
+/// covers the public amount encoding as well.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn transact_deposit_succeeds() -> Result<()> {
+    let fixture = transact_fixture([0, 0], [13, 0], 13)?;
+    assert!(fixture.transact().is_ok(), "deposit should succeed");
+    Ok(())
+}
+
+/// The on-chain verifier must reject a proof whose public inputs were changed.
+///
+/// The pool checks the root, the nullifiers, the external data hash and the
+/// public amount itself. It does not check the output commitments, so a changed
+/// commitment goes to the Groth16 verifier contract. The pairing check fails
+/// there, so the verifier answers `Groth16Error::InvalidProof` and the whole
+/// pool call fails with that code.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn transact_rejects_tampered_output_commitment() -> Result<()> {
+    let mut fixture = transact_fixture([0, 13], [13, 0], 0)?;
+
+    let tampered = commitment(
+        Scalar::from(13u64),
+        Scalar::from(501u64),
+        Scalar::from(999u64),
+    );
+    fixture.proof.output_commitment0 = scalar_to_u256(&fixture.env, tampered);
+
+    let outcome = fixture.transact();
+    assert!(
+        matches!(outcome, Err(Err(InvokeError::Contract(code))) if code == Groth16Error::InvalidProof as u32),
+        "expected the verifier to reject a tampered output commitment, got {outcome:?}"
+    );
+    Ok(())
+}
+
+/// Every committed transact graph must prove and verify.
+///
+/// The verifier contract holds one verification key only, so the other three
+/// stems are checked off chain. The test is expensive (four Groth16 proofs), so
+/// it stays behind `--ignored` and runs in the release CI job.
+#[test]
+#[ignore = "expensive: proves all four transact circuits"]
+#[cfg_attr(miri, ignore)]
+fn all_transact_graphs_prove_and_verify() -> Result<()> {
+    let case = TxCase::new(
+        vec![
+            InputNote {
+                leaf_index: 0,
+                priv_key: Scalar::from(101u64),
+                blinding: Scalar::from(201u64),
+                amount: Scalar::from(0u64),
+            },
+            InputNote {
+                leaf_index: 1,
+                priv_key: Scalar::from(102u64),
+                blinding: Scalar::from(211u64),
+                amount: Scalar::from(13u64),
+            },
+        ],
+        vec![
+            OutputNote {
+                pub_key: Scalar::from(501u64),
+                blinding: Scalar::from(601u64),
+                amount: Scalar::from(13u64),
+            },
+            OutputNote {
+                pub_key: Scalar::from(502u64),
+                blinding: Scalar::from(602u64),
+                amount: Scalar::from(0u64),
+            },
+        ],
+    );
+
+    let leaves = prepopulated_leaves(
+        LEVELS,
+        0xDEAD_BEEFu64,
+        &[case.inputs[0].leaf_index, case.inputs[1].leaf_index],
+        24,
+    );
+    let membership_trees = build_membership_trees(&case, |j| 0xFEED_FACEu64 ^ ((j as u64) << 40));
+    let keys = case
+        .inputs
+        .iter()
+        .map(|input| NonMembership {
+            key_non_inclusion: scalar_to_bigint(derive_public_key(input.priv_key)),
+        })
+        .collect::<Vec<_>>();
+
+    let all_inputs = build_policy_inputs(
+        &case,
+        leaves,
+        Scalar::from(0u64),
+        &membership_trees,
+        &keys,
+        None,
+    )?;
+
+    for stem in TRANSACT_STEMS {
+        let flags = PolicyFlags::from_stem(stem)?;
+        let inputs = inputs_for_flags(&all_inputs, flags);
+        let result = prove_with_graph(stem, &inputs)?;
+        assert!(result.verified, "{stem}: proof should verify locally");
+        assert!(
+            result.num_public_inputs() > 0,
+            "{stem}: proof should commit to public inputs"
+        );
+    }
     Ok(())
 }

--- a/e2e-tests/src/tests/e2e_pool_2tx_plan.rs
+++ b/e2e-tests/src/tests/e2e_pool_2tx_plan.rs
@@ -1,5 +1,8 @@
 //! E2E: tx-planner spend session multi-step spend (consolidate + final) with
 //! real proofs.
+//!
+//! Each step computes its witness from the committed `policy_tx_2_2_AB.graph
+//! .bin` operation graph, the same artifact the CLI and the SDK load.
 
 use super::utils::{
     DeployedContracts, LEVELS, NonMembership, build_membership_trees, bytes32_to_bigint,

--- a/e2e-tests/src/tests/utils.rs
+++ b/e2e-tests/src/tests/utils.rs
@@ -1,27 +1,32 @@
 //! Utility functions and types for end-to-end tests
 
-use anyhow::Result;
-use asp_membership::ASPMembership;
-use asp_non_membership::ASPNonMembership;
+use anyhow::{Context as _, Result, ensure};
+use asp_membership::{ASPMembership, ASPMembershipClient};
+use asp_non_membership::{ASPNonMembership, ASPNonMembershipClient};
 use circom_groth16_verifier::{CircomGroth16Verifier, Groth16Proof};
 use circuits::test::utils::{
-    circom_tester::{CircomResult, SignalKey, load_keys, prove_and_verify_with_keys},
+    circom_tester::{Inputs, SignalKey},
     general::{load_artifacts, poseidon2_hash2, scalar_to_bigint},
+    keypair::derive_public_key,
     merkle_tree::{merkle_proof, merkle_root},
     sparse_merkle_tree::prepare_smt_proof_with_overrides,
-    transaction::prepopulated_leaves,
-    transaction_case::{TxCase, build_base_inputs, prepare_transaction_witness},
+    transaction::{commitment, prepopulated_leaves},
+    transaction_case::{
+        TransactionWitness, TxCase, build_base_inputs, prepare_transaction_witness,
+    },
 };
 use num_bigint::{BigInt, BigUint};
-use pool::PoolContract;
+use pool::{PoolContract, PoolContractClient};
+use prover::prover::Prover;
 use soroban_sdk::{
     Address, Bytes, BytesN, Env, U256,
     crypto::bn254::{Bn254G1Affine as G1Affine, Bn254G2Affine as G2Affine},
     testutils::Address as _,
 };
 use types::PolicyFlags;
+use witness::WitnessCalculator;
 
-use soroban_utils::{g1_bytes_from_ark, g2_bytes_from_ark, utils::MockToken};
+use soroban_utils::utils::MockToken;
 
 use zkhash::{
     ark_ff::{BigInteger, PrimeField, Zero},
@@ -60,16 +65,115 @@ pub fn test_env() -> Env {
     }
 }
 
-/// Returns the path to the pre-generated proving key for the
-/// policy_tx_2_2_AB circuit. Uses CARGO_MANIFEST_DIR to find the
-/// workspace root.
-fn proving_key_path() -> std::path::PathBuf {
-    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    // e2e-tests is at <workspace>/e2e-tests, so workspace root is parent
-    manifest_dir
+/// Zero-value leaf of the pool commitment Merkle tree
+///
+/// The pool holds this value in the empty positions. The tests leave the last
+/// leaf pair empty, because a full tree makes `transact` revert before it can
+/// insert the new output commitments.
+pub const POOL_ZERO_LEAF: [u8; 32] = [
+    37, 48, 34, 136, 219, 153, 53, 3, 68, 151, 65, 131, 206, 49, 13, 99, 181, 58, 187, 158, 240,
+    248, 87, 87, 83, 238, 211, 110, 1, 24, 249, 206,
+];
+
+/// Transact circuit stem the pool e2e tests prove against.
+///
+/// The Groth16 verifier contract embeds this circuit's verification key (see
+/// `VERIFIER_VK_JSON` in `.cargo/config.toml`), so it is the only stem that can
+/// be verified on chain.
+pub const POLICY_STEM: &str = "policy_tx_2_2_AB";
+
+/// All transact circuit stems that ship a committed witness graph.
+pub const TRANSACT_STEMS: &[&str] = &[
+    "policy_tx_2_2",
+    "policy_tx_2_2_A",
+    "policy_tx_2_2_B",
+    POLICY_STEM,
+];
+
+/// Workspace root, derived from this crate's manifest directory.
+///
+/// `e2e-tests` sits at `<workspace>/e2e-tests`, so the parent is the root.
+pub fn workspace_root() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .expect("Failed to get workspace root")
-        .join("testdata/policy_tx_2_2_AB_proving_key.bin")
+        .to_path_buf()
+}
+
+/// Path of the committed `circom-witness-rs` operation graph for a circuit.
+///
+/// These are the same binaries the CLI, the SDK and the browser load at
+/// runtime, so proving from them is what makes these tests end to end.
+pub fn committed_graph_path(stem: &str) -> std::path::PathBuf {
+    workspace_root()
+        .join("deployments/testnet/circuit_keys")
+        .join(format!("{stem}.graph.bin"))
+}
+
+/// Path of the locally generated Groth16 proving key for a circuit.
+///
+/// `circuits/build.rs` writes these into `testdata/`, together with the
+/// verification key that the verifier contract embeds.
+pub fn proving_key_path(stem: &str) -> std::path::PathBuf {
+    workspace_root().join(format!("testdata/{stem}_proving_key.bin"))
+}
+
+/// Outcome of a Groth16 prove and verify cycle.
+///
+/// Holds everything the pool tests need: the local verification outcome, the
+/// Soroban proof bytes, and the public inputs the proof commits to.
+pub struct ProofResult {
+    /// True when the proof verifies locally against the proving key's own
+    /// verification key.
+    pub verified: bool,
+    /// Uncompressed Soroban proof bytes: `A (64) || B (128) || C (64)`.
+    pub proof_uncompressed: Vec<u8>,
+    /// Public inputs as little-endian field elements, 32 bytes each.
+    pub public_inputs: Vec<u8>,
+}
+
+impl ProofResult {
+    /// Number of public inputs the proof commits to.
+    pub fn num_public_inputs(&self) -> usize {
+        self.public_inputs.len() / 32
+    }
+}
+
+/// Prove a circuit from its committed witness graph, then verify locally.
+///
+/// This is the production pipeline: `*.graph.bin` supplies the witness, the
+/// R1CS and the proving key supply the Groth16 proof. The WASM witness path is
+/// not involved.
+pub fn prove_with_graph(stem: &str, inputs: &Inputs) -> Result<ProofResult> {
+    let graph_path = committed_graph_path(stem);
+    let graph_bytes = std::fs::read(&graph_path)
+        .with_context(|| format!("failed to read witness graph {}", graph_path.display()))?;
+    let calculator = WitnessCalculator::from_graph(&graph_bytes)?;
+    let witness_bytes = calculator.compute_witness(&inputs.to_witness_json()?)?;
+
+    let (_wasm, r1cs_path) = load_artifacts(stem)?;
+    let r1cs_bytes = std::fs::read(&r1cs_path)
+        .with_context(|| format!("failed to read R1CS {}", r1cs_path.display()))?;
+    let pk_path = proving_key_path(stem);
+    let pk_bytes = std::fs::read(&pk_path)
+        .with_context(|| format!("failed to read proving key {}", pk_path.display()))?;
+
+    let prover = Prover::new(&pk_bytes, &r1cs_bytes)?;
+    let proof_compressed = prover.prove_bytes(&witness_bytes)?;
+    let public_inputs = prover.extract_public_inputs(&witness_bytes)?;
+    let verified = prover.verify(&proof_compressed, &public_inputs)?;
+    let proof_uncompressed = prover.proof_bytes_to_uncompressed(&proof_compressed)?;
+    ensure!(
+        proof_uncompressed.len() == 256,
+        "unexpected uncompressed proof length: {}",
+        proof_uncompressed.len()
+    );
+
+    Ok(ProofResult {
+        verified,
+        proof_uncompressed,
+        public_inputs,
+    })
 }
 
 /// Addresses of deployed contracts for E2E tests
@@ -269,11 +373,11 @@ pub fn non_membership_overrides_from_pubs(pubs: &[Scalar]) -> Vec<(BigInt, BigIn
         .collect()
 }
 
-/// Generate a Groth16 proof for a transaction
+/// Build the complete input signal set for the policy transact circuit
 ///
-/// Builds the complete witness for the policy circuit and generates
-/// a Groth16 proof. This includes membership proofs, non-membership proofs,
-/// and all transaction data.
+/// Covers the transaction data, the membership proofs and the non-membership
+/// proofs. The same signal set feeds the graph witness calculator and, in the
+/// circuits crate, the WASM one.
 ///
 /// # Arguments
 ///
@@ -286,22 +390,19 @@ pub fn non_membership_overrides_from_pubs(pubs: &[Scalar]) -> Vec<(BigInt, BigIn
 ///
 /// # Returns
 ///
-/// The circuit result containing the proof and verification key
+/// The circuit input signals
 ///
 /// # Errors
 ///
-/// Returns an error if proof generation fails
-#[allow(clippy::too_many_arguments)]
-pub fn generate_proof(
+/// Returns an error if the transaction witness cannot be prepared
+pub fn build_policy_inputs(
     case: &TxCase,
     leaves: Vec<Scalar>,
     public_amount: Scalar,
     membership_trees: &[MembershipTreeProof],
     non_membership: &[NonMembership],
     ext_data_hash: Option<BigInt>,
-) -> Result<CircomResult> {
-    let (wasm, r1cs) = load_artifacts("policy_tx_2_2_AB")?;
-
+) -> Result<Inputs> {
     let n_inputs = case.inputs.len();
     let witness = prepare_transaction_witness(case, leaves, LEVELS)?;
     let mut inputs = build_base_inputs(case, &witness, public_amount);
@@ -423,16 +524,168 @@ pub fn generate_proof(
     }
     inputs.set("nonMembershipRoots", non_membership_roots);
 
-    // Load pre-generated keys from testdata
-    let keys = load_keys(proving_key_path())?;
-    prove_and_verify_with_keys(&wasm, &r1cs, &inputs, &keys)
+    Ok(inputs)
 }
 
-pub fn wrap_groth16_proof(env: &Env, result: CircomResult) -> Groth16Proof {
-    // Convert proof from Groth16 to Soroban format
-    let a_bytes = g1_bytes_from_ark(result.proof.a);
-    let b_bytes = g2_bytes_from_ark(result.proof.b);
-    let c_bytes = g1_bytes_from_ark(result.proof.c);
+/// Generate a Groth16 proof for a transaction from the committed witness graph
+///
+/// Builds the circuit inputs, computes the witness with
+/// `witness::WitnessCalculator`, then proves and verifies with the `prover`
+/// crate. This is the pipeline the CLI and the SDK use.
+///
+/// # Arguments
+///
+/// See [`build_policy_inputs`].
+///
+/// # Returns
+///
+/// The proof bytes, the public inputs, and the local verification outcome
+///
+/// # Errors
+///
+/// Returns an error if witness computation or proof generation fails
+pub fn generate_proof(
+    case: &TxCase,
+    leaves: Vec<Scalar>,
+    public_amount: Scalar,
+    membership_trees: &[MembershipTreeProof],
+    non_membership: &[NonMembership],
+    ext_data_hash: Option<BigInt>,
+) -> Result<ProofResult> {
+    let inputs = build_policy_inputs(
+        case,
+        leaves,
+        public_amount,
+        membership_trees,
+        non_membership,
+        ext_data_hash,
+    )?;
+    prove_with_graph(POLICY_STEM, &inputs)
+}
+
+/// Merkle roots of the contracts after a state sync
+pub struct SyncedRoots {
+    /// Pool commitment root, which must equal the root inside the proof
+    pub pool_root: U256,
+    /// ASP membership (allowlist) root
+    pub asp_membership_root: U256,
+    /// ASP non-membership (blocklist) root
+    pub asp_non_membership_root: U256,
+}
+
+/// Put the deployed contracts into the state that the proof was made from
+///
+/// A fresh deployment has empty trees. The proof commits to off-chain trees, so
+/// the tests must insert the same leaves before they call `transact`. The
+/// function inserts the membership leaves, the non-membership overrides and the
+/// pool commitments, then checks that the pool root equals the circuit root.
+///
+/// The last two pool leaves stay empty, so that the tree is not full and the
+/// pool accepts the two new output commitments.
+///
+/// # Arguments
+///
+/// * `env` - The Soroban environment
+/// * `contracts` - Addresses from [`deploy_contracts`]
+/// * `case` - The transaction case that the proof used
+/// * `leaves` - Pool leaves; the input commitments are written into them
+/// * `membership_trees` - Membership tree data from [`build_membership_trees`]
+/// * `witness` - Transaction witness from `prepare_transaction_witness`
+///
+/// # Panics
+///
+/// Panics if the pool root does not equal the circuit root, because the
+/// on-chain verification cannot succeed in that state.
+pub fn sync_contract_state(
+    env: &Env,
+    contracts: &DeployedContracts,
+    case: &TxCase,
+    leaves: &mut [Scalar],
+    membership_trees: &[MembershipTreeProof],
+    witness: &TransactionWitness,
+) -> SyncedRoots {
+    let asp_membership_client = ASPMembershipClient::new(env, &contracts.asp_membership);
+    let asp_non_membership_client = ASPNonMembershipClient::new(env, &contracts.asp_non_membership);
+
+    // Membership tree: rebuild the frozen leaves the proof used.
+    let mut memb_leaves = membership_trees[0].leaves;
+    for (i, tree) in membership_trees.iter().enumerate().take(case.inputs.len()) {
+        memb_leaves[tree.index] = poseidon2_hash2(
+            witness.public_keys[i],
+            tree.blinding,
+            Some(Scalar::from(1u64)),
+        );
+    }
+    for leaf in memb_leaves {
+        asp_membership_client.insert_leaf(&scalar_to_u256(env, leaf));
+    }
+
+    // Non-membership tree: insert the same sparse Merkle tree overrides.
+    for (key, value) in non_membership_overrides_from_pubs(&witness.public_keys) {
+        asp_non_membership_client
+            .insert_leaf(&bigint_to_u256(env, &key), &bigint_to_u256(env, &value));
+    }
+
+    // Pool tree: write the input commitments, then insert the leaves in pairs.
+    for note in &case.inputs {
+        let pub_key = derive_public_key(note.priv_key);
+        leaves[note.leaf_index] = commitment(note.amount, pub_key, note.blinding);
+    }
+    let len = leaves.len();
+    assert_eq!(len % 2, 0, "Leaves should be even for this test");
+    // Keep the last pair empty, so that `transact` can insert its two outputs.
+    let inserted = len.checked_sub(2).expect("pool needs at least two leaves");
+    let pool_client = PoolContractClient::new(env, &contracts.pool);
+    for (i, leaf) in leaves.iter().enumerate().take(inserted).step_by(2) {
+        let leaf_1 = scalar_to_u256(env, *leaf);
+        let second = i.checked_add(1).expect("leaf pair index");
+        let leaf_2 = scalar_to_u256(env, leaves[second]);
+        env.as_contract(&contracts.pool, || {
+            let _ = pool::merkle_with_history::MerkleTreeWithHistory::insert_two_leaves(
+                env, leaf_1, leaf_2,
+            );
+        });
+    }
+
+    let circuit_root = scalar_to_u256(env, witness.root);
+    let pool_root = pool_client.get_root();
+    assert_eq!(
+        circuit_root, pool_root,
+        "Pool root should match circuit root. Otherwise, the verification will fail"
+    );
+
+    SyncedRoots {
+        pool_root,
+        asp_membership_root: asp_membership_client.get_root(),
+        asp_non_membership_root: asp_non_membership_client.get_root(),
+    }
+}
+
+/// Convert a non-negative `BigInt` into a Soroban `U256`
+///
+/// # Panics
+///
+/// Panics if the value needs more than 32 bytes.
+pub fn bigint_to_u256(env: &Env, value: &BigInt) -> U256 {
+    let bytes = value.to_bytes_be().1;
+    let mut padded = [0u8; 32];
+    let start = padded
+        .len()
+        .checked_sub(bytes.len())
+        .expect("value exceeds 32 bytes");
+    padded[start..].copy_from_slice(&bytes);
+    U256::from_be_bytes(env, &Bytes::from_array(env, &padded))
+}
+
+/// Convert the uncompressed proof bytes into the Soroban proof type.
+///
+/// The `prover` crate already writes Soroban point ordering: `x || y` for G1,
+/// and `c1 || c0` per coordinate for G2.
+pub fn wrap_groth16_proof(env: &Env, result: ProofResult) -> Groth16Proof {
+    let bytes = &result.proof_uncompressed;
+    let a_bytes: [u8; 64] = bytes[..64].try_into().expect("proof A is 64 bytes");
+    let b_bytes: [u8; 128] = bytes[64..192].try_into().expect("proof B is 128 bytes");
+    let c_bytes: [u8; 64] = bytes[192..].try_into().expect("proof C is 64 bytes");
 
     Groth16Proof {
         a: G1Affine::from_array(env, &a_bytes),


### PR DESCRIPTION
Since #434 the CLI, the SDK and the browser compute the witness from a committed `*.graph.bin` operation graph, but the e2e tests still used ark-circom and the circuit WASM. Nothing covered the shipped pipeline.

- Moved the pool e2e tests onto the production path: `generate_proof` now feeds the committed graph through `witness::WitnessCalculator` and the `prover` crate
- Split `generate_proof` into `build_policy_inputs` + `prove_with_graph`, and extracted the contract state sync into `sync_contract_state`.
- Added `Inputs::to_witness_json`, which renders the shared input set as the flat JSON the graph evaluator accepts.
- Added e2e test cases for prove and verify path

Closes #451
