### PR TITLE
feat(app): live transaction-count hint on transfer/withdraw amounts

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -176,6 +176,7 @@
                                     <div class="mt-6">
                                         <label for="transfer-amount" class="text-xs font-medium uppercase tracking-[0.22em] text-slate-500">Amount</label>
                                         <input id="transfer-amount" type="text" inputmode="decimal" placeholder="0.0" class="mt-3 w-full rounded-2xl border border-white/10 bg-ink-950 px-4 py-4 font-mono text-base text-slate-100 outline-none transition focus:border-cyan-300/40" autocomplete="off" spellcheck="false">
+                                        <p id="transfer-cost-hint" class="mt-2 text-sm text-amber-200" aria-live="polite"></p>
                                     </div>
 
                                     <button id="btn-transfer" type="button" class="mt-6 inline-flex w-full items-center justify-center rounded-2xl bg-[linear-gradient(135deg,#74c5ff,#2f6dff)] px-5 py-3.5 text-sm font-semibold text-ink-950 shadow-[0_12px_30px_rgba(63,138,255,0.45)] transition hover:brightness-110 disabled:opacity-60">
@@ -197,6 +198,7 @@
                                         <div>
                                             <label for="withdraw-amount" class="text-xs font-medium uppercase tracking-[0.22em] text-slate-500">Amount</label>
                                             <input id="withdraw-amount" type="text" inputmode="decimal" placeholder="0.0" class="mt-3 w-full rounded-2xl border border-white/10 bg-ink-950 px-4 py-4 font-mono text-base text-slate-100 outline-none transition focus:border-cyan-300/40" autocomplete="off" spellcheck="false">
+                                            <p id="withdraw-cost-hint" class="mt-2 text-sm text-amber-200" aria-live="polite"></p>
                                         </div>
                                     </div>
                                     <button id="btn-withdraw" type="button" class="mt-6 inline-flex w-full items-center justify-center rounded-2xl bg-[linear-gradient(135deg,#74c5ff,#2f6dff)] px-5 py-3.5 text-sm font-semibold text-ink-950 shadow-[0_12px_30px_rgba(63,138,255,0.45)] transition hover:brightness-110 disabled:opacity-60">

--- a/app/js/ui/pool.js
+++ b/app/js/ui/pool.js
@@ -15,6 +15,11 @@ App.events.addEventListener('pool:selected', () => {
 let cachedContractConfig = null;
 let activeSession = null;
 let activeSessionContractId = null;
+// Concurrent callers (pool.js's own pool:selected listener and any consumer
+// calling ensureAppPool during the recreate window) must share a single
+// in-flight createAppPool — otherwise closeAppPool inside the second call
+// wipes the first call's just-published session.
+let pendingSession = null;
 
 export async function getContractConfig() {
     if (cachedContractConfig) return cachedContractConfig;
@@ -36,29 +41,36 @@ export function closeAppPool() {
 }
 
 export async function createAppPool() {
-    if (!App.state.wallet.connected || !App.state.wallet.address) {
-        throw new Error('Wallet not connected');
-    }
-    if (!App.state.wallet.networkPassphrase) {
-        throw new Error('Wallet network passphrase unavailable');
-    }
-    // wallet.connected flips true before the runtime finishes initializing
-    if (!isRuntimeReady()) {
-        throw new Error('Still connecting to your wallet. Please wait a moment and try again.');
-    }
+    if (pendingSession) return pendingSession;
+    pendingSession = (async () => {
+        if (!App.state.wallet.connected || !App.state.wallet.address) {
+            throw new Error('Wallet not connected');
+        }
+        if (!App.state.wallet.networkPassphrase) {
+            throw new Error('Wallet network passphrase unavailable');
+        }
+        // wallet.connected flips true before the runtime finishes initializing
+        if (!isRuntimeReady()) {
+            throw new Error('Still connecting to your wallet. Please wait a moment and try again.');
+        }
 
-    closeAppPool();
+        closeAppPool();
 
-    const config = await getContractConfig();
-    const poolContract = getActivePoolContractId(config);
-    if (!poolContract) throw new Error('Pool contract ID not available');
-    await client().openAccount(
-        { networkPassphrase: App.state.wallet.networkPassphrase, userAddress: App.state.wallet.address },
-    );
-    const pool = await client().account().pool({ poolContract });
-    activeSession = pool;
-    activeSessionContractId = poolContract;
-    return pool;
+        const config = await getContractConfig();
+        const poolContract = getActivePoolContractId(config);
+        if (!poolContract) throw new Error('Pool contract ID not available');
+        await client().openAccount(
+            { networkPassphrase: App.state.wallet.networkPassphrase, userAddress: App.state.wallet.address },
+        );
+        const pool = await client().account().pool({ poolContract });
+        activeSession = pool;
+        activeSessionContractId = poolContract;
+        App.events.dispatchEvent(new CustomEvent('pool:session-ready', { detail: { poolContract } }));
+        return pool;
+    })().finally(() => {
+        pendingSession = null;
+    });
+    return pendingSession;
 }
 
 export async function ensureAppPool() {

--- a/app/js/ui/transactions.js
+++ b/app/js/ui/transactions.js
@@ -97,21 +97,29 @@ function onEnterUnlessBusy(input, button, handler) {
     });
 }
 
-// Builds a confirmation-dialog row with the number of transactions the action
-// requires. Best-effort only: a failed estimate must not block the action.
-async function txCountRow(amountValue) {
+// Best-effort estimate of how many on-chain transactions an amount requires.
+// Returns null on any failure — the confirmation dialog and submit path already
+// surface anything that truly blocks the operation.
+async function estimateTxCount(amountValue) {
     try {
         const session = await ensureAppPool();
         const estimate = await session.estimate(amountValue);
-        const txCount = estimate?.txCount;
-        if (!txCount) return null;
-        return {
-            label: 'Transactions',
-            value: `${txCount} transaction${txCount === 1 ? '' : 's'}`,
-        };
+        const txCount = Number(estimate?.txCount ?? 0);
+        return txCount > 0 ? txCount : null;
     } catch {
         return null;
     }
+}
+
+// Builds a confirmation-dialog row with the number of transactions the action
+// requires. Best-effort only: a failed estimate must not block the action.
+async function txCountRow(amountValue) {
+    const txCount = await estimateTxCount(amountValue);
+    if (!txCount) return null;
+    return {
+        label: 'Transactions',
+        value: `${txCount} transaction${txCount === 1 ? '' : 's'}`,
+    };
 }
 
 // Re-estimate callbacks for every bound amount input, so a pool change can
@@ -125,10 +133,7 @@ function clearCostHint(hintId) {
 
 // Live "this will take N transactions" hint under an amount input, refreshed as
 // the user types. Only a split is worth flagging, so a single-transaction amount
-// leaves the hint empty. Best-effort like `txCountRow`: a disconnected wallet or
-// a failed estimate clears the hint rather than reporting an error, since the
-// confirmation dialog and submit path already surface anything that truly blocks
-// the operation.
+// leaves the hint empty.
 function bindAmountCostHint(input, hint) {
     if (!input || !hint) return;
     let timer = null;
@@ -145,17 +150,11 @@ function bindAmountCostHint(input, hint) {
             return;
         }
         timer = setTimeout(async () => {
-            try {
-                const session = await ensureAppPool();
-                const estimate = await session.estimate(amount.value);
-                if (current !== seq) return;
-                const txCount = Number(estimate?.txCount ?? 0);
-                hint.textContent = txCount > 1
-                    ? `This amount requires ${txCount} transactions to complete.`
-                    : '';
-            } catch {
-                if (current === seq) hint.textContent = '';
-            }
+            const txCount = await estimateTxCount(amount.value);
+            if (current !== seq) return;
+            hint.textContent = txCount && txCount > 1
+                ? `This amount requires ${txCount} transactions to complete.`
+                : '';
         }, ESTIMATE_DEBOUNCE_MS);
     };
 
@@ -412,7 +411,10 @@ export const Transactions = {
         App.events.addEventListener('pool:config', updateMoveFundsBalance);
         App.events.addEventListener('pool:selected', updateMoveFundsBalance);
         App.events.addEventListener('balances:updated', updateMoveFundsBalance);
-        App.events.addEventListener('pool:selected', refreshCostHints);
+        // Wait for pool.js to publish the new session rather than racing it on
+        // pool:selected — otherwise the debounced estimate can trigger a second
+        // concurrent createAppPool while the first is still in-flight.
+        App.events.addEventListener('pool:session-ready', refreshCostHints);
         App.events.addEventListener('advanced:use-note', (event) => {
             fillNextAdvancedInput(event.detail.id);
             Toast.show('Note added to advanced transact', 'success');

--- a/app/js/ui/transactions.js
+++ b/app/js/ui/transactions.js
@@ -20,6 +20,9 @@ import { onEnter } from './keys.js';
 const DECIMALS = 7;
 const N_OUTPUTS = 2;
 const TX_PROGRESS_EVENT = 'stellar-private-payments:tx-progress';
+// Amount inputs estimate on every keystroke; wait for a pause so a typed-out
+// amount costs one estimate rather than one per digit.
+const ESTIMATE_DEBOUNCE_MS = 300;
 
 function selectedPool() {
     return Utils.selectedPool();
@@ -111,6 +114,61 @@ async function txCountRow(amountValue) {
     }
 }
 
+// Re-estimate callbacks for every bound amount input, so a pool change can
+// refresh all of them without each caller holding its own element references.
+const costHintRefreshers = [];
+
+function clearCostHint(hintId) {
+    const hint = document.getElementById(hintId);
+    if (hint) hint.textContent = '';
+}
+
+// Live "this will take N transactions" hint under an amount input, refreshed as
+// the user types. Only a split is worth flagging, so a single-transaction amount
+// leaves the hint empty. Best-effort like `txCountRow`: a disconnected wallet or
+// a failed estimate clears the hint rather than reporting an error, since the
+// confirmation dialog and submit path already surface anything that truly blocks
+// the operation.
+function bindAmountCostHint(input, hint) {
+    if (!input || !hint) return;
+    let timer = null;
+    let seq = 0;
+
+    const schedule = () => {
+        clearTimeout(timer);
+        // Estimates resolve out of order, so tag each attempt and let only the
+        // newest write the hint — a stale reply describes a discarded amount.
+        const current = ++seq;
+        const amount = parseAmount(input.value, { allowNegative: false });
+        if (!amount.ok || amount.value <= 0n || !App.state.wallet.address || !isRuntimeReady()) {
+            hint.textContent = '';
+            return;
+        }
+        timer = setTimeout(async () => {
+            try {
+                const session = await ensureAppPool();
+                const estimate = await session.estimate(amount.value);
+                if (current !== seq) return;
+                const txCount = Number(estimate?.txCount ?? 0);
+                hint.textContent = txCount > 1
+                    ? `This amount requires ${txCount} transactions to complete.`
+                    : '';
+            } catch {
+                if (current === seq) hint.textContent = '';
+            }
+        }, ESTIMATE_DEBOUNCE_MS);
+    };
+
+    input.addEventListener('input', schedule);
+    costHintRefreshers.push(schedule);
+}
+
+// A pool switch invalidates whatever the hints show — the estimate depends on
+// the notes held in the selected pool — so recompute them against the new one.
+function refreshCostHints() {
+    costHintRefreshers.forEach((schedule) => schedule());
+}
+
 async function submitDeposit(button, amountValue, pool) {
     setLoading(button, true, 'Preparing deposit…');
     const session = await ensureAppPool();
@@ -145,6 +203,7 @@ async function submitTransfer(button, amountValue, pool, transferRefs, transferA
             hashes,
         });
         document.getElementById('transfer-amount').value = '';
+        clearCostHint('transfer-cost-hint');
         transferAddress.value = '';
         transferRefs.noteKey.value = '';
         transferRefs.encKey.value = '';
@@ -171,6 +230,7 @@ async function submitWithdraw(button, amountValue, pool, recipient) {
         });
         document.getElementById('withdraw-amount').value = '';
         document.getElementById('withdraw-recipient').value = '';
+        clearCostHint('withdraw-cost-hint');
     }
 }
 
@@ -325,6 +385,9 @@ export const Transactions = {
             const advancedRecipient = document.getElementById('advanced-public-recipient');
             if (withdrawRecipient) withdrawRecipient.value = address;
             if (advancedRecipient) advancedRecipient.value = address;
+            // An amount typed before connecting was skipped for want of a
+            // wallet; now that there is one, estimate what is already entered.
+            refreshCostHints();
         });
     },
 
@@ -349,6 +412,7 @@ export const Transactions = {
         App.events.addEventListener('pool:config', updateMoveFundsBalance);
         App.events.addEventListener('pool:selected', updateMoveFundsBalance);
         App.events.addEventListener('balances:updated', updateMoveFundsBalance);
+        App.events.addEventListener('pool:selected', refreshCostHints);
         App.events.addEventListener('advanced:use-note', (event) => {
             fillNextAdvancedInput(event.detail.id);
             Toast.show('Note added to advanced transact', 'success');
@@ -412,6 +476,7 @@ export const Transactions = {
 
         const transferAmountInput = document.getElementById('transfer-amount');
         const transferButton = document.getElementById('btn-transfer');
+        bindAmountCostHint(transferAmountInput, document.getElementById('transfer-cost-hint'));
 
         async function runTransfer(button) {
             try {
@@ -476,6 +541,7 @@ export const Transactions = {
         const withdrawRecipientInput = document.getElementById('withdraw-recipient');
         const withdrawAmountInput = document.getElementById('withdraw-amount');
         const withdrawButton = document.getElementById('btn-withdraw');
+        bindAmountCostHint(withdrawAmountInput, document.getElementById('withdraw-cost-hint'));
 
         async function runWithdraw(button) {
             try {


### PR DESCRIPTION
## 🚀 What’s this PR do?

Shows how many on-chain transactions an amount needs **inline, as the user types**, in the transfer and withdraw tabs only when that number is greater than one.

#436 already shows this figure in the confirmation dialog, i.e. after the user commits. This adds the part #386 describes as "updated whenever the input is changed by the user", so a split is visible while the amount can still be adjusted.

---

### 📎 Related issues

Refs #386 not `Closes`, since #436 may already satisfy it in your view. Happy to close this if so.

---

## 🧠 Context

Reuses the existing `PrivatePool.estimate(amount)` call, so the inline hint and the dialog can't disagree.

- Debounced 300ms otherwise one estimate per digit.
- Only shown when `txCount > 1`, per the issue.
- Out-of-order responses discarded by sequence number; a slow estimate must not describe an amount already changed.
- Recomputed on `pool:selected` (estimate is pool-specific) and `wallet:ready` (an amount typed before connecting is skipped for want of a wallet).
- Cleared on successful submit the field is reset programmatically and fires no `input` event.
- Best-effort like `txCountRow`: a failed estimate clears the hint rather than raising.

Note: `txCountRow()` guards with `if (!txCount)`, so the dialog still renders "1 transaction" for single-transaction ops, which #386 asks to suppress. Left untouched as out of scope say the word and I'll align it.

---

## ✅ Required Checklist

- [x] I’ve read the [contributing guide](../CONTRIBUTING.md).
- [ ] I’ve mentioned this PR in the project LinkedIn group (required for review so maintainers can see a human behind the contribution).
- [ ] I’ve tested this locally, run .githooks/pre-push and provided test instructions for maintainers if needed
- [x] I’ve added relevant docs or comments
- [ ] I’ve updated or created tests if needed

