### PR TITLE
Fix bug with worker running after closing the page

### DIFF
--- a/app/js/wasm-facade.js
+++ b/app/js/wasm-facade.js
@@ -126,8 +126,37 @@ export async function ensureStorage() {
     if (!storageHandle) {
         storageHandle = await Storage.open();
         bindAppStorage(storageHandle);
+        installStoragePauseOnUnload();
     }
     return appStorageInstance;
+}
+
+let pauseOnUnloadInstalled = false;
+
+/**
+ * Ask the storage worker to release its OPFS sync access handles as soon as
+ * this page starts unloading, instead of waiting for the worker to be torn
+ * down by the browser (which happens asynchronously and can race the next
+ * page's worker trying to acquire the same handles — surfacing as a false
+ * "another tab is using this app" error).
+ *
+ * Fire-and-forget: we don't await the response, since the page may not
+ * survive long enough to receive it. Posting the request is enough — the
+ * worker releases the handles synchronously as soon as it processes the
+ * message.
+ */
+function installStoragePauseOnUnload() {
+    if (pauseOnUnloadInstalled) {
+        return;
+    }
+    pauseOnUnloadInstalled = true;
+    window.addEventListener('pagehide', () => {
+        try {
+            storageHandle?.call('Pause', 1_000)?.catch(() => {});
+        } catch {
+            // Best-effort: nothing to do if the worker is already gone.
+        }
+    });
 }
 
 /**

--- a/sdk/web/src/protocol.rs
+++ b/sdk/web/src/protocol.rs
@@ -61,6 +61,7 @@ pub struct DisclaimerStatePayload {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum StorageWorkerRequest {
     Ping,
+    Pause,
     SyncState,
     SaveEvents(ContractsEventData),
     SaveSyncProgress {

--- a/sdk/web/src/workers/storage.rs
+++ b/sdk/web/src/workers/storage.rs
@@ -28,6 +28,8 @@ use stellar_private_payments_sdk::{
     },
 };
 use tracing::Instrument;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::JsCast;
 use wasm_bindgen::JsError;
 use wasm_bindgen_futures::spawn_local;
 
@@ -45,16 +47,25 @@ enum InitState {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn is_opfs_locked_error(message: &str) -> bool {
-    message.contains("NoModificationAllowedError")
-        && (message.contains("createSyncAccessHandle")
-            || message.contains("Access Handles cannot be created"))
+fn is_opfs_locked_error(err: &sqlite_wasm_vfs::sahpool::OpfsSAHError) -> bool {
+    // `OpfsSAHError`'s `Display`/`Debug` impls use fixed messages and do not
+    // interpolate the wrapped `JsValue`, so the real DOMException (thrown by
+    // the browser when another tab/worker still holds the OPFS sync access
+    // handles) must be inspected directly rather than via `to_string()`.
+    let sqlite_wasm_vfs::sahpool::OpfsSAHError::CreateSyncAccessHandle(js_err) = err else {
+        return false;
+    };
+    js_err
+        .dyn_ref::<web_sys::DomException>()
+        .is_some_and(|e| e.name() == "NoModificationAllowedError")
 }
 
 thread_local! {
     static STORAGE: RefCell<Option<SqliteStorage>> = const { RefCell::new(None) };
     static PROCESSOR_TX: RefCell<Option<mpsc::Sender<()>>> = const { RefCell::new(None) };
     static INIT_STATE: RefCell<InitState> = const { RefCell::new(InitState::Pending) };
+    #[cfg(target_arch = "wasm32")]
+    static SAH_POOL: RefCell<Option<sqlite_wasm_vfs::sahpool::OpfsSAHPoolUtil>> = const { RefCell::new(None) };
 }
 
 macro_rules! with_storage {
@@ -104,33 +115,55 @@ pub fn worker_main() {
     );
 }
 
+// A prior page's worker still releases its OPFS sync access handles
+// asynchronously after termination, so a fresh worker started right after a
+// navigation can transiently race that teardown. Retry for a bit before
+// treating the lock as held by a genuinely separate tab/window.
+#[cfg(target_arch = "wasm32")]
+const OPFS_LOCK_RETRY_ATTEMPTS: u32 = 10;
+#[cfg(target_arch = "wasm32")]
+const OPFS_LOCK_RETRY_DELAY_MS: u32 = 200;
+
 async fn init() -> Result<(), JsError> {
     INIT_STATE.with(|s| *s.borrow_mut() = InitState::Pending);
 
     #[cfg(target_arch = "wasm32")]
-    if let Err(e) = sqlite_wasm_vfs::sahpool::install::<sqlite_wasm_rs::WasmOsCallback>(
-        &sqlite_wasm_vfs::sahpool::OpfsSAHPoolCfg::default(),
-        true,
-    )
-    .await
     {
-        let error_details = format!("{e:?}");
-        let text = e.to_string();
-        let combined = if text.is_empty() {
-            error_details.clone()
-        } else {
-            format!("{text} {error_details}")
-        };
+        let mut attempt = 0;
+        loop {
+            match sqlite_wasm_vfs::sahpool::install::<sqlite_wasm_rs::WasmOsCallback>(
+                &sqlite_wasm_vfs::sahpool::OpfsSAHPoolCfg::default(),
+                true,
+            )
+            .await
+            {
+                Ok(util) => {
+                    SAH_POOL.with(|s| *s.borrow_mut() = Some(util));
+                    break;
+                }
+                Err(e) if is_opfs_locked_error(&e) && attempt < OPFS_LOCK_RETRY_ATTEMPTS => {
+                    attempt += 1;
+                    tracing::debug!(
+                        attempt,
+                        "[{WORKER_NAME}] OPFS SAH pool still locked by a previous worker, retrying"
+                    );
+                    TimeoutFuture::new(OPFS_LOCK_RETRY_DELAY_MS).await;
+                }
+                Err(e) => {
+                    let error_details = format!("{e:?}");
 
-        let msg = if is_opfs_locked_error(&combined) {
-            "Another tab or window is using this app's local database. Please close other tabs/windows running this app, then reload this page.".to_string()
-        } else {
-            "Failed to initialize local database storage.".to_string()
-        };
+                    let msg = if is_opfs_locked_error(&e) {
+                        "Another tab or window is using this app's local database. Please close other tabs/windows running this app, then reload this page.".to_string()
+                    } else {
+                        "Failed to initialize local database storage.".to_string()
+                    };
 
-        tracing::error!(details = %error_details, "[{WORKER_NAME}] fatal error installing OPFS Sqlite VFS");
-        INIT_STATE.with(|s| *s.borrow_mut() = InitState::Failed(msg.clone()));
-        return Err(JsError::new(&msg));
+                    tracing::error!(details = %error_details, "[{WORKER_NAME}] fatal error installing OPFS Sqlite VFS");
+                    INIT_STATE.with(|s| *s.borrow_mut() = InitState::Failed(msg.clone()));
+                    return Err(JsError::new(&msg));
+                }
+            }
+        }
     }
 
     let storage = match SqliteStorage::connect() {
@@ -185,6 +218,24 @@ pub(crate) async fn StorageWorker(
 // Main router of worker requests
 pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerResponse> {
     let resp = match req {
+        StorageWorkerRequest::Pause => {
+            tracing::debug!("[{WORKER_NAME}] pausing OPFS SAH pool ahead of page unload");
+            // `pause_vfs` refuses to release handles while SQLite still has
+            // files open on this VFS, so the live connection must be closed
+            // first — this worker is about to be torn down by the browser
+            // anyway, and any in-flight request will simply fail from here on.
+            let dropped_storage = STORAGE.with(|s| s.borrow_mut().take());
+            drop(dropped_storage);
+            #[cfg(target_arch = "wasm32")]
+            SAH_POOL.with(|s| {
+                if let Some(pool) = s.borrow().as_ref()
+                    && let Err(e) = pool.pause_vfs()
+                {
+                    tracing::debug!("[{WORKER_NAME}] pause_vfs failed: {e:#}");
+                }
+            });
+            StorageWorkerResponse::Saved
+        }
         StorageWorkerRequest::Ping => {
             tracing::trace!("[{WORKER_NAME}] ping");
             loop {


### PR DESCRIPTION
Each page (index.html/admin.html) spawns its own dedicated storage worker, which installs an OPFS SQLite VFS (sahpool). Navigating between them raced the outgoing worker's OPFS handle release against the incoming worker's acquire, and the failure was consistently misreported:

- OpfsSAHError's Display/Debug never interpolate the wrapped JsValue, so the lock-detection heuristic (is_opfs_locked_error) was matching against a string that could never contain the real DOMException text, always falling through to a generic "Failed to initialize" toast.
- After fixing detection to inspect the DomException directly, a retry loop was added to tolerate the async release race — but pause_vfs() refuses to release handles while SQLite still has files open, and the worker never closed its connection, so the "release on pagehide" path was a silent no-op.

Fixes, in order of effect:
- is_opfs_locked_error now matches on OpfsSAHError::CreateSyncAccessHandle and checks the wrapped DomException's name directly.
- storage worker retries sahpool::install for ~2s on a detected lock before surfacing the "another tab" message, tolerating the normal async handle-release delay.
- New Pause request: on the page's `pagehide` event, the main thread fire-and-forgets a Pause call; the worker now drops its live SQLite connection first (closing the VFS file) so pause_vfs() can actually succeed, releasing the OPFS pool before the browser tears the worker down.  

Note: The issue is reproduced in Firefox