### PR TITLE
SDK crate `Cargo.toml` publish flag as true

### DIFF
--- a/sdk/native/Cargo.toml
+++ b/sdk/native/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 repository.workspace = true
 license.workspace = true
-publish.workspace = true
+publish = true
 description = "Stellar Private Payments Rust SDK"
 build = "build.rs"
 


### PR DESCRIPTION
Make the crate publishable!

`cargo publish -n` works in current state, so we can already publish the SDK. But better way for the #499 stack to be included.