### PR TITLE
Fix log level test in release mode

### DIFF
--- a/sdk/web/src/telemetry.rs
+++ b/sdk/web/src/telemetry.rs
@@ -501,12 +501,12 @@ mod tests {
             set_log_level("error").expect("set level to error");
             // The loop body is a single callsite visited twice: the first
             // visit is filtered out at error level, the second must be
-            // emitted after raising the level to debug.
+            // emitted after raising the level to warn.
             for round in 0..2 {
                 if round == 1 {
-                    set_log_level("debug").expect("set level to debug");
+                    set_log_level("warn").expect("set level to warn");
                 }
-                tracing::debug!("loop callsite event");
+                tracing::warn!("loop callsite event");
             }
             set_log_level("info").expect("restore level");
 


### PR DESCRIPTION
This test was failing in release mode (e.g., in root `cargo test --release`) since debug level logs are not emitted in that mode. This just changes the test level from debug to warn, keeping the same test purpose.