### PR TITLE
Refactor witness graph generation

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -40,7 +40,7 @@ if ! typos; then
     exit 4
 fi
 
-# Linting (--all-features would enable regen-graph, whose build script requires
+# Linting (--all-features would enable witness-graph, whose build script requires
 # WITNESS_CPP; mirror .github/workflows/linter.yml with an explicit list)
 if ! cargo clippy --all-targets -- -D warnings; then
     echo "❌ Clippy violations (check warnings above)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ The circuit compiler (`tools/circuit-compiler`, via `make circuits`) also honors
 - **`--tests`** (`make circuits TESTS=1`): Builds the circom test circuits. Most Circom circuits simply define a template. And if you want to use it or test it, you need to instantiate it with some specific parameters.
 For efficiency, the compilation of these circuits test is gatekeeped behind this flag. When enabled, if the verifying keys are not in `testdata`, it will generate them. Deployed testnet keys are committed under `deployments/testnet/circuit_keys`.
 - **`--regen-keys`** (`make circuits REGEN_KEYS=1`): Forces the generation of new verification keys. R1CS compilation uses Circom `--O2`.
-- **`--graphs`** (`make circuits GRAPHS=1`): Regenerates `*.graph.bin` witness graphs after compiling the circuits. Requires the Circom CLI version in `circuits/circom.lock` and a C++ toolchain. Graphs are written next to R1CS/WASM under `target/circuits-artifacts/` (or `--out`).
+- **`--graphs`** (`make circuits GRAPHS=1`): Regenerates `*.graph.bin` witness graphs after compiling. Requires Circom CLI matching `circuits/circom.lock` and a C++ toolchain. Graphs land in `target/circuits-artifacts/`; copy them into `deployments/testnet/circuit_keys/` to update committed artifacts.
 
 Also, for efficiency reasons, some tests are ignored by default. To run them:
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ Also we delete `ethereum.rs` module to get rid of many irrelevant dependencies.
 the `soroban-sdk` - see https://github.com/NethermindEth/stellar-private-payments/issues/192.
 This patch remains for **circuits / ceremony** builds that still use ark-circom → Wasmer + Cranelift.
 The native SDK (`stellar-private-payments`) no longer depends on Wasmer; witness generation uses
-committed `circom-witness-rs` graphs (see `make witness-graphs`).
+committed `circom-witness-rs` graphs (see `make circuits GRAPHS=1`).
 
 ### Running WASM tests
 
@@ -134,8 +134,8 @@ make circuits
 The circuit compiler (`tools/circuit-compiler`, via `make circuits`) also honors these flags:
 - **`--tests`** (`make circuits TESTS=1`): Builds the circom test circuits. Most Circom circuits simply define a template. And if you want to use it or test it, you need to instantiate it with some specific parameters.
 For efficiency, the compilation of these circuits test is gatekeeped behind this flag. When enabled, if the verifying keys are not in `testdata`, it will generate them. Deployed testnet keys are committed under `deployments/testnet/circuit_keys`.
-- **`--regen-keys`** (`make circuits REGEN_KEYS=1`): Forces the generation of new verification keys. R1CS compilation uses Circom `--O2` (same as `make witness-graphs`).
-- **`make witness-graphs`**: Regenerates committed `*.graph.bin` witness graphs (`--features regen-graph` with `WITNESS_CPP` + `CIRCOM_LIBRARY_PATH` per circuit). Requires Circom CLI matching `circuits/circom.lock` and a C++ toolchain. Note: running with `--features regen-graph` and `WITNESS_CPP` set writes generated `*.graph.bin` files directly into `circuits/` and `deployments/testnet/circuit_keys/` (outside `target/circuits-artifacts/`), dirtying source-tree files.
+- **`--regen-keys`** (`make circuits REGEN_KEYS=1`): Forces the generation of new verification keys. R1CS compilation uses Circom `--O2`.
+- **`--graphs`** (`make circuits GRAPHS=1`): Regenerates `*.graph.bin` witness graphs after compiling the circuits. Requires the Circom CLI version in `circuits/circom.lock` and a C++ toolchain. Graphs are written next to R1CS/WASM under `target/circuits-artifacts/` (or `--out`).
 
 Also, for efficiency reasons, some tests are ignored by default. To run them:
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build-debug:
 .PHONY: circuits
 circuits:
 	@echo "Building circuits (this may take a while)..."
-	cargo run -p circuit-compiler --release -- compile \
+	cargo run -p circuit-compiler --bin circuit-compiler --release -- compile \
 		--circuits $(CURDIR)/circuits \
 		--out $(CURDIR)/target/circuits-artifacts $(if $(TESTS),--tests) $(if $(REGEN_KEYS),--regen-keys) $(if $(GRAPHS),--graphs)
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ DIST_DIR ?= dist
 PUBLIC_URL ?= /
 TESTS ?=
 REGEN_KEYS ?=
+GRAPHS ?=
 RELEASE ?=
 # LOGS=1 builds the WASM SDK with verbose diagnostic logging enabled
 # (WASM_PROFILE=release-with-logs) instead of the quiet, privacy-first default.
@@ -43,49 +44,7 @@ circuits:
 	@echo "Building circuits (this may take a while)..."
 	cargo run -p circuit-compiler --release -- compile \
 		--circuits $(CURDIR)/circuits \
-		--out $(CURDIR)/target/circuits-artifacts \
-		$(if $(TESTS),--tests) \
-		$(if $(REGEN_KEYS),--regen-keys)
-
-# Production stems for circom-witness-rs graph regen (keep in sync with SDK).
-WITNESS_GRAPH_STEMS := \
-	policy_tx_2_2.circom \
-	policy_tx_2_2_A.circom \
-	policy_tx_2_2_B.circom \
-	policy_tx_2_2_AB.circom \
-	selectiveDisclosure_1.circom \
-	selectiveDisclosure_2.circom \
-	selectiveDisclosure_3.circom \
-	selectiveDisclosure_4.circom
-
-# Vendors circomlib and injects the black-box hints the graph runtime needs.
-.PHONY: circomlib-hints
-circomlib-hints:
-	@echo "Applying circomlib black-box hints..."
-	@CIRCOMLIB_HINTS_ONLY=1 cargo run -p circuit-compiler -- compile \
-		--circuits $(CURDIR)/circuits \
-		--out $(CURDIR)/target/circuits-artifacts
-	@grep -q "function bbf_inv" circuits/src/circomlib/circuits/comparators.circom || \
-		{ echo "circomlib hints missing after priming build"; exit 1; }
-
-# Regenerates committed circom-witness-rs graphs under
-# deployments/testnet/circuit_keys/*.graph.bin. Requires Circom CLI matching
-# circuits/circom.lock and a C++ toolchain. One stem per run (single-
-# circuit circom-witness-rs); clean between stems so WITNESS_CPP is re-read.
-.PHONY: witness-graphs
-witness-graphs: circomlib-hints
-	@echo "Regenerating witness graphs (Circom $$(tr -d '[:space:]' < circuits/circom.lock))..."
-	@for entry in $(WITNESS_GRAPH_STEMS); do \
-		stem=$${entry%.circom}; \
-		echo "===== $$stem ====="; \
-		cargo clean -p circom-witness-rs >/dev/null; \
-		CIRCOM_LIBRARY_PATH="$(CURDIR)/circuits/src" \
-		WITNESS_CPP="$(CURDIR)/circuits/src/$$entry" \
-		cargo run -p circuit-compiler --features regen-graph -- compile \
-			--circuits $(CURDIR)/circuits \
-			--out $(CURDIR)/target/circuits-artifacts || exit 1; \
-	done
-	@echo "Done. Graphs in deployments/testnet/circuit_keys/"
+		--out $(CURDIR)/target/circuits-artifacts $(if $(TESTS),--tests) $(if $(REGEN_KEYS),--regen-keys) $(if $(GRAPHS),--graphs)
 
 # Both targets record the built profile in sdk/web/.trunk-wasm-profile so a
 # subsequent `trunk serve`/`trunk build` (which `serve`/`build` invoke) sees a

--- a/cli/src/artifacts.rs
+++ b/cli/src/artifacts.rs
@@ -66,7 +66,7 @@ fn read_circuit_graph(circuits: &Path, stem: &str) -> Result<Vec<u8>> {
     let committed = committed_circuit_keys_dir().join(format!("{stem}.graph.bin"));
     std::fs::read(&committed).with_context(|| {
         format!(
-            "read {stem} witness graph from {} or {} (run `make witness-graphs`)",
+            "read {stem} witness graph from {} or {} (run `make circuits GRAPHS=1` and copy into circuit_keys)",
             runtime.display(),
             committed.display(),
         )

--- a/deployments/scripts/package-circuits-source-bundle.sh
+++ b/deployments/scripts/package-circuits-source-bundle.sh
@@ -77,19 +77,16 @@ cp -R circuits/src/ <REPO_ROOT>/circuits/src/
 At minimum, ensure:
 \`<REPO_ROOT>/circuits/src/circomlib\` matches revision: $LOCK_SHA
 
-3) From the repository root, build R1CS artifacts and regenerate witness graphs.
-   Requires Circom CLI matching \`circuits/circom.lock\` and a C++ toolchain for
-   graphs:
+3) From the repository root, rebuild R1CS and witness graphs:
 
 \`\`\`
-make circuits
-make witness-graphs
+make circuits GRAPHS=1
 \`\`\`
 
-R1CS files land under \`target/circuits-artifacts/\`. Graph files
-(\`*.graph.bin\`) are written to \`deployments/testnet/circuit_keys/\`. The web
-SDK staging script (\`sdk/web/scripts/stage-circuits-dist.sh\`) copies both into
-\`dist/circuits/\` for redistribution.
+R1CS and \`*.graph.bin\` land under \`target/circuits-artifacts/\`. Copy graphs
+into \`deployments/testnet/circuit_keys/\` before restaging. The web SDK
+staging script copies R1CS from artifacts and graphs/keys from
+\`circuit_keys/\` into \`dist/circuits/\`.
 EOF
 
 mkdir -p "$TMP_DIR/src/licenses"

--- a/deployments/testnet/circuit_keys/README.md
+++ b/deployments/testnet/circuit_keys/README.md
@@ -11,9 +11,12 @@ This directory contains the Groth16 key material used by the testnet deployment.
 ## Witness graphs (`*.graph.bin`)
 
 Native and browser witness generation uses committed `circom-witness-rs` operation
-graphs (not Circom WASM / Wasmer). Regenerate with `make witness-graphs`.
+graphs (not Circom WASM / Wasmer). Regenerate with `make circuits GRAPHS=1`, then
+copy the `*.graph.bin` files from `target/circuits-artifacts/` into this
+directory to update the committed artifacts.
 The Circom CLI must match `circuits/circom.lock` (pinned to the same release as
-the Rust circom crates used for R1CS).
+the Rust circom crates used for R1CS), and graph generation requires a C++
+toolchain.
 
 Committed for all production stems: `policy_tx_2_2`, `policy_tx_2_2_{A,B,AB}`,
 and `selectiveDisclosure_{1..4}`.

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -134,7 +134,7 @@ The circuit compiler (`tools/circuit-compiler`, via `make circuits`) also honors
 - **`--tests`** (`make circuits TESTS=1`): Builds the circom test circuits. Most Circom circuits simply define a template. And if you want to use it or test it, you need to instantiate it with some specific parameters.
 For efficiency, the compilation of these circuits test is gatekeeped behind this flag. When enabled, if the verifying keys are not in `testdata`, it will generate them. Deployed testnet keys are committed under `deployments/testnet/circuit_keys`.
 - **`--regen-keys`** (`make circuits REGEN_KEYS=1`): Forces the generation of new verification keys. R1CS compilation uses Circom `--O2`.
-- **`--graphs`** (`make circuits GRAPHS=1`): Regenerates `*.graph.bin` witness graphs after compiling the circuits. Requires the Circom CLI version in `circuits/circom.lock` and a C++ toolchain. Graphs are written next to R1CS/WASM under `target/circuits-artifacts/` (or `--out`).
+- **`--graphs`** (`make circuits GRAPHS=1`): Regenerates `*.graph.bin` witness graphs after compiling. Requires Circom CLI matching `circuits/circom.lock` and a C++ toolchain. Graphs land in `target/circuits-artifacts/`; copy them into `deployments/testnet/circuit_keys/` to update committed artifacts.
 
 Also, for efficiency reasons, some tests are ignored by default. To run them:
 ```bash

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -106,7 +106,7 @@ Also we delete `ethereum.rs` module to get rid of many irrelevant dependencies.
 the `soroban-sdk` - see https://github.com/NethermindEth/stellar-private-payments/issues/192.
 This patch remains for **circuits / ceremony** builds that still use ark-circom → Wasmer + Cranelift.
 The native SDK (`stellar-private-payments`) no longer depends on Wasmer; witness generation uses
-committed `circom-witness-rs` graphs (see `make witness-graphs`).
+committed `circom-witness-rs` graphs (see `make circuits GRAPHS=1`).
 
 ### Running WASM tests
 
@@ -133,8 +133,8 @@ make circuits
 The circuit compiler (`tools/circuit-compiler`, via `make circuits`) also honors these flags:
 - **`--tests`** (`make circuits TESTS=1`): Builds the circom test circuits. Most Circom circuits simply define a template. And if you want to use it or test it, you need to instantiate it with some specific parameters.
 For efficiency, the compilation of these circuits test is gatekeeped behind this flag. When enabled, if the verifying keys are not in `testdata`, it will generate them. Deployed testnet keys are committed under `deployments/testnet/circuit_keys`.
-- **`--regen-keys`** (`make circuits REGEN_KEYS=1`): Forces the generation of new verification keys. R1CS compilation uses Circom `--O2` (same as `make witness-graphs`).
-- **`make witness-graphs`**: Regenerates committed `*.graph.bin` witness graphs (`--features regen-graph` with `WITNESS_CPP` + `CIRCOM_LIBRARY_PATH` per circuit). Requires Circom CLI matching `circuits/circom.lock` and a C++ toolchain. Note: running with `--features regen-graph` and `WITNESS_CPP` set writes generated `*.graph.bin` files directly into `circuits/` and `deployments/testnet/circuit_keys/` (outside `target/circuits-artifacts/`), dirtying source-tree files.
+- **`--regen-keys`** (`make circuits REGEN_KEYS=1`): Forces the generation of new verification keys. R1CS compilation uses Circom `--O2`.
+- **`--graphs`** (`make circuits GRAPHS=1`): Regenerates `*.graph.bin` witness graphs after compiling the circuits. Requires the Circom CLI version in `circuits/circom.lock` and a C++ toolchain. Graphs are written next to R1CS/WASM under `target/circuits-artifacts/` (or `--out`).
 
 Also, for efficiency reasons, some tests are ignored by default. To run them:
 ```bash

--- a/tools/circuit-compiler/Cargo.toml
+++ b/tools/circuit-compiler/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 repository.workspace = true
 license = "GPL-3.0"
 publish = false
+default-run = "circuit-compiler"
 
 [lib]
 name = "circuit_compiler"
@@ -14,10 +15,15 @@ path = "src/lib.rs"
 name = "circuit-compiler"
 path = "bin/compiler.rs"
 
+[[bin]]
+name = "circuit-witness-graph-generator"
+path = "bin/witness-graph-generator.rs"
+required-features = ["witness-graph"]
+
 [features]
 default = []
-# Enables circom-witness-rs C++ graph generation (`make witness-graphs`).
-regen-graph = ["dep:circom-witness-rs"]
+# Enables the circom-witness-rs C++ witness-graph-generator binary.
+witness-graph = ["dep:circom-witness-rs"]
 
 [dependencies]
 # workspace

--- a/tools/circuit-compiler/bin/compiler.rs
+++ b/tools/circuit-compiler/bin/compiler.rs
@@ -22,7 +22,7 @@ enum Commands {
         /// Circom package directory (`src/`, lockfiles)
         #[arg(long, default_value = concat!(env!("CARGO_MANIFEST_DIR"), "/../../circuits"))]
         circuits: PathBuf,
-        /// Directory for published R1CS/WASM
+        /// Directory for published R1CS/WASM/graphs
         #[arg(long, default_value = concat!(env!("CARGO_MANIFEST_DIR"), "/../../target/circuits-artifacts"))]
         out: PathBuf,
         /// Include circuits under directories named `test`
@@ -31,6 +31,9 @@ enum Commands {
         /// Force Groth16 key regeneration even if keys already exist
         #[arg(long)]
         regen_keys: bool,
+        /// Regenerate witness graphs after compilation
+        #[arg(long)]
+        graphs: bool,
     },
 }
 
@@ -42,11 +45,13 @@ fn main() -> Result<()> {
             out,
             tests,
             regen_keys,
+            graphs,
         } => circuit_compiler::run(CompileOptions {
             circuits,
             out,
             tests,
             regen_keys,
+            graphs,
         }),
     }
 }

--- a/tools/circuit-compiler/bin/witness-graph-generator.rs
+++ b/tools/circuit-compiler/bin/witness-graph-generator.rs
@@ -1,0 +1,28 @@
+//! Single-circuit witness graph generator.
+//!
+//! circom-witness-rs 0.3 selects the circuit at build time through
+//! `WITNESS_CPP`, so the compiler rebuilds and invokes this binary once per
+//! production circuit.
+
+use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "circuit-witness-graph-generator",
+    about = "Generate the witness graph baked into circom-witness-rs"
+)]
+struct Cli {
+    /// Circom package directory (`src/`, lockfiles)
+    #[arg(long, default_value = concat!(env!("CARGO_MANIFEST_DIR"), "/../../circuits"))]
+    circuits: PathBuf,
+    /// Directory for published `*.graph.bin` files
+    #[arg(long, default_value = concat!(env!("CARGO_MANIFEST_DIR"), "/../../target/circuits-artifacts"))]
+    out: PathBuf,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    circuit_compiler::generate_witness_graph(&cli.circuits, &cli.out)
+}

--- a/tools/circuit-compiler/src/lib.rs
+++ b/tools/circuit-compiler/src/lib.rs
@@ -3,9 +3,6 @@
 //! Circom sources live under workspace `circuits/`. This crate builds
 //! R1CS / WASM / keys / witness graphs. The CLI entrypoint is
 //! `bin/compiler.rs`.
-//!
-//! Graph regen still uses `WITNESS_CPP` / `CIRCOM_LIBRARY_PATH` (consumed by
-//! `circom-witness-rs` at crate-build time).
 
 use anyhow::{Context, Result, anyhow, bail};
 use ark_bn254::Bn254;
@@ -22,12 +19,16 @@ use constraint_writers::ConstraintExporter;
 use program_structure::error_definition::Report;
 use regex::Regex;
 use std::{
-    env, fs,
+    fs,
     path::{Path, PathBuf},
     process::Command,
     string::ToString,
 };
 use type_analysis::check_types::check_types;
+
+mod witness;
+
+pub use witness::generate_witness_graph;
 
 const CURVE_ID: &str = "bn128";
 
@@ -76,7 +77,7 @@ fn groth16_key_circuits() -> Vec<String> {
     circuits
 }
 
-fn copy(src: &Path, dst: &Path) -> Result<()> {
+pub(crate) fn copy(src: &Path, dst: &Path) -> Result<()> {
     if let Some(parent) = dst.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("Could not create directory {}", parent.display()))?;
@@ -118,13 +119,15 @@ fn publish_circuit_artifacts(
 pub struct CompileOptions {
     /// Circom package directory (`src/`, `circom.lock`, `circomlib.lock`).
     pub circuits: PathBuf,
-    /// Directory for published R1CS/WASM (and compile intermediates under
-    /// `out/`).
+    /// Directory for published R1CS/WASM/graphs (and compile intermediates
+    /// under `out/`).
     pub out: PathBuf,
     /// Include `.circom` files under directories named `test`.
     pub tests: bool,
     /// Force Groth16 key regeneration even when keys already exist.
     pub regen_keys: bool,
+    /// Regenerate witness graphs after a successful compile.
+    pub graphs: bool,
 }
 
 /// Run the full compile pipeline (circomlib, R1CS/WASM, keys, optional graphs).
@@ -151,13 +154,7 @@ pub fn run(opts: CompileOptions) -> Result<()> {
     // revision in `circomlib.lock` for reproducible builds.
     get_circomlib(&circuits_dir, &src_dir)?;
     // The hints stay on disk after the build
-    let circomlib_was_patched = inject_black_box_hints(&src_dir.join("circomlib"))?;
-
-    // `make witness-graphs` primes hints through this flag (circom-witness-rs).
-    if env::var("CIRCOMLIB_HINTS_ONLY").is_ok() {
-        eprintln!("CIRCOMLIB_HINTS_ONLY set. Stopping after circomlib hints");
-        return Ok(());
-    }
+    witness::inject_black_box_hints(&src_dir.join("circomlib"))?;
 
     // === FIND CIRCOM FILES ===
     // Find all .circom files with a main component
@@ -388,12 +385,8 @@ pub fn run(opts: CompileOptions) -> Result<()> {
         }
     }
 
-    // === WITNESS GRAPH REGENERATION ===
-    // Committed graphs: deployments/testnet/circuit_keys/<stem>.graph.bin
-    // Regen via `make witness-graphs` / `--features regen-graph` with
-    // `WITNESS_CPP` + `CIRCOM_LIBRARY_PATH` for one circuit at a time.
-    if env::var("WITNESS_CPP").is_ok() {
-        regenerate_witness_graphs(&circuits_dir, &out_dir, circomlib_was_patched)?;
+    if opts.graphs {
+        witness::generate_witness_graphs(&circuits_dir, &publish_dir)?;
     }
 
     Ok(())
@@ -818,184 +811,8 @@ fn get_circomlib(circuits_dir: &Path, src_dir: &Path) -> Result<()> {
         return Err(anyhow!("git checkout failed for circomlib dependency"));
     }
 
-    inject_black_box_hints(&circomlib_path)?;
+    witness::inject_black_box_hints(&circomlib_path)?;
     Ok(())
-}
-
-/// Run circom-witness-rs graph generation and publish a `*.graph.bin` artifact.
-///
-/// Requires `--features regen-graph` (so the C++ generator is linked) plus
-/// `WITNESS_CPP` / `CIRCOM_LIBRARY_PATH` (see `make witness-graphs`).
-/// Circom CLI must match `circuits/circom.lock`.
-///
-/// `circomlib_was_patched` reports whether the black-box hints were already on
-/// disk when this build started
-///
-/// Expects a single `.circom` path in `WITNESS_CPP`. Writes
-/// `deployments/testnet/circuit_keys/<stem>.graph.bin`.
-fn regenerate_witness_graphs(
-    circuits_dir: &Path,
-    out_dir: &Path,
-    circomlib_was_patched: bool,
-) -> Result<()> {
-    #[cfg(not(feature = "regen-graph"))]
-    {
-        let _ = (circuits_dir, out_dir, circomlib_was_patched);
-        bail!(
-            "WITNESS_CPP requires `cargo run -p circuit-compiler --features regen-graph -- compile` \
-             (see `make witness-graphs`)"
-        );
-    }
-
-    #[cfg(feature = "regen-graph")]
-    {
-        let expected = fs::read_to_string(circuits_dir.join("circom.lock"))
-            .context("read circuits/circom.lock")?
-            .trim()
-            .to_string();
-        let ver = Command::new("circom")
-            .arg("--version")
-            .output()
-            .context("run `circom --version` (is Circom on PATH?)")?;
-        let ver_text = format!(
-            "{}{}",
-            String::from_utf8_lossy(&ver.stdout),
-            String::from_utf8_lossy(&ver.stderr)
-        );
-        anyhow::ensure!(
-            ver.status.success() && ver_text.contains(&expected),
-            "Circom CLI must be {expected} (circuits/circom.lock); got:\n{ver_text}"
-        );
-
-        anyhow::ensure!(
-            circomlib_was_patched,
-            "circomlib was missing the black-box hints when circom-witness-rs \
-             generated its C++; they are applied now, so re-run the build"
-        );
-
-        let witness_cpp = env::var("WITNESS_CPP")
-            .map_err(|_| anyhow!("WITNESS_CPP must be set for graph regeneration"))?;
-        let stem = Path::new(witness_cpp.trim())
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .ok_or_else(|| anyhow!("invalid WITNESS_CPP circuit path: {witness_cpp}"))?;
-
-        eprintln!("WITNESS_CPP detected - regenerating witness graph for {stem}");
-        circom_witness_rs::generate::build_witness()
-            .map_err(|e| anyhow!("witness graph generation failed: {e}"))?;
-
-        // circom-witness-rs typically writes `graph.bin` into the process cwd.
-        let tool_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let mut candidates = vec![
-            env::current_dir().ok().map(|d| d.join("graph.bin")),
-            Some(out_dir.join("graph.bin")),
-            Some(tool_dir.join("graph.bin")),
-        ];
-        let src = candidates
-            .drain(..)
-            .flatten()
-            .find(|p| p.is_file())
-            .ok_or_else(|| anyhow!("expected circom-witness-rs to write graph.bin; not found"))?;
-        let dst = circuits_dir
-            .join("..")
-            .join("deployments/testnet/circuit_keys")
-            .join(format!("{stem}.graph.bin"));
-        copy(&src, &dst)?;
-        fs::remove_file(&src)?;
-        eprintln!("Wrote witness graph {}", dst.display());
-        Ok(())
-    }
-}
-
-/// Inject the `bbf_inv` / `bbf_bit` black-box hint functions into
-/// circomlib and route the non-quadratic (`<--`) assignments through them.
-///
-/// circom-witness-rs only hooks unconstrained/dynamic control flow when it
-/// lives in a `bbf*`-prefixed circom *function*. Stock circomlib computes
-/// `1/in` (`IsZero`) and the bit decomposition (`Num2Bits`) inline inside
-/// templates, which the graph runtime cannot evaluate.
-///
-/// Returns `true` when every hint was already present, i.e. this build did not
-/// have to touch circomlib.
-fn inject_black_box_hints(circomlib_path: &Path) -> Result<bool> {
-    let circuits_dir = circomlib_path.join("circuits");
-
-    let comparators_hinted = inject_hint(
-        &circuits_dir.join("comparators.circom"),
-        "function bbf_inv",
-        "include \"binsum.circom\";",
-        "\n\nfunction bbf_inv(in) {\n    return in!=0 ? 1/in : 0;\n}",
-        &[("    inv <-- in!=0 ? 1/in : 0;", "    inv <-- bbf_inv(in);")],
-    )?;
-
-    let bitify_hinted = inject_hint(
-        &circuits_dir.join("bitify.circom"),
-        "function bbf_bit",
-        "include \"aliascheck.circom\";",
-        "\n\nfunction bbf_bit(in, bit) {\n    return (in >> bit) & 1;\n}",
-        &[
-            (
-                "        out[i] <-- (in >> i) & 1;",
-                "        out[i] <-- bbf_bit(in, i);",
-            ),
-            (
-                "        out[i] <-- (neg >> i) & 1;",
-                "        out[i] <-- bbf_bit(neg, i);",
-            ),
-        ],
-    )?;
-
-    Ok(comparators_hinted && bitify_hinted)
-}
-
-/// Apply a single circomlib black-box hint patch (one `bbf_*` function).
-///
-/// Returns `true` if the hint was already present and the file was left alone.
-fn inject_hint(
-    file: &Path,
-    marker: &str,
-    anchor: &str,
-    fn_def: &str,
-    rewrites: &[(&str, &str)],
-) -> Result<bool> {
-    let content =
-        fs::read_to_string(file).with_context(|| format!("Failed to read {}", file.display()))?;
-
-    if content.contains(marker) {
-        return Ok(true);
-    }
-
-    let anchor_idx = content
-        .find(anchor)
-        .ok_or_else(|| anyhow!("anchor {anchor:?} not found in {}", file.display()))?;
-    let insert_at = content[anchor_idx..]
-        .find('\n')
-        .map(|nl| anchor_idx.checked_add(nl).expect("anchor lines overflow"))
-        .ok_or_else(|| anyhow!("no newline after anchor {anchor:?} in {}", file.display()))?;
-
-    let mut patched = String::with_capacity(
-        content
-            .len()
-            .checked_add(fn_def.len())
-            .expect("circomlib patch size overflow"),
-    );
-    patched.push_str(&content[..=insert_at]);
-    patched.push_str(fn_def);
-    patched.push_str(&content[insert_at.checked_add(1).expect("insert_at overflow")..]);
-
-    for (from, to) in rewrites {
-        if !patched.contains(from) {
-            bail!(
-                "rewrite source {from:?} not found in {} (upstream circomlib changed?)",
-                file.display()
-            );
-        }
-        patched = patched.replace(from, to);
-    }
-
-    fs::write(file, patched).with_context(|| format!("Failed to write {}", file.display()))?;
-    eprintln!("Injected {marker} into {}", file.display());
-    Ok(false)
 }
 
 /// Compile WASM using Rust through Circom library

--- a/tools/circuit-compiler/src/witness.rs
+++ b/tools/circuit-compiler/src/witness.rs
@@ -1,0 +1,238 @@
+//! Witness-graph generation (`circom-witness-rs` 0.3).
+
+use anyhow::{Context, Result, anyhow, bail};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[cfg(feature = "witness-graph")]
+use crate::copy;
+
+const WITNESS_GRAPH_CIRCUITS: &[&str] = &[
+    "policy_tx_2_2",
+    "policy_tx_2_2_A",
+    "policy_tx_2_2_B",
+    "policy_tx_2_2_AB",
+    "selectiveDisclosure_1",
+    "selectiveDisclosure_2",
+    "selectiveDisclosure_3",
+    "selectiveDisclosure_4",
+];
+
+fn check_circom_version(circuits_dir: &Path) -> Result<()> {
+    let expected = fs::read_to_string(circuits_dir.join("circom.lock"))
+        .context("read circuits/circom.lock")?
+        .trim()
+        .to_string();
+    let version = Command::new("circom")
+        .arg("--version")
+        .output()
+        .context("run `circom --version` (is Circom on PATH?)")?;
+    let version_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&version.stdout),
+        String::from_utf8_lossy(&version.stderr)
+    );
+    anyhow::ensure!(
+        version.status.success() && version_text.contains(&expected),
+        "Circom CLI must be {expected} (circuits/circom.lock); got:\n{version_text}"
+    );
+    Ok(())
+}
+
+/// Rebuild circom-witness-rs once per production circuit and emit its graph.
+///
+/// Version 0.3 selects the circuit in its build script, so each worker needs a
+/// clean dependency build with a different `WITNESS_CPP`.
+pub(crate) fn generate_witness_graphs(circuits_dir: &Path, out_dir: &Path) -> Result<()> {
+    check_circom_version(circuits_dir)?;
+
+    let circuits_dir = fs::canonicalize(circuits_dir)
+        .with_context(|| format!("canonicalize {}", circuits_dir.display()))?;
+    fs::create_dir_all(out_dir)
+        .with_context(|| format!("Could not create {}", out_dir.display()))?;
+    let out_dir =
+        fs::canonicalize(out_dir).with_context(|| format!("canonicalize {}", out_dir.display()))?;
+    let workspace_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+
+    for stem in WITNESS_GRAPH_CIRCUITS {
+        eprintln!("Regenerating witness graph for {stem}");
+
+        let clean = Command::new("cargo")
+            .args(["clean", "-p", "circom-witness-rs"])
+            .current_dir(&workspace_dir)
+            .status()
+            .context("clean circom-witness-rs before graph generation")?;
+        anyhow::ensure!(
+            clean.success(),
+            "failed to clean circom-witness-rs before generating {stem}"
+        );
+
+        let worker = Command::new("cargo")
+            .args([
+                "run",
+                "-p",
+                "circuit-compiler",
+                "--bin",
+                "circuit-witness-graph-generator",
+                "--features",
+                "witness-graph",
+                "--",
+                "--circuits",
+            ])
+            .arg(&circuits_dir)
+            .arg("--out")
+            .arg(&out_dir)
+            .env(
+                "WITNESS_CPP",
+                circuits_dir.join("src").join(format!("{stem}.circom")),
+            )
+            .env("CIRCOM_LIBRARY_PATH", circuits_dir.join("src"))
+            .current_dir(&workspace_dir)
+            .status()
+            .with_context(|| format!("start witness graph worker for {stem}"))?;
+        anyhow::ensure!(worker.success(), "witness graph worker failed for {stem}");
+    }
+
+    eprintln!("Wrote witness graphs to {}", out_dir.display());
+    Ok(())
+}
+
+/// Generate the one witness graph baked into the graph-generator binary.
+pub fn generate_witness_graph(circuits_dir: &Path, out_dir: &Path) -> Result<()> {
+    #[cfg(not(feature = "witness-graph"))]
+    {
+        let _ = (circuits_dir, out_dir);
+        bail!("internal graph worker requires the `witness-graph` feature");
+    }
+
+    #[cfg(feature = "witness-graph")]
+    {
+        let hints_were_present = inject_black_box_hints(&circuits_dir.join("src/circomlib"))?;
+        anyhow::ensure!(
+            hints_were_present,
+            "circomlib hints were missing when the graph worker was built; rerun with --graphs"
+        );
+
+        let witness_cpp = env::var("WITNESS_CPP")
+            .map_err(|_| anyhow!("WITNESS_CPP must be set for graph generation"))?;
+        let stem = Path::new(witness_cpp.trim())
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .ok_or_else(|| anyhow!("invalid WITNESS_CPP circuit path: {witness_cpp}"))?;
+
+        let graph = env::current_dir()
+            .context("resolve graph worker directory")?
+            .join("graph.bin");
+        if graph.exists() {
+            fs::remove_file(&graph).with_context(|| format!("remove stale {}", graph.display()))?;
+        }
+
+        circom_witness_rs::generate::build_witness()
+            .map_err(|error| anyhow!("witness graph generation failed: {error}"))?;
+        anyhow::ensure!(
+            graph.is_file(),
+            "expected circom-witness-rs to write {}",
+            graph.display()
+        );
+
+        let destination = out_dir.join(format!("{stem}.graph.bin"));
+        copy(&graph, &destination)?;
+        fs::remove_file(&graph)?;
+        eprintln!("Wrote witness graph {}", destination.display());
+        Ok(())
+    }
+}
+
+/// Inject the `bbf_inv` / `bbf_bit` black-box hint functions into
+/// circomlib and route the non-quadratic (`<--`) assignments through them.
+///
+/// circom-witness-rs only hooks unconstrained/dynamic control flow when it
+/// lives in a `bbf*`-prefixed circom *function*. Stock circomlib computes
+/// `1/in` (`IsZero`) and the bit decomposition (`Num2Bits`) inline inside
+/// templates, which the graph runtime cannot evaluate.
+///
+/// Returns `true` when every hint was already present, i.e. this build did not
+/// have to touch circomlib.
+pub(crate) fn inject_black_box_hints(circomlib_path: &Path) -> Result<bool> {
+    let circuits_dir = circomlib_path.join("circuits");
+
+    let comparators_hinted = inject_hint(
+        &circuits_dir.join("comparators.circom"),
+        "function bbf_inv",
+        "include \"binsum.circom\";",
+        "\n\nfunction bbf_inv(in) {\n    return in!=0 ? 1/in : 0;\n}",
+        &[("    inv <-- in!=0 ? 1/in : 0;", "    inv <-- bbf_inv(in);")],
+    )?;
+
+    let bitify_hinted = inject_hint(
+        &circuits_dir.join("bitify.circom"),
+        "function bbf_bit",
+        "include \"aliascheck.circom\";",
+        "\n\nfunction bbf_bit(in, bit) {\n    return (in >> bit) & 1;\n}",
+        &[
+            (
+                "        out[i] <-- (in >> i) & 1;",
+                "        out[i] <-- bbf_bit(in, i);",
+            ),
+            (
+                "        out[i] <-- (neg >> i) & 1;",
+                "        out[i] <-- bbf_bit(neg, i);",
+            ),
+        ],
+    )?;
+
+    Ok(comparators_hinted && bitify_hinted)
+}
+
+/// Apply a single circomlib black-box hint patch (one `bbf_*` function).
+///
+/// Returns `true` if the hint was already present and the file was left alone.
+fn inject_hint(
+    file: &Path,
+    marker: &str,
+    anchor: &str,
+    fn_def: &str,
+    rewrites: &[(&str, &str)],
+) -> Result<bool> {
+    let content =
+        fs::read_to_string(file).with_context(|| format!("Failed to read {}", file.display()))?;
+
+    if content.contains(marker) {
+        return Ok(true);
+    }
+
+    let anchor_idx = content
+        .find(anchor)
+        .ok_or_else(|| anyhow!("anchor {anchor:?} not found in {}", file.display()))?;
+    let insert_at = content[anchor_idx..]
+        .find('\n')
+        .map(|nl| anchor_idx.checked_add(nl).expect("anchor lines overflow"))
+        .ok_or_else(|| anyhow!("no newline after anchor {anchor:?} in {}", file.display()))?;
+
+    let mut patched = String::with_capacity(
+        content
+            .len()
+            .checked_add(fn_def.len())
+            .expect("circomlib patch size overflow"),
+    );
+    patched.push_str(&content[..=insert_at]);
+    patched.push_str(fn_def);
+    patched.push_str(&content[insert_at.checked_add(1).expect("insert_at overflow")..]);
+
+    for (from, to) in rewrites {
+        if !patched.contains(from) {
+            bail!(
+                "rewrite source {from:?} not found in {} (upstream circomlib changed?)",
+                file.display()
+            );
+        }
+        patched = patched.replace(from, to);
+    }
+
+    fs::write(file, patched).with_context(|| format!("Failed to write {}", file.display()))?;
+    eprintln!("Injected {marker} into {}", file.display());
+    Ok(false)
+}


### PR DESCRIPTION
Adds a `--graphs` option to the compiler to build the witness graph bins.

Introduces a new binary for graph generation to circumvent the one-graph one-cargo-build of `circom-witness-rs` v0.3. This potentially can be replaced in the future by the new [`circom-witness-graph-builder`](https://github.com/philsippl/circom-witness-rs/tree/master/graph-builder) utility. However that is linked with `circom-witness-rs` v0.4 which currently doesn't compile for wasm32.
