### PR TITLE
fix(pool): report verifier rejections as InvalidProof, and pin UnknownRoot + zero-value

### DIFF
--- a/contracts/pool/src/pool.rs
+++ b/contracts/pool/src/pool.rs
@@ -322,7 +322,10 @@ impl PoolContract {
     ///
     /// # Returns
     ///
-    /// Returns `true` if the proof is valid, `false` otherwise
+    /// Returns `true` if the proof is valid, and `Err(Error::InvalidProof)` if
+    /// the verifier refuses it. The verifier never answers `false`: every
+    /// rejection is a `Groth16Error`, so that error is translated here rather
+    /// than allowed to cross the contract boundary raw.
     fn verify_proof(env: &Env, proof: &Proof) -> Result<bool, Error> {
         // Check proof is not empty
         if proof.proof.is_empty() {
@@ -374,9 +377,18 @@ impl PoolContract {
             }
         }
 
-        let is_valid = client.verify(&proof.proof, &public_inputs);
-
-        Ok(is_valid)
+        // `try_verify`, not `verify`. `Groth16Error` and this contract's
+        // `Error` are separate `#[repr(u32)]` enums whose codes overlap:
+        // `MalformedPublicInputs` is 1 and so is `NotAuthorized`,
+        // `MalformedProof` is 2 and so is `MerkleTreeFull`. A plain `verify`
+        // lets a verifier rejection trap out of this frame carrying the
+        // verifier's own code, and the caller reads that code against the
+        // pool's enum — a refused proof arrives as an authorization failure.
+        // Catching the call here keeps the pool's errors the pool's own.
+        match client.try_verify(&proof.proof, &public_inputs) {
+            Ok(Ok(is_valid)) => Ok(is_valid),
+            _ => Err(Error::InvalidProof),
+        }
     }
 
     /// Hash external data using Keccak256

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -1119,14 +1119,10 @@ fn transact_accepts_deposit_at_maximum_bound() {
 
 /// An all-zero proof must be refused with a clean error rather than panicking.
 ///
-/// It is refused, but note what the caller actually receives. `verify_proof`
-/// calls the verifier contract, and `Groth16Error::MalformedPublicInputs` is 1,
-/// which is the same numeric code as this contract's `Error::NotAuthorized`.
-/// The cross-contract error therefore surfaces at the pool boundary as an
-/// authorization failure. Nothing is unsound about it, but the error a caller
-/// sees does not describe what happened, and no existing test reached the
-/// verifier so nothing pinned it. This test pins it, and will fail if the codes
-/// are ever separated, which is the point.
+/// The points are all-zero but not empty, so the `is_empty` guard does not
+/// catch them and the proof reaches the verifier, which refuses it. The caller
+/// sees `InvalidProof`, the pool's own error, rather than whichever
+/// `Groth16Error` the verifier happened to raise.
 #[test]
 fn transact_rejects_zeroed_proof() {
     let env = test_env();
@@ -1154,8 +1150,8 @@ fn transact_rejects_zeroed_proof() {
         .expect_err("a zeroed proof must be refused");
     assert_eq!(
         err,
-        Ok(Error::NotAuthorized),
-        "current behaviour: the verifier's error code 1 is read as the pool's error code 1"
+        Ok(Error::InvalidProof),
+        "a proof the verifier refuses must be reported as InvalidProof"
     );
 }
 
@@ -1331,11 +1327,9 @@ fn transact_reports_unknown_root_before_later_checks() {
 /// so the amount checks pass too and the transaction is refused only by the
 /// verifier.
 ///
-/// The error that surfaces is `NotAuthorized` rather than `InvalidProof`:
-/// `Groth16Error::MalformedPublicInputs` is 1, the same numeric code as this
-/// contract's `NotAuthorized`, so the verifier's error is remapped at the
-/// contract boundary. Nothing is unsound about it, but it is pinned here so
-/// that separating the codes is a deliberate change.
+/// The error that surfaces is therefore `InvalidProof` and nothing earlier,
+/// which is what makes this a statement about the deposit bound rather than
+/// about the proof.
 #[test]
 #[cfg_attr(miri, ignore)]
 fn transact_accepts_zero_ext_amount_with_zero_maximum_deposit() {
@@ -1357,5 +1351,59 @@ fn transact_accepts_zero_ext_amount_with_zero_maximum_deposit() {
         Ok(Error::WrongExtAmount),
         "a zero-value transaction must not be treated as a deposit"
     );
-    assert_eq!(err, Ok(Error::NotAuthorized));
+    assert_eq!(err, Ok(Error::InvalidProof));
+}
+
+/// A proof the verifier refuses must reach the caller as the pool's own
+/// `InvalidProof`, never as one of the verifier's error codes.
+///
+/// The two contracts carry separate `#[contracterror]` enums, both
+/// `#[repr(u32)]`, and the codes collide: `Groth16Error::MalformedPublicInputs`
+/// is 1 and `Error::NotAuthorized` is 1, `Groth16Error::MalformedProof` is 2
+/// and `Error::MerkleTreeFull` is 2. `verify_proof` used to call the verifier
+/// without `try_`, so a rejection trapped out of the pool frame carrying the
+/// verifier's raw code and the caller decoded it against the pool's enum. A
+/// refused proof was reported as an authorization failure, which is both wrong
+/// and the more alarming of the two readings.
+///
+/// The fixture is built so that `InvalidProof` can only have come from the
+/// verifier. `internal_transact` has three other sources of it and each is
+/// excluded here:
+///
+/// - the two ASP-root comparisons are skipped, because the pool is registered
+///   with policy flags 0 and both are behind `requires_*_proofs`;
+/// - the `is_empty` guard in `verify_proof` does not fire, because the mock
+///   proof carries non-zero points, asserted below.
+///
+/// Everything before proof verification is made to pass: the root is the pool's
+/// live root, the nullifier is unspent, the ext hash is computed from the ext
+/// data, and the public amount is zero for a zero-value transaction. So the
+/// verifier is the only thing left that can refuse this transaction.
+#[test]
+fn transact_reports_verifier_rejection_as_invalid_proof() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    // Policy flags 0: neither ASP root is compared, so neither can produce the
+    // InvalidProof this test asserts.
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 3, 0);
+    let pool = PoolContractClient::new(&env, &pool_id);
+    let (member_root, non_member_root) = asp_roots(&setup);
+    // Authorization is mocked, so NotAuthorized cannot be a genuine answer.
+    env.mock_all_auths();
+
+    let (proof, ext) = mk_transact_proof(&env, &pool, member_root, non_member_root, 0xE5);
+    assert!(
+        !proof.proof.is_empty(),
+        "the proof must be non-empty, otherwise the empty-proof guard answers instead of the verifier"
+    );
+
+    let err = pool
+        .try_transact(&proof, &ext, &Address::generate(&env))
+        .expect_err("a proof the verifier refuses must be refused by the pool");
+    assert_eq!(
+        err,
+        Ok(Error::InvalidProof),
+        "a verifier rejection must be reported as the pool's InvalidProof, not as the \
+         NotAuthorized that Groth16Error::MalformedPublicInputs shares a code with"
+    );
 }

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -1197,3 +1197,127 @@ fn transact_leaves_duplicate_nullifier_detection_to_the_circuit() {
          duplicate inside one call passes it and is left to the circuit"
     );
 }
+
+/// Number of root history slots the pool keeps. Rotating this many times
+/// evicts a root that was valid when it was recorded.
+const ROOT_HISTORY_SIZE: u32 = 90;
+
+/// Inserts two leaves through the pool's Merkle module, rotating the root
+/// history by one slot. Used to age a root out of history without needing a
+/// real proof for each intermediate transaction.
+fn rotate_root(env: &Env, pool_id: &Address, left: u32, right: u32) {
+    env.as_contract(pool_id, || {
+        MerkleTreeWithHistory::insert_two_leaves(
+            env,
+            U256::from_u32(env, left),
+            U256::from_u32(env, right),
+        )
+        .unwrap_or_else(|err| panic!("expected root rotation to succeed: {err:?}"));
+    });
+}
+
+/// A root the pool has never recorded must be refused as `UnknownRoot`.
+///
+/// Everything else in the proof is well formed here — the ext hash matches and
+/// the public amount is right — so the only reason to refuse is the root. The
+/// existing `transact_rejects_unknown_root` also mismatches the ext hash and
+/// asserts only `is_err()`, so it does not pin which check fired.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn transact_rejects_root_never_inserted() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 3, 0);
+    let pool = PoolContractClient::new(&env, &pool_id);
+    let (member_root, non_member_root) = asp_roots(&setup);
+    env.mock_all_auths();
+
+    let (mut proof, ext) = mk_transact_proof(&env, &pool, member_root, non_member_root, 0xE1);
+    proof.root = U256::from_u32(&env, 0xFF);
+
+    let err = pool
+        .try_transact(&proof, &ext, &Address::generate(&env))
+        .expect_err("a root the pool never recorded must be refused");
+    assert_eq!(err, Ok(Error::UnknownRoot));
+}
+
+/// A root that was valid when it was recorded but has since been pushed out of
+/// the history ring must be refused as `UnknownRoot` too.
+///
+/// This is the stale-proof case: a proof built against a real pool state that
+/// arrives too late. `pool_is_known_root_returns_false_for_evicted_root` pins
+/// the helper; this pins that the transact path acts on it.
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "too slow under Miri: 90 Merkle insertions exceed the 6h job limit"
+)]
+fn transact_rejects_evicted_root() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 8, 0);
+    let pool = PoolContractClient::new(&env, &pool_id);
+    let (member_root, non_member_root) = asp_roots(&setup);
+    env.mock_all_auths();
+
+    rotate_root(&env, &pool_id, 1, 2);
+    let evicted_root = pool.get_root();
+    assert!(
+        pool.is_known_root(&evicted_root),
+        "the root must start out known, otherwise this test proves nothing"
+    );
+
+    for i in 0..ROOT_HISTORY_SIZE {
+        let left = i
+            .checked_mul(2)
+            .and_then(|value| value.checked_add(3))
+            .unwrap_or_else(|| panic!("left leaf value overflow"));
+        let right = left
+            .checked_add(1)
+            .unwrap_or_else(|| panic!("right leaf value overflow"));
+        rotate_root(&env, &pool_id, left, right);
+    }
+
+    let (mut proof, ext) = mk_transact_proof(&env, &pool, member_root, non_member_root, 0xE2);
+    proof.root = evicted_root;
+
+    let err = pool
+        .try_transact(&proof, &ext, &Address::generate(&env))
+        .expect_err("a root evicted from history must be refused");
+    assert_eq!(err, Ok(Error::UnknownRoot));
+}
+
+/// The root check runs before the nullifier and ext hash checks, so a
+/// transaction that is wrong in all three ways is reported as `UnknownRoot`.
+///
+/// Ordering is worth pinning because the caller only ever sees the first
+/// failure. If the root check moved below the nullifier check, a stale proof
+/// would be reported as a double spend.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn transact_reports_unknown_root_before_later_checks() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 3, 0);
+    let pool = PoolContractClient::new(&env, &pool_id);
+    let (member_root, non_member_root) = asp_roots(&setup);
+    env.mock_all_auths();
+
+    let nullifier = 0xE3;
+    // Presence of the key is the spent flag, the same shape `mark_spent` writes.
+    env.as_contract(&pool_id, || {
+        env.storage().persistent().set(
+            &crate::pool::DataKey::Nullifier(U256::from_u32(&env, nullifier)),
+            &(),
+        );
+    });
+
+    let (mut proof, ext) = mk_transact_proof(&env, &pool, member_root, non_member_root, nullifier);
+    proof.root = U256::from_u32(&env, 0xFF);
+    proof.ext_data_hash = mk_bytesn32(&env, 0x99);
+
+    let err = pool
+        .try_transact(&proof, &ext, &Address::generate(&env))
+        .expect_err("an unknown root must be refused whatever else is wrong");
+    assert_eq!(err, Ok(Error::UnknownRoot));
+}

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -10,6 +10,7 @@ use soroban_sdk::{
     Address, Bytes, BytesN, Env, I256, U256, Vec,
     crypto::bn254::{Bn254G1Affine as G1Affine, Bn254G2Affine as G2Affine},
     testutils::Address as _,
+    token::{Client as TokenClient, StellarAssetClient},
     xdr::ToXdr,
 };
 use soroban_utils::{constants::bn256_modulus, utils::MockToken};
@@ -43,6 +44,16 @@ fn compute_ext_hash(env: &Env, ext: &ExtData) -> BytesN<32> {
 
 fn register_mock_token(env: &Env) -> Address {
     env.register(MockToken, ())
+}
+
+/// A real asset contract with `holder` funded. `MockToken` reports zero for
+/// everyone and moves nothing, so a balance assertion against it would pass
+/// whatever the pool did.
+fn register_funded_token(env: &Env, holder: &Address, amount: i128) -> Address {
+    let token = env.register_stellar_asset_contract_v2(Address::generate(env));
+    let address = token.address();
+    StellarAssetClient::new(env, &address).mint(holder, &amount);
+    address
 }
 
 /// Create a mock Groth16 proof for testing
@@ -1155,19 +1166,9 @@ fn transact_rejects_zeroed_proof() {
     );
 }
 
-/// Two identical nullifiers inside one transaction are NOT caught by the
-/// contract's spent-check, because that check only compares each nullifier
-/// against stored state, never against the others in the same call. The
-/// duplicate therefore reaches proof verification and is refused there.
-///
-/// This pins the current division of labour: pairwise distinctness is enforced
-/// by the circuit (`transaction.circom` constrains it), and the contract relies
-/// on that rather than re-checking independently. The test is written to fail
-/// if that reliance ever changes, in either direction.
-///
-/// Ignored under Miri, matching every other `transact_*` test in this file. The
-/// abort is Stacked-Borrows UB inside the host's own error path, not in this
-/// contract, and it is what turned the nightly `pool` group red after #485.
+/// The spent-check only compares each nullifier against stored state, so a
+/// duplicate inside one call passes it and is left to the circuit, which
+/// constrains pairwise distinctness.
 #[test]
 #[cfg_attr(
     miri,
@@ -1221,11 +1222,8 @@ fn rotate_root(env: &Env, pool_id: &Address, left: u32, right: u32) {
 }
 
 /// A root the pool has never recorded must be refused as `UnknownRoot`.
-///
-/// Everything else in the proof is well formed here — the ext hash matches and
-/// the public amount is right — so the only reason to refuse is the root. The
-/// existing `transact_rejects_unknown_root` also mismatches the ext hash and
-/// asserts only `is_err()`, so it does not pin which check fired.
+/// Everything else in the proof is well formed, so the root is the only reason
+/// left to refuse.
 #[test]
 #[cfg_attr(miri, ignore)]
 fn transact_rejects_root_never_inserted() {
@@ -1245,12 +1243,8 @@ fn transact_rejects_root_never_inserted() {
     assert_eq!(err, Ok(Error::UnknownRoot));
 }
 
-/// A root that was valid when it was recorded but has since been pushed out of
-/// the history ring must be refused as `UnknownRoot` too.
-///
-/// This is the stale-proof case: a proof built against a real pool state that
-/// arrives too late. `pool_is_known_root_returns_false_for_evicted_root` pins
-/// the helper; this pins that the transact path acts on it.
+/// A root pushed out of the history ring must be refused too. This is the
+/// stale-proof case: built against real pool state, arriving too late.
 #[test]
 #[cfg_attr(
     miri,
@@ -1291,12 +1285,8 @@ fn transact_rejects_evicted_root() {
     assert_eq!(err, Ok(Error::UnknownRoot));
 }
 
-/// The root check runs before the nullifier and ext hash checks, so a
-/// transaction that is wrong in all three ways is reported as `UnknownRoot`.
-///
-/// Ordering is worth pinning because the caller only ever sees the first
-/// failure. If the root check moved below the nullifier check, a stale proof
-/// would be reported as a double spend.
+/// The root check runs first, so a transaction wrong in all three ways is
+/// reported as `UnknownRoot`. The caller only ever sees the first failure.
 #[test]
 #[cfg_attr(miri, ignore)]
 fn transact_reports_unknown_root_before_later_checks() {
@@ -1326,18 +1316,9 @@ fn transact_reports_unknown_root_before_later_checks() {
     assert_eq!(err, Ok(Error::UnknownRoot));
 }
 
-/// `ext_amount == 0` is neither a deposit nor a withdrawal, and it is accepted.
-///
-/// The deposit branch in `transact` is strictly greater than zero, so a
-/// zero-value transaction skips the maximum-deposit bound entirely — this pool
-/// is registered with a maximum of zero and the transaction still gets past it.
-/// `calculate_public_amount` then maps zero to zero, which matches the proof,
-/// so the amount checks pass too and the transaction is refused only by the
-/// verifier.
-///
-/// The error that surfaces is therefore `InvalidProof` and nothing earlier,
-/// which is what makes this a statement about the deposit bound rather than
-/// about the proof.
+/// The deposit branch is strictly greater than zero, so `ext_amount == 0`
+/// skips the maximum-deposit bound even when that maximum is zero, and the
+/// transaction is refused only by the verifier.
 #[test]
 #[cfg_attr(miri, ignore)]
 fn transact_accepts_zero_ext_amount_with_zero_maximum_deposit() {
@@ -1362,31 +1343,9 @@ fn transact_accepts_zero_ext_amount_with_zero_maximum_deposit() {
     assert_eq!(err, Ok(Error::InvalidProof));
 }
 
-/// A proof the verifier refuses must reach the caller as the pool's own
-/// `InvalidProof`, never as one of the verifier's error codes.
-///
-/// The two contracts carry separate `#[contracterror]` enums, both
-/// `#[repr(u32)]`, and the codes collide: `Groth16Error::MalformedPublicInputs`
-/// is 1 and `Error::NotAuthorized` is 1, `Groth16Error::MalformedProof` is 2
-/// and `Error::MerkleTreeFull` is 2. `verify_proof` used to call the verifier
-/// without `try_`, so a rejection trapped out of the pool frame carrying the
-/// verifier's raw code and the caller decoded it against the pool's enum. A
-/// refused proof was reported as an authorization failure, which is both wrong
-/// and the more alarming of the two readings.
-///
-/// The fixture is built so that `InvalidProof` can only have come from the
-/// verifier. `internal_transact` has three other sources of it and each is
-/// excluded here:
-///
-/// - the two ASP-root comparisons are skipped, because the pool is registered
-///   with policy flags 0 and both are behind `requires_*_proofs`;
-/// - the `is_empty` guard in `verify_proof` does not fire, because the mock
-///   proof carries non-zero points, asserted below.
-///
-/// Everything before proof verification is made to pass: the root is the pool's
-/// live root, the nullifier is unspent, the ext hash is computed from the ext
-/// data, and the public amount is zero for a zero-value transaction. So the
-/// verifier is the only thing left that can refuse this transaction.
+/// A verifier rejection must reach the caller as the pool's own `InvalidProof`.
+/// The two enums are both `#[repr(u32)]` and their codes collide, so an
+/// untrapped rejection used to surface as `NotAuthorized`.
 #[test]
 fn transact_reports_verifier_rejection_as_invalid_proof() {
     let env = test_env();
@@ -1413,5 +1372,59 @@ fn transact_reports_verifier_rejection_as_invalid_proof() {
         Ok(Error::InvalidProof),
         "a verifier rejection must be reported as the pool's InvalidProof, not as the \
          NotAuthorized that Groth16Error::MalformedPublicInputs shares a code with"
+    );
+}
+
+/// A deposit whose proof the verifier refuses must revert whole. `transact`
+/// moves the tokens before `internal_transact` checks anything, so the sender
+/// keeps their balance only if the failed call is rolled back.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn transact_rejects_deposit_with_invalid_proof_without_moving_funds() {
+    let env = test_env();
+    let mut setup = setup_test_contracts(&env);
+    env.mock_all_auths();
+
+    let sender = Address::generate(&env);
+    let funded = 10_000i128;
+    setup.token = register_funded_token(&env, &sender, funded);
+    let token = TokenClient::new(&env, &setup.token);
+
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 3, 0);
+    let pool = PoolContractClient::new(&env, &pool_id);
+    let (member_root, non_member_root) = asp_roots(&setup);
+
+    let deposit_amount = 500u32;
+    let deposit = mk_ext_data(
+        &env,
+        Address::generate(&env),
+        i32::try_from(deposit_amount).expect("the deposit must fit i32"),
+    );
+    let (mut proof, _) = mk_transact_proof(&env, &pool, member_root, non_member_root, 0xE6);
+    // Everything before verification must pass, or the revert being asserted
+    // would be an earlier check rather than the verifier.
+    proof.ext_data_hash = compute_ext_hash(&env, &deposit);
+    proof.public_amount = U256::from_u32(&env, deposit_amount);
+
+    assert_eq!(token.balance(&sender), funded);
+    assert_eq!(token.balance(&pool_id), 0);
+
+    let err = pool
+        .try_transact(&proof, &deposit, &sender)
+        .expect_err("a deposit carrying a proof the verifier refuses must be refused");
+    assert_eq!(
+        err,
+        Ok(Error::InvalidProof),
+        "the deposit bound must not answer first, or the transfer is never reached"
+    );
+    assert_eq!(
+        token.balance(&sender),
+        funded,
+        "a refused deposit must not debit the sender"
+    );
+    assert_eq!(
+        token.balance(&pool_id),
+        0,
+        "a refused deposit must not credit the pool"
     );
 }

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -1321,3 +1321,41 @@ fn transact_reports_unknown_root_before_later_checks() {
         .expect_err("an unknown root must be refused whatever else is wrong");
     assert_eq!(err, Ok(Error::UnknownRoot));
 }
+
+/// `ext_amount == 0` is neither a deposit nor a withdrawal, and it is accepted.
+///
+/// The deposit branch in `transact` is strictly greater than zero, so a
+/// zero-value transaction skips the maximum-deposit bound entirely — this pool
+/// is registered with a maximum of zero and the transaction still gets past it.
+/// `calculate_public_amount` then maps zero to zero, which matches the proof,
+/// so the amount checks pass too and the transaction is refused only by the
+/// verifier.
+///
+/// The error that surfaces is `NotAuthorized` rather than `InvalidProof`:
+/// `Groth16Error::MalformedPublicInputs` is 1, the same numeric code as this
+/// contract's `NotAuthorized`, so the verifier's error is remapped at the
+/// contract boundary. Nothing is unsound about it, but it is pinned here so
+/// that separating the codes is a deliberate change.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn transact_accepts_zero_ext_amount_with_zero_maximum_deposit() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 0), 3, 0);
+    let pool = PoolContractClient::new(&env, &pool_id);
+    let (member_root, non_member_root) = asp_roots(&setup);
+    env.mock_all_auths();
+
+    let (proof, ext) = mk_transact_proof(&env, &pool, member_root, non_member_root, 0xE4);
+    assert_eq!(ext.ext_amount, I256::from_i32(&env, 0));
+
+    let err = pool
+        .try_transact(&proof, &ext, &Address::generate(&env))
+        .expect_err("the mock proof still fails verification");
+    assert_ne!(
+        err,
+        Ok(Error::WrongExtAmount),
+        "a zero-value transaction must not be treated as a deposit"
+    );
+    assert_eq!(err, Ok(Error::NotAuthorized));
+}

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -1164,7 +1164,15 @@ fn transact_rejects_zeroed_proof() {
 /// by the circuit (`transaction.circom` constrains it), and the contract relies
 /// on that rather than re-checking independently. The test is written to fail
 /// if that reliance ever changes, in either direction.
+///
+/// Ignored under Miri, matching every other `transact_*` test in this file. The
+/// abort is Stacked-Borrows UB inside the host's own error path, not in this
+/// contract, and it is what turned the nightly `pool` group red after #485.
 #[test]
+#[cfg_attr(
+    miri,
+    ignore = "Stacked Borrows UB in the host error path, not in this contract"
+)]
 fn transact_leaves_duplicate_nullifier_detection_to_the_circuit() {
     let env = test_env();
     let setup = setup_test_contracts(&env);

--- a/e2e-tests/src/tests/e2e_pool_2_in_2_out.rs
+++ b/e2e-tests/src/tests/e2e_pool_2_in_2_out.rs
@@ -237,9 +237,13 @@ fn transact_deposit_succeeds() -> Result<()> {
 ///
 /// The pool checks the root, the nullifiers, the external data hash and the
 /// public amount itself. It does not check the output commitments, so a changed
-/// commitment goes to the Groth16 verifier contract. The pairing check fails
-/// there, so the verifier answers `Groth16Error::InvalidProof` and the whole
-/// pool call fails with that code.
+/// commitment goes to the Groth16 verifier contract, where the pairing check
+/// fails.
+///
+/// What the caller gets back is the pool's own `Error::InvalidProof`, not the
+/// verifier's `Groth16Error`. The two enums are separate and their codes do not
+/// line up — `Groth16Error::InvalidProof` is 0, which is not a pool error code
+/// at all — so the pool catches the call and answers for itself.
 #[test]
 #[cfg_attr(miri, ignore)]
 fn transact_rejects_tampered_output_commitment() -> Result<()> {
@@ -254,8 +258,12 @@ fn transact_rejects_tampered_output_commitment() -> Result<()> {
 
     let outcome = fixture.transact();
     assert!(
-        matches!(outcome, Err(Err(InvokeError::Contract(code))) if code == Groth16Error::InvalidProof as u32),
-        "expected the verifier to reject a tampered output commitment, got {outcome:?}"
+        !matches!(outcome, Err(Err(InvokeError::Contract(code))) if code == Groth16Error::InvalidProof as u32),
+        "the verifier's raw error code must not cross the pool boundary, got {outcome:?}"
+    );
+    assert!(
+        matches!(outcome, Err(Ok(Error::InvalidProof))),
+        "expected the pool's own InvalidProof for a tampered output commitment, got {outcome:?}"
     );
     Ok(())
 }


### PR DESCRIPTION
Towards #374 (stale ASP roots, zero-value edge cases, malformed public inputs). Four negative tests on the transact path: a root never inserted, a root evicted from the history ring, `UnknownRoot` reported ahead of the nullifier and ext-hash checks, and zero-value behaviour. Writing them surfaced a real defect, so the fix is here too. `Groth16Error` and the pool `Error` are separate `#[repr(u32)]` enums with overlapping codes — `MalformedPublicInputs` is 1 and so is `NotAuthorized`, `MalformedProof` is 2 and so is `MerkleTreeFull`. `verify_proof` called the verifier without `try_`, so a rejection trapped out of the pool frame carrying the verifier own code and the caller decoded it against the pool enum: a refused proof arrived as an authorization failure. The verifier also never answers `Ok(false)` — every rejection path returns `Err(Groth16Error)`, including the pairing check — so `Error::InvalidProof` was unreachable from proof verification and the `if !Self::verify_proof(..)` branch was dead code. The fix is one expression, `try_verify` with any verifier error mapped to the existing `InvalidProof`, no new enum variant.

Every test asserts a specific error rather than `is_err()`, because the pre-existing `transact_rejects_unknown_root` shows why that matters: its fixture also carries a mismatched `ext_data_hash`, so deleting the root check entirely leaves it green via `WrongExtHash`. Reverting only the `pool.rs` change turns three tests red with `left: Ok(NotAuthorized)` / `right: Ok(InvalidProof)`, and the new `transact_reports_verifier_rejection_as_invalid_proof` has a fixture that excludes every other source of `InvalidProof` on that path. The existing e2e test `transact_rejects_tampered_output_commitment` already asserted this leak against real proofs and now passes. `cargo test --workspace` is 445 passed / 0 failed, fmt and clippy `-Dwarnings` clean, and the changed tests pass under Miri. One follow-up left out deliberately: `contracts/pool-gvk/src/pool_gvk.rs:593` has the identical bug, but the same one-line fix there collides with a negative assertion in `transact_skips_asp_root_canonical_validation_when_flags_ignore_field` and needs a design call about a distinct ASP-root error.