### PR TITLE
Remove CI `e2e-testnet` environment

### DIFF
--- a/.github/workflows/e2e-freighter.yml
+++ b/.github/workflows/e2e-freighter.yml
@@ -22,11 +22,10 @@ permissions:
 jobs:
   e2e-freighter:
     name: Freighter e2e
-    # Fork PRs must not run this job: it reads the e2e-testnet environment's
-    # secrets. Same guard as e2e-webclient.yml.
+    # Fork PRs must not run this job: untrusted code must not drive live
+    # testnet provisioning. Same guard as e2e-webclient.yml.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    environment: e2e-testnet
     timeout-minutes: 75
     steps:
       - name: Checkout source code
@@ -121,11 +120,12 @@ jobs:
           set -a
           . deployments/testnet/.e2e-accounts.env
           set +a
-          # These mask freshly-generated secrets so they never leak in logs.
+          # Mask generated keys and password so they never leak in logs.
           echo "::add-mask::$E2E_ACCOUNT_A_SECRET"
           echo "::add-mask::$E2E_ACCOUNT_B_SECRET"
           echo "::add-mask::$E2E_ACCOUNT_C_SECRET"
           echo "::add-mask::$E2E_ACCOUNT_D_SECRET"
+          echo "::add-mask::$E2E_FREIGHTER_PASSWORD"
           {
             echo "E2E_ACCOUNT_A_ADDRESS=$E2E_ACCOUNT_A_ADDRESS"
             echo "E2E_ACCOUNT_A_SECRET=$E2E_ACCOUNT_A_SECRET"
@@ -136,6 +136,7 @@ jobs:
             echo "E2E_ACCOUNT_D_ADDRESS=$E2E_ACCOUNT_D_ADDRESS"
             echo "E2E_ACCOUNT_D_SECRET=$E2E_ACCOUNT_D_SECRET"
             echo "E2E_POOL_CONTRACT=$E2E_POOL_CONTRACT"
+            echo "E2E_FREIGHTER_PASSWORD=$E2E_FREIGHTER_PASSWORD"
           } >> "$GITHUB_ENV"
 
 
@@ -147,11 +148,10 @@ jobs:
       # locally: it builds+serves the app on :8000, exports APP_URL, and stops
       # the server afterwards. Without it provisioning dies with
       # "APP_URL is not set".
-      # E2E_ACCOUNT_C_SECRET/ADDRESS come from the Provision step above; only
-      # the CI-only wallet password is a secret here.
+      # E2E_ACCOUNT_* and E2E_FREIGHTER_PASSWORD come from the Provision step
+      # above via $GITHUB_ENV (generated fresh per run).
       - name: Generate Freighter profile snapshot
         env:
-          E2E_FREIGHTER_PASSWORD: ${{ secrets.E2E_FREIGHTER_PASSWORD }}
           # Cold `make serve` (circuits + wasm SDK) takes longer than the
           # default 900s on a fresh runner, same as the test step below.
           E2E_SERVE_TIMEOUT: "1800"
@@ -172,16 +172,13 @@ jobs:
       # `make freighter-e2e` uses locally, so CI and a developer's machine
       # exercise identical wiring.
       #
-      # run-all.sh runs scripts/e2e-preflight.sh --check --suite freighter once
-      # before the tests. The account vars were exported to $GITHUB_ENV by the
-      # Provision step above (no .e2e-accounts.env is committed), so the
-      # preflight's env-file checks SKIP when CI is detected while
-      # env.vars.required still verifies against the environment for real, and
-      # chain.accounts.* now runs for real — they were registered moments ago.
+      # run-all.sh runs e2e-preflight.sh --check --suite freighter once before
+      # the tests. In CI, env-file and chain.accounts.* checks SKIP (vars come
+      # from $GITHUB_ENV; registration was verified during provisioning).
+      # env.vars.required and artifact checks still run.
       - name: Run Freighter tests
         env:
           APPROVE: auto
-          E2E_FREIGHTER_PASSWORD: ${{ secrets.E2E_FREIGHTER_PASSWORD }}
           # A cold CI build (circuits + wasm SDK) is slower than a warm local one.
           E2E_SERVE_TIMEOUT: "1800"
         run: bash e2e-freighter/scripts/serve-and-run.sh ${{ steps.select.outputs.tests }}

--- a/.github/workflows/e2e-webclient.yml
+++ b/.github/workflows/e2e-webclient.yml
@@ -15,7 +15,6 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 45
     runs-on: ubuntu-latest
-    environment: e2e-testnet
     steps:
       - name: Checkout source code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4

--- a/e2e-freighter/README.md
+++ b/e2e-freighter/README.md
@@ -329,24 +329,16 @@ gh workflow run e2e-freighter.yml --repo <OWNER/REPO>
 
 Overlapping runs are safe: each run provisions its own ephemeral testnet
 accounts (`--ephemeral`), so two runs cannot spend each other's notes and
-no `concurrency` group is needed. Fork PRs never run this job (it reads
-the protected environment's secrets).
+no `concurrency` group is needed. Fork PRs never run this job (untrusted
+code must not drive live testnet provisioning).
 
-### Environment and secrets
+### CI credentials
 
-The Freighter workflow requires the protected `e2e-testnet` environment,
-which provides exactly one secret:
-
-- `E2E_FREIGHTER_PASSWORD` — password the generated Freighter profile is
-  created with and unlocked with (CI-only; the local setup script
-  generates one that satisfies Freighter's
-  uppercase/lowercase/digit rules)
-
-No account secrets exist in CI. The account addresses, secrets, and the
-pool contract id are exported to `$GITHUB_ENV` by the account-provisioning
-step at run time (the pool is whatever `deployments.json` currently
-names). The webclient workflow uses the same `e2e-testnet` environment
-with the same single secret.
+No GitHub secrets or environments. Each run generates ephemeral testnet
+accounts and an `E2E_FREIGHTER_PASSWORD` (Freighter wallet unlock;
+uppercase/lowercase/digit). All values are masked with `::add-mask::` and
+exported to `$GITHUB_ENV` by the provisioning step (the pool is whatever
+`deployments.json` currently names).
 
 ### Account provisioning in CI
 
@@ -358,8 +350,8 @@ is assumed from pre-seeded state:
    on the runner, the first account is friendbot-funded as a faucet and
    distributes XLM to the rest in a single multi-operation transaction,
    and every account is onboarded and registered against whatever pool
-   `deployments.json` currently names. The generated secrets are masked
-   with `::add-mask::` and exported via `$GITHUB_ENV`.
+   `deployments.json` currently names. Generated keys and the Freighter
+   password are masked with `::add-mask::` and exported via `$GITHUB_ENV`.
 2. **Generate Freighter profile snapshot** — `setup.sh` runs through
    `serve-and-run.sh --` (the `--` form), which builds+serves the app on
    :8000, exports `APP_URL`, and stops the server afterwards. The
@@ -367,17 +359,15 @@ is assumed from pre-seeded state:
    dies with "APP_URL is not set". `xvfb-run` provides the virtual
    display for setup's headed steps.
 
-Because the accounts are registered moments before the tests run, the
-preflight's `chain.accounts.*` checks execute for real instead of
-skipping. The env-file checks do skip (no `.e2e-accounts.env` is
-committed; the vars arrive via `$GITHUB_ENV`), while `env.vars.required`
-still verifies against the environment for real.
+In CI, preflight skips env-file and `chain.accounts.*` checks (vars come
+from `$GITHUB_ENV`; registration was verified during provisioning). It
+still runs `env.vars.required` and artifact checks.
 
 ### Gating
 
 The pre-signing suite gates every push and PR to main, validating the
 checked-out commit's SDK code. The Freighter smoke gate runs on the same
-events and validates the checked-out app plus environment/state health.
+events and validates the checked-out app plus runtime state health.
 The full Freighter suite does not gate and runs manually against a locally
 built app.
 

--- a/sdk/web/tests/README.md
+++ b/sdk/web/tests/README.md
@@ -69,8 +69,8 @@ checks without creating, and `--force` recreates.
 CI does none of this: the `e2e-webclient.yml` workflow runs the script with
 `--ephemeral --accounts a,b`, which generates fresh keypairs on the runner
 every run — the first account is friendbot-funded as a faucet and distributes
-XLM to the second in one multi-operation transaction — so no account secrets
-are stored anywhere.
+XLM to the second in one multi-operation transaction. No GitHub secrets or
+environments are involved.
 
 No ASP membership registration and no admin secret are required: the target pool
 carries `policyFlags: ["blocklist"]`, so membership proofs are not needed (they


### PR DESCRIPTION
Removes that environment, which now is mostly a leftover of e2e web tests as we have ephemeral accounts.
Only used for `E2E_FREIGHTER_PASSWORD`, but we can generate it per run and pass it through `$GITHUB_ENV`, so no stored secret is needed.