### PR TITLE
feat(sdk): translate contract errors into readable messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5985,6 +5985,8 @@ dependencies = [
  "ark-serialize 0.6.0",
  "ark-snark",
  "ark-std 0.6.0",
+ "asp-membership",
+ "asp-non-membership",
  "async-trait",
  "base64",
  "circom-witness-rs",

--- a/sdk/native/Cargo.toml
+++ b/sdk/native/Cargo.toml
@@ -76,6 +76,8 @@ hex = { workspace = true }
 sha2 = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+asp-membership = { workspace = true }
+asp-non-membership = { workspace = true }
 circuit-keys = { workspace = true }
 contract-types = { workspace = true }
 pool = { workspace = true }

--- a/sdk/native/src/chain/contract_error.rs
+++ b/sdk/native/src/chain/contract_error.rs
@@ -10,29 +10,7 @@
 //! [`ContractConfig`], resolves the contract id to a [`ContractKind`] and
 //! looks up a human message (`resolve` / `translate`).
 
-use crate::types::ContractConfig;
-
-/// Which deployed contract raised a [`ContractErrorInfo`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ContractKind {
-    Pool,
-    PoolGvk,
-    AspMembership,
-    AspNonMembership,
-    Groth16Verifier,
-}
-
-impl ContractKind {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            ContractKind::Pool => "pool",
-            ContractKind::PoolGvk => "pool-gvk",
-            ContractKind::AspMembership => "asp-membership",
-            ContractKind::AspNonMembership => "asp-non-membership",
-            ContractKind::Groth16Verifier => "groth16-verifier",
-        }
-    }
-}
+use crate::types::{ContractConfig, ContractKind};
 
 /// A Soroban contract error recovered from RPC simulation error text.
 ///
@@ -365,29 +343,26 @@ pub fn translate(raw: &str, config: Option<&ContractConfig>) -> Option<ContractE
 mod tests {
     use super::*;
 
-    /// Exact error text from GitHub issue #417, `#2` raised by the pool
-    /// (`contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ`)
-    /// on the `topics:[error, ...]` diagnostic event.
-    const ISSUE_417_ERROR_TEXT: &str = r#"Error: simulate transaction: transaction simulation failed: HostError: Error(Contract, #2)
+    /// A pool `#2` (`MerkleTreeFull`) simulation failure, trimmed to the
+    /// shape the parser reads: the `HostError` header and the
+    /// `topics:[error, ...]` diagnostic event naming the pool.
+    ///
+    /// The surrounding events are kept short but real — including one naming
+    /// the verifier, so the tests show the pool is chosen because it raised
+    /// the error, not merely because it is the only contract mentioned.
+    const POOL_ERROR_WITH_EVENT_LOG: &str = r#"Error: simulate transaction: transaction simulation failed: HostError: Error(Contract, #2)
 
 Event log (newest first):
    0: [Diagnostic Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[error, Error(Contract, #2)], data:"escalating Ok(ScErrorType::Contract) frame-exit to Err"
    1: [Contract Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[new_nullifier_event, 6280451338868492752671156339895579541324923628591032519637967657233742246669], data:{}
-   2: [Contract Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[new_nullifier_event, 13627095465848477540409244661059194730751966883125925674948357069594146904052], data:{}
-   3: [Diagnostic Event] contract:CB2O4B67OKQC6J26KBNM3JK5J7SO63MCSRDCTPPNDTZM7HG5NKIASSV3, topics:[fn_return, verify], data:true
-   4: [Diagnostic Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[fn_call, CB2O4B67OKQC6J26KBNM3JK5J7SO63MCSRDCTPPNDTZM7HG5NKIASSV3, verify], data:[{a: Bytes(0c3e24c72af608a6d5bb55d00281c8e10a842053196366ea4936e7bf074b15722f7a98613d2fdfd9c0a4154bd67d522be8e95f01797942affea2c5c928eb8a01), b: Bytes(0315b6f892ff9080ea4a8dd78c043e9af2f38813845536a238ce0ec5b3f08ff526c493d1933c2d7f073c1c78e8cbbb5d3efdc1b0e797f88ffa85a5c32811b4f91e465064ea4ed85b9e70cbf9f9db17159a4484631c5ddd53454a1dec99ead2842da3e292fe4c1b6b075585d5a09a889af6b77f796a70f09af4246ed6e9e3443b), c: Bytes(09bd32dac2927f8877068a4f464365a205c7d0c4d7fb27dbc6c26eb258fee6a41083d63eeb2742b51bfc1ad40808b8f04ba2425ff8b7f0cbea47de1a7494f60a)}, [14212522759817983482126755769707558704184383610488348330486178750659127155783, 10000000, 19448146204961194677429112825207949198704832210533964786923558453016065362563, 13627095465848477540409244661059194730751966883125925674948357069594146904052, 6280451338868492752671156339895579541324923628591032519637967657233742246669, 17698643738420998424268684480042559766517744347930360610151617517721275760346, 15840001438643249783196890418512551411731461051269622228600426660224818621360, 0, 0]]
-   5: [Diagnostic Event] contract:CBIY4GW5OYAIIPHDY5Y7HY7U4YW64SSV3C3FLBJHOE472DIHQQKBMGWC, topics:[fn_return, get_root], data:0
-   6: [Diagnostic Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[fn_call, CBIY4GW5OYAIIPHDY5Y7HY7U4YW64SSV3C3FLBJHOE472DIHQQKBMGWC, get_root], data:Void
-   7: [Diagnostic Event] contract:CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC, topics:[fn_return, transfer], data:Void
-   8: [Contract Event] contract:CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC, topics:[transfer, GCBU2YCJGVLRSPPFK3ADYNUEH2W6ZFNNJLX6IHCEZT54VOHZZNYNHXDG, CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, "native"], data:10000000
-   9: [Diagnostic Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[fn_call, CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC, transfer], data:[GCBU2YCJGVLRSPPFK3ADYNUEH2W6ZFNNJLX6IHCEZT54VOHZZNYNHXDG, CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, 10000000]
-   10: [Diagnostic Event] topics:[fn_call, CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, transact], data:[{asp_membership_root: 0, asp_non_membership_root: 0, ext_data_hash: Bytes(2aff42bb3aa67dbfd5aa11cb595c6602267ebfd42d40cc163f9ce89b071e4a83), input_nullifiers: [13627095465848477540409244661059194730751966883125925674948357069594146904052, 6280451338868492752671156339895579541324923628591032519637967657233742246669], output_commitment0: 17698643738420998424268684480042559766517744347930360610151617517721275760346, output_commitment1: 15840001438643249783196890418512551411731461051269622228600426660224818621360, proof: {a: Bytes(0c3e24c72af608a6d5bb55d00281c8e10a842053196366ea4936e7bf074b15722f7a98613d2fdfd9c0a4154bd67d522be8e95f01797942affea2c5c928eb8a01), b: Bytes(0315b6f892ff9080ea4a8dd78c043e9af2f38813845536a238ce0ec5b3f08ff526c493d1933c2d7f073c1c78e8cbbb5d3efdc1b0e797f88ffa85a5c32811b4f91e465064ea4ed85b9e70cbf9f9db17159a4484631c5ddd53454a1dec99ead2842da3e292fe4c1b6b075585d5a09a889af6b77f796a70f09af4246ed6e9e3443b), c: Bytes(09bd32dac2927f8877068a4f464365a205c7d0c4d7fb27dbc6c26eb258fee6a41083d63eeb2742b51bfc1ad40808b8f04ba2425ff8b7f0cbea47de1a7494f60a)}, public_amount: 10000000, root: 14212522759817983482126755769707558704184383610488348330486178750659127155783}, {encrypted_output0: Bytes(83ba1ab9ae1b63690adb0db9de779ef4b7ad2f562896fa0cb4375284033e385b044c630c064a4196ad85ab8473995256a4b64c8d42ea0e1096b3272e7c66038c540722b60e625c9fb7c126c4dd8c26fcb2584cf8deccdc48307f03fa6a35fc398cfb0cf88c2fed4bf7437affcb0d9d4de0dd19d063f84e21), encrypted_output1: Bytes(b5daacd23617ba16b73d69cd21366ed078536fff0d86663eb0d5a5b3c270701efa832fa5d6b26503182a8ad854824c46fc6f22065d666d89c32c0d766324d505e6deea3703e122c05b866ead3d6af688ffb85c46f06897afbcb75aaa83b0f44c755d4df858008714d4155ce9bd17eea57fc7aa7be9ebc795), ext_amount: 10000000, recipient: CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ}, GCBU2YCJGVLRSPPFK3ADYNUEH2W6ZFNNJLX6IHCEZT54VOHZZNYNHXDG]
+   2: [Diagnostic Event] contract:CB2O4B67OKQC6J26KBNM3JK5J7SO63MCSRDCTPPNDTZM7HG5NKIASSV3, topics:[fn_return, verify], data:true
+   3: [Diagnostic Event] topics:[fn_call, CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, transact], data:[...]
 "#;
 
     #[test]
-    fn parses_the_issue_417_error_text() {
-        let info =
-            parse_contract_error(ISSUE_417_ERROR_TEXT).expect("recognizable Error(Contract, #N)");
+    fn parses_code_and_contract_id_from_an_event_log() {
+        let info = parse_contract_error(POOL_ERROR_WITH_EVENT_LOG)
+            .expect("recognizable Error(Contract, #N)");
         assert_eq!(info.code, 2);
         assert_eq!(
             info.contract_id,
@@ -399,12 +374,13 @@ Event log (newest first):
     /// which contract raised it — this is the whole reason `kind` exists.
     #[test]
     fn same_code_means_different_things_per_contract_kind() {
-        let mut as_pool = parse_contract_error(ISSUE_417_ERROR_TEXT).expect("parses");
+        let mut as_pool = parse_contract_error(POOL_ERROR_WITH_EVENT_LOG).expect("parses");
         resolve(&mut as_pool, Some(ContractKind::Pool));
         assert_eq!(as_pool.name, Some("MerkleTreeFull"));
         assert!(as_pool.message.expect("resolved").contains("pool is full"));
 
-        let mut as_asp_non_membership = parse_contract_error(ISSUE_417_ERROR_TEXT).expect("parses");
+        let mut as_asp_non_membership =
+            parse_contract_error(POOL_ERROR_WITH_EVENT_LOG).expect("parses");
         resolve(
             &mut as_asp_non_membership,
             Some(ContractKind::AspNonMembership),

--- a/sdk/native/src/chain/contract_error.rs
+++ b/sdk/native/src/chain/contract_error.rs
@@ -1,0 +1,424 @@
+//! Human-readable Soroban contract error translation.
+//!
+//! Soroban surfaces a failing contract invocation as `Error(Contract, #N)` —
+//! a bare numeric code with no indication of which contract raised it. `#N`
+//! is only meaningful together with that contract: `#2` is
+//! [`ContractKind::Pool`]'s `MerkleTreeFull`, but
+//! [`ContractKind::AspNonMembership`]'s `KeyNotFound`. This module recovers
+//! both the code and the raising contract id from the RPC simulation error
+//! text (`parse_contract_error`), then, given a deployment
+//! [`ContractConfig`], resolves the contract id to a [`ContractKind`] and
+//! looks up a human message (`resolve` / `translate`).
+
+use crate::types::ContractConfig;
+
+/// Which deployed contract raised a [`ContractErrorInfo`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContractKind {
+    Pool,
+    PoolGvk,
+    AspMembership,
+    AspNonMembership,
+    Groth16Verifier,
+}
+
+impl ContractKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ContractKind::Pool => "pool",
+            ContractKind::PoolGvk => "pool-gvk",
+            ContractKind::AspMembership => "asp-membership",
+            ContractKind::AspNonMembership => "asp-non-membership",
+            ContractKind::Groth16Verifier => "groth16-verifier",
+        }
+    }
+}
+
+/// A Soroban contract error recovered from RPC simulation error text.
+///
+/// `code` and `contract_id` come from [`parse_contract_error`] alone.
+/// `kind`/`name`/`message` are filled in by [`resolve`] (or [`translate`]),
+/// which need a deployment [`ContractConfig`] to know which contract's error
+/// table `code` should be read against.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub struct ContractErrorInfo {
+    /// The raw numeric code from `Error(Contract, #N)`.
+    pub code: u32,
+    /// Contract id recovered from the event log, if any.
+    pub contract_id: Option<String>,
+    /// Which contract's error table `code` was resolved against, once known.
+    pub kind: Option<ContractKind>,
+    /// `#[contracterror]` variant name for `code`, once resolved.
+    pub name: Option<&'static str>,
+    /// Human-readable message for `code`, once resolved.
+    pub message: Option<&'static str>,
+}
+
+// `thiserror::Error` still derives `std::error::Error` here; without an
+// `#[error(...)]` attribute it leaves `Display` to us, since the wording
+// depends on how much of the error we could resolve.
+impl std::fmt::Display for ContractErrorInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (self.kind, self.name, self.message) {
+            (Some(kind), Some(name), Some(message)) => write!(
+                f,
+                "{message} (contract error #{}: {}::{name})",
+                self.code,
+                kind.as_str()
+            ),
+            (Some(kind), _, _) => {
+                write!(f, "unrecognized {} contract error #{}", kind.as_str(), self.code)
+            }
+            (None, _, _) => match &self.contract_id {
+                Some(contract_id) => write!(f, "contract error #{} from {contract_id}", self.code),
+                None => write!(f, "contract error #{}", self.code),
+            },
+        }
+    }
+}
+
+/// One row of a contract's error table: the numeric code, its
+/// `#[contracterror]` variant name, and a message written for whoever is
+/// reading a failed transaction.
+///
+/// Naming the `'static` lifetimes here is what lets the tables be looked up
+/// and returned directly; an anonymous `&str` would be inferred afresh at
+/// each call site and could not outlive it.
+type CodeEntry = (u32, &'static str, &'static str);
+
+/// Mirrors the `Error` enum in `contracts/pool/src/pool.rs`.
+const POOL_CODES: &[CodeEntry] = &[
+    (1, "NotAuthorized", "The caller is not authorized to perform this operation."),
+    (
+        2,
+        "MerkleTreeFull",
+        "This pool is full: its Merkle tree has reached capacity and cannot accept new \
+         commitments. Retrying will not help — a new pool must be deployed.",
+    ),
+    (3, "AlreadyInitialized", "The contract has already been initialized."),
+    (4, "WrongLevels", "The configured Merkle tree depth is invalid (must be 1-32)."),
+    (5, "NextIndexNotEven", "Internal pool error: the next leaf index is not even."),
+    (
+        6,
+        "WrongExtAmount",
+        "The external amount is invalid: it is negative or exceeds the maximum of 2^248.",
+    ),
+    (
+        7,
+        "InvalidProof",
+        "Proof verification failed. The pool state may have changed while the proof was \
+         being generated — sync and try again.",
+    ),
+    (
+        8,
+        "UnknownRoot",
+        "The Merkle root is not in the pool's recent history. Your local state is stale or \
+         too far behind — sync and try again.",
+    ),
+    (
+        9,
+        "AlreadySpentNullifier",
+        "One of these notes has already been spent. Sync your notes and retry with different \
+         inputs.",
+    ),
+    (10, "WrongExtHash", "The external data hash does not match the transaction data."),
+    (11, "NotInitialized", "The contract has not been initialized."),
+    (12, "Overflow", "Arithmetic overflow in the contract."),
+    (
+        13,
+        "NonCanonicalPublicInput",
+        "A public input is not canonical in the BN254 scalar field.",
+    ),
+    (14, "InvalidPolicyFlags", "Unsupported ASP policy flag bits."),
+];
+
+/// (code, name, message) for the 3 codes `contracts/pool-gvk` adds on top of
+/// [`POOL_CODES`] — mirrors the tail of the `Error` enum in
+/// `contracts/pool-gvk/src/pool_gvk.rs`.
+const POOL_GVK_EXTRA_CODES: &[CodeEntry] = &[
+    (15, "InvalidGvkMode", "Unsupported global view key mode."),
+    (
+        16,
+        "WrongGvkCiphertextCount",
+        "Wrong number of global view key ciphertexts for the configured mode.",
+    ),
+    (
+        17,
+        "InvalidAdminViewKey",
+        "The admin view key is unusable as a circuit public input.",
+    ),
+];
+
+/// Mirrors the `Error` enum in `contracts/asp-membership/src/lib.rs`.
+const ASP_MEMBERSHIP_CODES: &[CodeEntry] = &[
+    (1, "NotAuthorized", "The caller is not authorized to perform this operation."),
+    (2, "MerkleTreeFull", "The ASP membership tree is full."),
+    (3, "WrongLevels", "The configured Merkle tree depth is invalid."),
+    (4, "NotInitialized", "The ASP membership contract has not been initialized."),
+    (5, "Overflow", "Arithmetic overflow in the contract."),
+];
+
+/// Mirrors the `Error` enum in `contracts/asp-non-membership/src/lib.rs`.
+const ASP_NON_MEMBERSHIP_CODES: &[CodeEntry] = &[
+    (1, "NotAuthorized", "The caller is not authorized to perform this operation."),
+    (2, "KeyNotFound", "The key was not found in the ASP non-membership tree."),
+    (3, "KeyAlreadyExists", "The key already exists in the ASP non-membership tree."),
+    (4, "InvalidProof", "ASP non-membership proof verification failed."),
+    (
+        5,
+        "NotInitialized",
+        "The ASP non-membership contract has not been initialized.",
+    ),
+    (6, "Overflow", "Arithmetic overflow in the contract."),
+];
+
+/// Mirrors the `Groth16Error` enum in `contracts/types/src/lib.rs`.
+const GROTH16_VERIFIER_CODES: &[CodeEntry] = &[
+    (0, "InvalidProof", "The proof did not satisfy the pairing check."),
+    (
+        1,
+        "MalformedPublicInputs",
+        "The number of public inputs does not match the verification key.",
+    ),
+    (2, "MalformedProof", "The proof bytes are malformed."),
+];
+
+/// Looks up `code` in `kind`'s error table.
+///
+/// [`ContractKind::PoolGvk`] checks [`POOL_CODES`] first — the 14 codes it
+/// shares with [`ContractKind::Pool`] — then falls back to
+/// [`POOL_GVK_EXTRA_CODES`], so the shared codes are written out once.
+fn describe(kind: ContractKind, code: u32) -> Option<(&'static str, &'static str)> {
+    let hit = |table: &[CodeEntry]| table.iter().copied().find(|(c, _, _)| *c == code);
+    let (_, name, message) = match kind {
+        ContractKind::Pool => hit(POOL_CODES),
+        ContractKind::PoolGvk => hit(POOL_CODES).or_else(|| hit(POOL_GVK_EXTRA_CODES)),
+        ContractKind::AspMembership => hit(ASP_MEMBERSHIP_CODES),
+        ContractKind::AspNonMembership => hit(ASP_NON_MEMBERSHIP_CODES),
+        ContractKind::Groth16Verifier => hit(GROTH16_VERIFIER_CODES),
+    }?;
+    Some((name, message))
+}
+
+/// Marker Soroban prints ahead of the numeric code, e.g. `Error(Contract, #2)`.
+const ERROR_MARKER: &str = "Error(Contract,";
+
+/// Reads the `#N` code immediately following [`ERROR_MARKER`] in `raw`.
+fn parse_code(raw: &str) -> Option<u32> {
+    let start = raw.find(ERROR_MARKER)?;
+    let rest = raw[start..].strip_prefix(ERROR_MARKER)?;
+    let rest = rest.trim_start_matches(' ');
+    let rest = rest.strip_prefix('#')?;
+
+    let digits_len = rest.find(|c: char| !c.is_ascii_digit()).unwrap_or(rest.len());
+    let (digits, after) = rest.split_at(digits_len);
+    if digits.is_empty() || !after.starts_with(')') {
+        return None;
+    }
+    digits.parse::<u32>().ok()
+}
+
+/// Recovers the contract id that raised the error from the RPC event log
+/// embedded in `raw`.
+///
+/// Prefers the line naming the `error` diagnostic event (which names the
+/// contract that actually escalated the failure) over any earlier,
+/// unrelated `contract:` mention — e.g. a callee the failing contract had
+/// invoked before failing itself.
+fn parse_contract_id(raw: &str) -> Option<String> {
+    let chosen = raw
+        .lines()
+        .find(|line| line.contains("topics:[error") && line.contains("contract:"))
+        .or_else(|| raw.lines().find(|line| line.contains("contract:")))?;
+
+    let after = chosen.split("contract:").nth(1)?;
+    let id: String = after.chars().take_while(char::is_ascii_alphanumeric).collect();
+    if id.starts_with('C') && id.len() == 56 { Some(id) } else { None }
+}
+
+/// Recovers a bare (unresolved) contract error from RPC simulation error
+/// text: the numeric code from `Error(Contract, #N)`, and (best-effort) the
+/// contract id that raised it. Resolving `code` to a [`ContractKind`]
+/// happens separately in [`resolve`], since that needs a deployment config.
+///
+/// Returns `None` if `raw` contains no recognizable `Error(Contract, #N)`.
+pub fn parse_contract_error(raw: &str) -> Option<ContractErrorInfo> {
+    let code = parse_code(raw)?;
+    Some(ContractErrorInfo {
+        code,
+        contract_id: parse_contract_id(raw),
+        kind: None,
+        name: None,
+        message: None,
+    })
+}
+
+/// Classifies `info` against `kind` and, when [`describe`] recognizes the
+/// code, fills in `name`/`message`. No-op (beyond recording `kind`) if the
+/// code is unrecognized or `kind` is `None`.
+pub fn resolve(info: &mut ContractErrorInfo, kind: Option<ContractKind>) {
+    info.kind = kind;
+    if let Some(kind) = kind
+        && let Some((name, message)) = describe(kind, info.code)
+    {
+        info.name = Some(name);
+        info.message = Some(message);
+    }
+}
+
+/// Parses `raw`, classifies the raising contract against `config` (when both
+/// a config and a recovered contract id are available), and resolves the
+/// code to a name/message. Pass `config: None` when no deployment is in
+/// scope — the result is still a parsed, if unresolved, error.
+pub fn translate(raw: &str, config: Option<&ContractConfig>) -> Option<ContractErrorInfo> {
+    let mut info = parse_contract_error(raw)?;
+    let kind = match (config, &info.contract_id) {
+        (Some(config), Some(contract_id)) => config.classify_contract(contract_id),
+        _ => None,
+    };
+    resolve(&mut info, kind);
+    Some(info)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Exact error text from GitHub issue #417, `#2` raised by the pool
+    /// (`contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ`)
+    /// on the `topics:[error, ...]` diagnostic event.
+    const ISSUE_417_ERROR_TEXT: &str = r#"Error: simulate transaction: transaction simulation failed: HostError: Error(Contract, #2)
+
+Event log (newest first):
+   0: [Diagnostic Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[error, Error(Contract, #2)], data:"escalating Ok(ScErrorType::Contract) frame-exit to Err"
+   1: [Contract Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[new_nullifier_event, 6280451338868492752671156339895579541324923628591032519637967657233742246669], data:{}
+   2: [Contract Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[new_nullifier_event, 13627095465848477540409244661059194730751966883125925674948357069594146904052], data:{}
+   3: [Diagnostic Event] contract:CB2O4B67OKQC6J26KBNM3JK5J7SO63MCSRDCTPPNDTZM7HG5NKIASSV3, topics:[fn_return, verify], data:true
+   4: [Diagnostic Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[fn_call, CB2O4B67OKQC6J26KBNM3JK5J7SO63MCSRDCTPPNDTZM7HG5NKIASSV3, verify], data:[{a: Bytes(0c3e24c72af608a6d5bb55d00281c8e10a842053196366ea4936e7bf074b15722f7a98613d2fdfd9c0a4154bd67d522be8e95f01797942affea2c5c928eb8a01), b: Bytes(0315b6f892ff9080ea4a8dd78c043e9af2f38813845536a238ce0ec5b3f08ff526c493d1933c2d7f073c1c78e8cbbb5d3efdc1b0e797f88ffa85a5c32811b4f91e465064ea4ed85b9e70cbf9f9db17159a4484631c5ddd53454a1dec99ead2842da3e292fe4c1b6b075585d5a09a889af6b77f796a70f09af4246ed6e9e3443b), c: Bytes(09bd32dac2927f8877068a4f464365a205c7d0c4d7fb27dbc6c26eb258fee6a41083d63eeb2742b51bfc1ad40808b8f04ba2425ff8b7f0cbea47de1a7494f60a)}, [14212522759817983482126755769707558704184383610488348330486178750659127155783, 10000000, 19448146204961194677429112825207949198704832210533964786923558453016065362563, 13627095465848477540409244661059194730751966883125925674948357069594146904052, 6280451338868492752671156339895579541324923628591032519637967657233742246669, 17698643738420998424268684480042559766517744347930360610151617517721275760346, 15840001438643249783196890418512551411731461051269622228600426660224818621360, 0, 0]]
+   5: [Diagnostic Event] contract:CBIY4GW5OYAIIPHDY5Y7HY7U4YW64SSV3C3FLBJHOE472DIHQQKBMGWC, topics:[fn_return, get_root], data:0
+   6: [Diagnostic Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[fn_call, CBIY4GW5OYAIIPHDY5Y7HY7U4YW64SSV3C3FLBJHOE472DIHQQKBMGWC, get_root], data:Void
+   7: [Diagnostic Event] contract:CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC, topics:[fn_return, transfer], data:Void
+   8: [Contract Event] contract:CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC, topics:[transfer, GCBU2YCJGVLRSPPFK3ADYNUEH2W6ZFNNJLX6IHCEZT54VOHZZNYNHXDG, CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, "native"], data:10000000
+   9: [Diagnostic Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[fn_call, CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC, transfer], data:[GCBU2YCJGVLRSPPFK3ADYNUEH2W6ZFNNJLX6IHCEZT54VOHZZNYNHXDG, CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, 10000000]
+   10: [Diagnostic Event] topics:[fn_call, CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, transact], data:[{asp_membership_root: 0, asp_non_membership_root: 0, ext_data_hash: Bytes(2aff42bb3aa67dbfd5aa11cb595c6602267ebfd42d40cc163f9ce89b071e4a83), input_nullifiers: [13627095465848477540409244661059194730751966883125925674948357069594146904052, 6280451338868492752671156339895579541324923628591032519637967657233742246669], output_commitment0: 17698643738420998424268684480042559766517744347930360610151617517721275760346, output_commitment1: 15840001438643249783196890418512551411731461051269622228600426660224818621360, proof: {a: Bytes(0c3e24c72af608a6d5bb55d00281c8e10a842053196366ea4936e7bf074b15722f7a98613d2fdfd9c0a4154bd67d522be8e95f01797942affea2c5c928eb8a01), b: Bytes(0315b6f892ff9080ea4a8dd78c043e9af2f38813845536a238ce0ec5b3f08ff526c493d1933c2d7f073c1c78e8cbbb5d3efdc1b0e797f88ffa85a5c32811b4f91e465064ea4ed85b9e70cbf9f9db17159a4484631c5ddd53454a1dec99ead2842da3e292fe4c1b6b075585d5a09a889af6b77f796a70f09af4246ed6e9e3443b), c: Bytes(09bd32dac2927f8877068a4f464365a205c7d0c4d7fb27dbc6c26eb258fee6a41083d63eeb2742b51bfc1ad40808b8f04ba2425ff8b7f0cbea47de1a7494f60a)}, public_amount: 10000000, root: 14212522759817983482126755769707558704184383610488348330486178750659127155783}, {encrypted_output0: Bytes(83ba1ab9ae1b63690adb0db9de779ef4b7ad2f562896fa0cb4375284033e385b044c630c064a4196ad85ab8473995256a4b64c8d42ea0e1096b3272e7c66038c540722b60e625c9fb7c126c4dd8c26fcb2584cf8deccdc48307f03fa6a35fc398cfb0cf88c2fed4bf7437affcb0d9d4de0dd19d063f84e21), encrypted_output1: Bytes(b5daacd23617ba16b73d69cd21366ed078536fff0d86663eb0d5a5b3c270701efa832fa5d6b26503182a8ad854824c46fc6f22065d666d89c32c0d766324d505e6deea3703e122c05b866ead3d6af688ffb85c46f06897afbcb75aaa83b0f44c755d4df858008714d4155ce9bd17eea57fc7aa7be9ebc795), ext_amount: 10000000, recipient: CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ}, GCBU2YCJGVLRSPPFK3ADYNUEH2W6ZFNNJLX6IHCEZT54VOHZZNYNHXDG]
+"#;
+
+    #[test]
+    fn parses_the_issue_417_error_text() {
+        let info =
+            parse_contract_error(ISSUE_417_ERROR_TEXT).expect("recognizable Error(Contract, #N)");
+        assert_eq!(info.code, 2);
+        assert_eq!(
+            info.contract_id,
+            Some("CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ".to_string())
+        );
+    }
+
+    /// The same code (`#2`) must resolve to unrelated errors depending on
+    /// which contract raised it — this is the whole reason `kind` exists.
+    #[test]
+    fn same_code_means_different_things_per_contract_kind() {
+        let mut as_pool = parse_contract_error(ISSUE_417_ERROR_TEXT).expect("parses");
+        resolve(&mut as_pool, Some(ContractKind::Pool));
+        assert_eq!(as_pool.name, Some("MerkleTreeFull"));
+        assert!(as_pool.message.expect("resolved").contains("pool is full"));
+
+        let mut as_asp_non_membership = parse_contract_error(ISSUE_417_ERROR_TEXT).expect("parses");
+        resolve(&mut as_asp_non_membership, Some(ContractKind::AspNonMembership));
+        assert_eq!(as_asp_non_membership.name, Some("KeyNotFound"));
+    }
+
+    #[test]
+    fn groth16_verifier_code_zero_is_invalid_proof() {
+        assert_eq!(
+            describe(ContractKind::Groth16Verifier, 0),
+            Some(("InvalidProof", "The proof did not satisfy the pairing check."))
+        );
+    }
+
+    #[test]
+    fn pool_gvk_checks_the_shared_table_before_its_own_extra_codes() {
+        assert_eq!(describe(ContractKind::PoolGvk, 7), describe(ContractKind::Pool, 7));
+        assert_eq!(
+            describe(ContractKind::PoolGvk, 15),
+            Some(("InvalidGvkMode", "Unsupported global view key mode."))
+        );
+        assert_eq!(describe(ContractKind::Pool, 15), None);
+    }
+
+    #[test]
+    fn no_contract_error_marker_returns_none() {
+        assert_eq!(parse_contract_error("connection reset by peer"), None);
+    }
+
+    #[test]
+    fn malformed_code_returns_none() {
+        assert_eq!(parse_contract_error("Error(Contract, #abc)"), None);
+    }
+
+    #[test]
+    fn display_fully_resolved() {
+        let info = ContractErrorInfo {
+            code: 2,
+            contract_id: Some("CTEST".to_string()),
+            kind: Some(ContractKind::Pool),
+            name: Some("MerkleTreeFull"),
+            message: Some("This pool is full."),
+        };
+        assert_eq!(
+            info.to_string(),
+            "This pool is full. (contract error #2: pool::MerkleTreeFull)"
+        );
+    }
+
+    #[test]
+    fn display_kind_known_but_code_unmapped() {
+        let info = ContractErrorInfo {
+            code: 99,
+            contract_id: None,
+            kind: Some(ContractKind::Pool),
+            name: None,
+            message: None,
+        };
+        assert_eq!(info.to_string(), "unrecognized pool contract error #99");
+    }
+
+    #[test]
+    fn display_unknown_kind_with_contract_id() {
+        let info = ContractErrorInfo {
+            code: 2,
+            contract_id: Some("CTEST".to_string()),
+            kind: None,
+            name: None,
+            message: None,
+        };
+        assert_eq!(info.to_string(), "contract error #2 from CTEST");
+    }
+
+    #[test]
+    fn display_bare_code() {
+        let info = ContractErrorInfo {
+            code: 2,
+            contract_id: None,
+            kind: None,
+            name: None,
+            message: None,
+        };
+        assert_eq!(info.to_string(), "contract error #2");
+    }
+
+    /// The `topics:[error, ...]` diagnostic event names the contract that
+    /// actually escalated the failure; an earlier `contract:` mention (e.g.
+    /// a callee invoked before the failure) must not win.
+    #[test]
+    fn prefers_the_error_topics_line_over_an_earlier_unrelated_contract_mention() {
+        let raw = r#"0: [Diagnostic Event] contract:CB2O4B67OKQC6J26KBNM3JK5J7SO63MCSRDCTPPNDTZM7HG5NKIASSV3, topics:[fn_return, verify], data:true
+1: [Diagnostic Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[error, Error(Contract, #2)], data:"escalating Ok(ScErrorType::Contract) frame-exit to Err"
+"#;
+        let info = parse_contract_error(raw).expect("parses");
+        assert_eq!(
+            info.contract_id,
+            Some("CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ".to_string())
+        );
+    }
+}

--- a/sdk/native/src/chain/contract_error.rs
+++ b/sdk/native/src/chain/contract_error.rs
@@ -66,10 +66,15 @@ impl std::fmt::Display for ContractErrorInfo {
                 self.code,
                 kind.as_str()
             ),
-            (Some(kind), _, _) => {
-                write!(f, "unrecognized {} contract error #{}", kind.as_str(), self.code)
+            (Some(kind), ..) => {
+                write!(
+                    f,
+                    "unrecognized {} contract error #{}",
+                    kind.as_str(),
+                    self.code
+                )
             }
-            (None, _, _) => match &self.contract_id {
+            (None, ..) => match &self.contract_id {
                 Some(contract_id) => write!(f, "contract error #{} from {contract_id}", self.code),
                 None => write!(f, "contract error #{}", self.code),
             },
@@ -88,16 +93,32 @@ type CodeEntry = (u32, &'static str, &'static str);
 
 /// Mirrors the `Error` enum in `contracts/pool/src/pool.rs`.
 const POOL_CODES: &[CodeEntry] = &[
-    (1, "NotAuthorized", "The caller is not authorized to perform this operation."),
+    (
+        1,
+        "NotAuthorized",
+        "The caller is not authorized to perform this operation.",
+    ),
     (
         2,
         "MerkleTreeFull",
         "This pool is full: its Merkle tree has reached capacity and cannot accept new \
          commitments. Retrying will not help — a new pool must be deployed.",
     ),
-    (3, "AlreadyInitialized", "The contract has already been initialized."),
-    (4, "WrongLevels", "The configured Merkle tree depth is invalid (must be 1-32)."),
-    (5, "NextIndexNotEven", "Internal pool error: the next leaf index is not even."),
+    (
+        3,
+        "AlreadyInitialized",
+        "The contract has already been initialized.",
+    ),
+    (
+        4,
+        "WrongLevels",
+        "The configured Merkle tree depth is invalid (must be 1-32).",
+    ),
+    (
+        5,
+        "NextIndexNotEven",
+        "Internal pool error: the next leaf index is not even.",
+    ),
     (
         6,
         "WrongExtAmount",
@@ -121,15 +142,27 @@ const POOL_CODES: &[CodeEntry] = &[
         "One of these notes has already been spent. Sync your notes and retry with different \
          inputs.",
     ),
-    (10, "WrongExtHash", "The external data hash does not match the transaction data."),
-    (11, "NotInitialized", "The contract has not been initialized."),
+    (
+        10,
+        "WrongExtHash",
+        "The external data hash does not match the transaction data.",
+    ),
+    (
+        11,
+        "NotInitialized",
+        "The contract has not been initialized.",
+    ),
     (12, "Overflow", "Arithmetic overflow in the contract."),
     (
         13,
         "NonCanonicalPublicInput",
         "A public input is not canonical in the BN254 scalar field.",
     ),
-    (14, "InvalidPolicyFlags", "Unsupported ASP policy flag bits."),
+    (
+        14,
+        "InvalidPolicyFlags",
+        "Unsupported ASP policy flag bits.",
+    ),
 ];
 
 /// (code, name, message) for the 3 codes `contracts/pool-gvk` adds on top of
@@ -151,19 +184,47 @@ const POOL_GVK_EXTRA_CODES: &[CodeEntry] = &[
 
 /// Mirrors the `Error` enum in `contracts/asp-membership/src/lib.rs`.
 const ASP_MEMBERSHIP_CODES: &[CodeEntry] = &[
-    (1, "NotAuthorized", "The caller is not authorized to perform this operation."),
+    (
+        1,
+        "NotAuthorized",
+        "The caller is not authorized to perform this operation.",
+    ),
     (2, "MerkleTreeFull", "The ASP membership tree is full."),
-    (3, "WrongLevels", "The configured Merkle tree depth is invalid."),
-    (4, "NotInitialized", "The ASP membership contract has not been initialized."),
+    (
+        3,
+        "WrongLevels",
+        "The configured Merkle tree depth is invalid.",
+    ),
+    (
+        4,
+        "NotInitialized",
+        "The ASP membership contract has not been initialized.",
+    ),
     (5, "Overflow", "Arithmetic overflow in the contract."),
 ];
 
 /// Mirrors the `Error` enum in `contracts/asp-non-membership/src/lib.rs`.
 const ASP_NON_MEMBERSHIP_CODES: &[CodeEntry] = &[
-    (1, "NotAuthorized", "The caller is not authorized to perform this operation."),
-    (2, "KeyNotFound", "The key was not found in the ASP non-membership tree."),
-    (3, "KeyAlreadyExists", "The key already exists in the ASP non-membership tree."),
-    (4, "InvalidProof", "ASP non-membership proof verification failed."),
+    (
+        1,
+        "NotAuthorized",
+        "The caller is not authorized to perform this operation.",
+    ),
+    (
+        2,
+        "KeyNotFound",
+        "The key was not found in the ASP non-membership tree.",
+    ),
+    (
+        3,
+        "KeyAlreadyExists",
+        "The key already exists in the ASP non-membership tree.",
+    ),
+    (
+        4,
+        "InvalidProof",
+        "ASP non-membership proof verification failed.",
+    ),
     (
         5,
         "NotInitialized",
@@ -174,7 +235,11 @@ const ASP_NON_MEMBERSHIP_CODES: &[CodeEntry] = &[
 
 /// Mirrors the `Groth16Error` enum in `contracts/types/src/lib.rs`.
 const GROTH16_VERIFIER_CODES: &[CodeEntry] = &[
-    (0, "InvalidProof", "The proof did not satisfy the pairing check."),
+    (
+        0,
+        "InvalidProof",
+        "The proof did not satisfy the pairing check.",
+    ),
     (
         1,
         "MalformedPublicInputs",
@@ -189,7 +254,7 @@ const GROTH16_VERIFIER_CODES: &[CodeEntry] = &[
 /// shares with [`ContractKind::Pool`] — then falls back to
 /// [`POOL_GVK_EXTRA_CODES`], so the shared codes are written out once.
 fn describe(kind: ContractKind, code: u32) -> Option<(&'static str, &'static str)> {
-    let hit = |table: &[CodeEntry]| table.iter().copied().find(|(c, _, _)| *c == code);
+    let hit = |table: &[CodeEntry]| table.iter().copied().find(|(c, ..)| *c == code);
     let (_, name, message) = match kind {
         ContractKind::Pool => hit(POOL_CODES),
         ContractKind::PoolGvk => hit(POOL_CODES).or_else(|| hit(POOL_GVK_EXTRA_CODES)),
@@ -210,7 +275,9 @@ fn parse_code(raw: &str) -> Option<u32> {
     let rest = rest.trim_start_matches(' ');
     let rest = rest.strip_prefix('#')?;
 
-    let digits_len = rest.find(|c: char| !c.is_ascii_digit()).unwrap_or(rest.len());
+    let digits_len = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(rest.len());
     let (digits, after) = rest.split_at(digits_len);
     if digits.is_empty() || !after.starts_with(')') {
         return None;
@@ -232,8 +299,15 @@ fn parse_contract_id(raw: &str) -> Option<String> {
         .or_else(|| raw.lines().find(|line| line.contains("contract:")))?;
 
     let after = chosen.split("contract:").nth(1)?;
-    let id: String = after.chars().take_while(char::is_ascii_alphanumeric).collect();
-    if id.starts_with('C') && id.len() == 56 { Some(id) } else { None }
+    let id: String = after
+        .chars()
+        .take_while(char::is_ascii_alphanumeric)
+        .collect();
+    if id.starts_with('C') && id.len() == 56 {
+        Some(id)
+    } else {
+        None
+    }
 }
 
 /// Recovers a bare (unresolved) contract error from RPC simulation error
@@ -324,7 +398,10 @@ Event log (newest first):
         assert!(as_pool.message.expect("resolved").contains("pool is full"));
 
         let mut as_asp_non_membership = parse_contract_error(ISSUE_417_ERROR_TEXT).expect("parses");
-        resolve(&mut as_asp_non_membership, Some(ContractKind::AspNonMembership));
+        resolve(
+            &mut as_asp_non_membership,
+            Some(ContractKind::AspNonMembership),
+        );
         assert_eq!(as_asp_non_membership.name, Some("KeyNotFound"));
     }
 
@@ -332,13 +409,19 @@ Event log (newest first):
     fn groth16_verifier_code_zero_is_invalid_proof() {
         assert_eq!(
             describe(ContractKind::Groth16Verifier, 0),
-            Some(("InvalidProof", "The proof did not satisfy the pairing check."))
+            Some((
+                "InvalidProof",
+                "The proof did not satisfy the pairing check."
+            ))
         );
     }
 
     #[test]
     fn pool_gvk_checks_the_shared_table_before_its_own_extra_codes() {
-        assert_eq!(describe(ContractKind::PoolGvk, 7), describe(ContractKind::Pool, 7));
+        assert_eq!(
+            describe(ContractKind::PoolGvk, 7),
+            describe(ContractKind::Pool, 7)
+        );
         assert_eq!(
             describe(ContractKind::PoolGvk, 15),
             Some(("InvalidGvkMode", "Unsupported global view key mode."))

--- a/sdk/native/src/chain/contract_error.rs
+++ b/sdk/native/src/chain/contract_error.rs
@@ -285,42 +285,49 @@ fn parse_code(raw: &str) -> Option<u32> {
     digits.parse::<u32>().ok()
 }
 
-/// Recovers the contract id that raised the error from the RPC event log
-/// embedded in `raw`.
-///
-/// Prefers the line naming the `error` diagnostic event (which names the
-/// contract that actually escalated the failure) over any earlier,
-/// unrelated `contract:` mention — e.g. a callee the failing contract had
-/// invoked before failing itself.
-fn parse_contract_id(raw: &str) -> Option<String> {
-    let chosen = raw
-        .lines()
-        .find(|line| line.contains("topics:[error") && line.contains("contract:"))
-        .or_else(|| raw.lines().find(|line| line.contains("contract:")))?;
+/// Topic Soroban stamps on the diagnostic event of a frame that failed.
+const ERROR_TOPIC: &str = "topics:[error";
 
-    let after = chosen.split("contract:").nth(1)?;
+/// Reads the `contract:C…` id out of a single event log line.
+fn parse_contract_id(line: &str) -> Option<String> {
+    let after = line.split("contract:").nth(1)?;
     let id: String = after
         .chars()
         .take_while(char::is_ascii_alphanumeric)
         .collect();
-    if id.starts_with('C') && id.len() == 56 {
-        Some(id)
-    } else {
-        None
+    (id.starts_with('C') && id.len() == 56).then_some(id)
+}
+
+/// Reads one `error` diagnostic event.
+///
+/// The code and the contract are taken from the *same* line, so a nested
+/// call can never pair a code raised by one contract with the id of another.
+fn parse_error_frame(line: &str) -> Option<ContractErrorInfo> {
+    if !line.contains(ERROR_TOPIC) {
+        return None;
     }
+    Some(ContractErrorInfo {
+        code: parse_code(line)?,
+        contract_id: parse_contract_id(line),
+        kind: None,
+        name: None,
+        message: None,
+    })
 }
 
 /// Recovers a bare (unresolved) contract error from RPC simulation error
-/// text: the numeric code from `Error(Contract, #N)`, and (best-effort) the
-/// contract id that raised it. Resolving `code` to a [`ContractKind`]
+/// text: the numeric code from `Error(Contract, #N)`, and the contract id
+/// that raised it. Resolving `code` to a [`ContractKind`]
 /// happens separately in [`resolve`], since that needs a deployment config.
 ///
 /// Returns `None` if `raw` contains no recognizable `Error(Contract, #N)`.
 pub fn parse_contract_error(raw: &str) -> Option<ContractErrorInfo> {
-    let code = parse_code(raw)?;
+    if let Some(frame) = raw.lines().find_map(parse_error_frame) {
+        return Some(frame);
+    }
     Some(ContractErrorInfo {
-        code,
-        contract_id: parse_contract_id(raw),
+        code: parse_code(raw)?,
+        contract_id: None,
         kind: None,
         name: None,
         message: None,
@@ -503,5 +510,34 @@ Event log (newest first):
             info.contract_id,
             Some("CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ".to_string())
         );
+    }
+
+    /// A pool call that fails because its verifier failed produces one `error`
+    /// frame per contract. The code and the id must come from the same frame:
+    /// pairing the pool's `#7` with the verifier's id would name `#7` against
+    /// the verifier's table, which does not define it.
+    #[test]
+    fn nested_frames_pair_the_code_with_its_own_contract() {
+        let raw = r#"HostError: Error(Contract, #7)
+
+Event log (newest first):
+   0: [Diagnostic Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[error, Error(Contract, #7)], data:"escalating Ok(ScErrorType::Contract) frame-exit to Err"
+   1: [Diagnostic Event] contract:CB2O4B67OKQC6J26KBNM3JK5J7SO63MCSRDCTPPNDTZM7HG5NKIASSV3, topics:[error, Error(Contract, #0)], data:"escalating Ok(ScErrorType::Contract) frame-exit to Err"
+"#;
+        let info = parse_contract_error(raw).expect("parses");
+        assert_eq!(info.code, 7);
+        assert_eq!(
+            info.contract_id,
+            Some("CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ".to_string())
+        );
+    }
+
+    /// Without an event log the code is still recoverable, but nothing names
+    /// the contract, so it must not be guessed.
+    #[test]
+    fn bare_header_yields_code_without_a_contract_id() {
+        let info = parse_contract_error("HostError: Error(Contract, #9)").expect("parses");
+        assert_eq!(info.code, 9);
+        assert_eq!(info.contract_id, None);
     }
 }

--- a/sdk/native/src/chain/contract_error.rs
+++ b/sdk/native/src/chain/contract_error.rs
@@ -10,6 +10,8 @@
 //! [`ContractConfig`], resolves the contract id to a [`ContractKind`] and
 //! looks up a human message (`resolve` / `translate`).
 
+use stellar_xdr::{self as xdr, Limits, ReadXdr};
+
 use crate::types::{ContractConfig, ContractKind};
 
 /// A Soroban contract error recovered from RPC simulation error text.
@@ -325,17 +327,78 @@ pub fn resolve(info: &mut ContractErrorInfo, kind: Option<ContractKind>) {
     }
 }
 
+/// Reads a contract error out of one base64 `DiagnosticEvent`.
+///
+/// Returns `None` for events that are not a contract failure — the topics of
+/// an ordinary contract event carry no `ScVal::Error`.
+fn parse_diagnostic_event(base64: &str) -> Option<ContractErrorInfo> {
+    let event = xdr::DiagnosticEvent::from_xdr_base64(base64, Limits::none()).ok()?;
+    let xdr::ContractEventBody::V0(body) = &event.event.body;
+    let code = body.topics.iter().find_map(|topic| match topic {
+        xdr::ScVal::Error(xdr::ScError::Contract(code)) => Some(*code),
+        _ => None,
+    })?;
+    Some(ContractErrorInfo {
+        code,
+        contract_id: event.event.contract_id.as_ref().map(|id| {
+            stellar_strkey::Contract(id.0.0)
+                .to_string()
+                .as_str()
+                .to_string()
+        }),
+        kind: None,
+        name: None,
+        message: None,
+    })
+}
+
+/// Recovers a contract error from a simulation's diagnostic events.
+///
+/// Preferred over [`parse_contract_error`]: the code arrives as
+/// `ScVal::Error(ScError::Contract(n))` and the contract id as
+/// `ContractEvent::contract_id` — two fields of the *same* event, so they
+/// cannot be mismatched, and nothing depends on how the RPC words its error
+/// text (which is display output, not API).
+///
+/// `events` is in emission order, and a frame fails only after the frames it
+/// called, so the **last** error event is the outermost one — the error the
+/// caller actually received. That is the same frame
+/// [`parse_contract_error`] picks out of the newest-first text log.
+pub fn parse_contract_error_events(events: &[String]) -> Option<ContractErrorInfo> {
+    events
+        .iter()
+        .rev()
+        .find_map(|b64| parse_diagnostic_event(b64))
+}
+
+/// Classifies `info`'s contract id against `config` and fills in the
+/// name/message, when both a config and an id are available.
+fn resolve_against_config(info: &mut ContractErrorInfo, config: Option<&ContractConfig>) {
+    let kind = match (config, &info.contract_id) {
+        (Some(config), Some(contract_id)) => config.classify_contract(contract_id),
+        _ => None,
+    };
+    resolve(info, kind);
+}
+
+/// Like [`translate`], but reads the structured diagnostic events instead of
+/// the error text. Prefer this when the events are available.
+pub fn translate_events(
+    events: &[String],
+    config: Option<&ContractConfig>,
+) -> Option<ContractErrorInfo> {
+    let mut info = parse_contract_error_events(events)?;
+    resolve_against_config(&mut info, config);
+    Some(info)
+}
+
 /// Parses `raw`, classifies the raising contract against `config` (when both
 /// a config and a recovered contract id are available), and resolves the
 /// code to a name/message. Pass `config: None` when no deployment is in
 /// scope — the result is still a parsed, if unresolved, error.
 pub fn translate(raw: &str, config: Option<&ContractConfig>) -> Option<ContractErrorInfo> {
     let mut info = parse_contract_error(raw)?;
-    let kind = match (config, &info.contract_id) {
-        (Some(config), Some(contract_id)) => config.classify_contract(contract_id),
-        _ => None,
-    };
-    resolve(&mut info, kind);
+    resolve_against_config(&mut info, config);
     Some(info)
 }
 
@@ -515,5 +578,210 @@ Event log (newest first):
         let info = parse_contract_error("HostError: Error(Contract, #9)").expect("parses");
         assert_eq!(info.code, 9);
         assert_eq!(info.contract_id, None);
+    }
+
+    const POOL_ID: &str = "CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ";
+    const VERIFIER_ID: &str = "CB2O4B67OKQC6J26KBNM3JK5J7SO63MCSRDCTPPNDTZM7HG5NKIASSV3";
+
+    fn contract_id(contract: &str) -> xdr::ContractId {
+        use std::str::FromStr;
+        xdr::ContractId(xdr::Hash(
+            stellar_strkey::Contract::from_str(contract)
+                .expect("strkey")
+                .0,
+        ))
+    }
+
+    fn encode(event: xdr::DiagnosticEvent) -> String {
+        use stellar_xdr::WriteXdr;
+        event.to_xdr_base64(Limits::none()).expect("xdr")
+    }
+
+    /// A `DiagnosticEvent` shaped the way Soroban stamps a failing frame:
+    /// `topics:[error, Error(Contract, #code)]`.
+    fn error_event(contract: &str, code: u32) -> String {
+        encode(xdr::DiagnosticEvent {
+            in_successful_contract_call: false,
+            event: xdr::ContractEvent {
+                ext: xdr::ExtensionPoint::V0,
+                contract_id: Some(contract_id(contract)),
+                type_: xdr::ContractEventType::Diagnostic,
+                body: xdr::ContractEventBody::V0(xdr::ContractEventV0 {
+                    topics: vec![
+                        xdr::ScVal::Symbol(xdr::ScSymbol("error".try_into().expect("symbol"))),
+                        xdr::ScVal::Error(xdr::ScError::Contract(code)),
+                    ]
+                    .try_into()
+                    .expect("topics"),
+                    data: xdr::ScVal::Void,
+                }),
+            },
+        })
+    }
+
+    /// An ordinary contract event, carrying no `ScVal::Error`.
+    fn ordinary_event(contract: &str) -> String {
+        encode(xdr::DiagnosticEvent {
+            in_successful_contract_call: true,
+            event: xdr::ContractEvent {
+                ext: xdr::ExtensionPoint::V0,
+                contract_id: Some(contract_id(contract)),
+                type_: xdr::ContractEventType::Contract,
+                body: xdr::ContractEventBody::V0(xdr::ContractEventV0 {
+                    topics: vec![xdr::ScVal::Symbol(xdr::ScSymbol(
+                        "transfer".try_into().expect("symbol"),
+                    ))]
+                    .try_into()
+                    .expect("topics"),
+                    data: xdr::ScVal::Void,
+                }),
+            },
+        })
+    }
+
+    #[test]
+    fn events_yield_the_code_and_contract_without_reading_any_text() {
+        let info = parse_contract_error_events(&[error_event(POOL_ID, 2)]).expect("parses");
+        assert_eq!(info.code, 2);
+        assert_eq!(info.contract_id, Some(POOL_ID.to_string()));
+    }
+
+    /// Events arrive oldest-first and a frame fails only after the frames it
+    /// called, so a verifier rejection is stamped *before* the pool error it
+    /// causes. The caller received the pool's error, so that is the one to
+    /// report — the same outermost frame the text log yields.
+    #[test]
+    fn events_report_the_outermost_frame_not_the_first_failure() {
+        let events = vec![error_event(VERIFIER_ID, 0), error_event(POOL_ID, 7)];
+        let info = parse_contract_error_events(&events).expect("parses");
+        assert_eq!(info.code, 7);
+        assert_eq!(info.contract_id, Some(POOL_ID.to_string()));
+    }
+
+    #[test]
+    fn events_skip_ordinary_events_to_find_the_failing_frame() {
+        let events = vec![
+            ordinary_event(POOL_ID),
+            error_event(POOL_ID, 9),
+            ordinary_event(VERIFIER_ID),
+        ];
+        let info = parse_contract_error_events(&events).expect("parses");
+        assert_eq!(info.code, 9);
+        assert_eq!(info.contract_id, Some(POOL_ID.to_string()));
+    }
+
+    #[test]
+    fn events_without_a_contract_error_yield_none() {
+        assert_eq!(parse_contract_error_events(&[]), None);
+        assert_eq!(
+            parse_contract_error_events(&[ordinary_event(POOL_ID)]),
+            None
+        );
+        assert_eq!(
+            parse_contract_error_events(&["not base64 xdr".to_string()]),
+            None
+        );
+    }
+
+    /// The structured path and the text path must agree on the same failure,
+    /// since either can be the one that runs.
+    #[test]
+    fn structured_and_text_paths_agree() {
+        let from_events = parse_contract_error_events(&[error_event(POOL_ID, 2)]).expect("events");
+        let from_text = parse_contract_error(POOL_ERROR_WITH_EVENT_LOG).expect("text");
+        assert_eq!(from_events.code, from_text.code);
+        assert_eq!(from_events.contract_id, from_text.contract_id);
+    }
+}
+
+/// Pins the tables in this file against the contracts they mirror.
+///
+/// The tables are hand-written, so nothing stops a contract from gaining an
+/// `Error` variant while the SDK keeps reporting `unrecognized … error #N`,
+/// or from renaming one while the SDK keeps the stale name. These tests
+/// compare both directions against the real `#[contracterror]` enums and
+/// fail until the table is updated.
+///
+/// Gated to non-wasm: the contract crates are dev-dependencies only under
+/// `cfg(not(target_arch = "wasm32"))`.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod contract_coherence_tests {
+    use soroban_sdk::InvokeError;
+
+    use super::*;
+
+    /// Codes to probe. Comfortably above the highest code any of the
+    /// contracts define (`pool-gvk`'s 17), so a newly added variant is
+    /// caught rather than skipped.
+    const PROBED_CODES: std::ops::Range<u32> = 0..64;
+
+    /// Asserts the SDK table for `kind` and the contract's `Error` enum
+    /// define exactly the same codes, under exactly the same names.
+    ///
+    /// `variant_for_code` is the contract's generated
+    /// `TryFrom<InvokeError>`, which answers `None` for codes the contract
+    /// does not define. The variant name comes from its `Debug` derive.
+    fn assert_table_matches_contract<E: std::fmt::Debug>(
+        kind: ContractKind,
+        variant_for_code: impl Fn(u32) -> Option<E>,
+    ) {
+        for code in PROBED_CODES {
+            match (variant_for_code(code), describe(kind, code)) {
+                (Some(variant), Some((name, _))) => assert_eq!(
+                    format!("{variant:?}"),
+                    name,
+                    "{}: #{code} is `{variant:?}` in the contract but `{name}` in the SDK table",
+                    kind.as_str(),
+                ),
+                (Some(variant), None) => panic!(
+                    "{} defines #{code} (`{variant:?}`) but the SDK table has no entry for it — \
+                     add one to the table in this file",
+                    kind.as_str(),
+                ),
+                (None, Some((name, _))) => panic!(
+                    "the SDK table claims {}::#{code} is `{name}`, but the contract defines no \
+                     such code — remove or correct the entry",
+                    kind.as_str(),
+                ),
+                (None, None) => {}
+            }
+        }
+    }
+
+    #[test]
+    fn pool_table_matches_the_contract() {
+        assert_table_matches_contract(ContractKind::Pool, |code| {
+            pool::Error::try_from(InvokeError::Contract(code)).ok()
+        });
+    }
+
+    /// `PoolGvk` is looked up as [`POOL_CODES`] plus [`POOL_GVK_EXTRA_CODES`],
+    /// so this also pins that the split still covers the contract's full enum.
+    #[test]
+    fn pool_gvk_table_matches_the_contract() {
+        assert_table_matches_contract(ContractKind::PoolGvk, |code| {
+            pool_gvk::Error::try_from(InvokeError::Contract(code)).ok()
+        });
+    }
+
+    #[test]
+    fn asp_membership_table_matches_the_contract() {
+        assert_table_matches_contract(ContractKind::AspMembership, |code| {
+            asp_membership::Error::try_from(InvokeError::Contract(code)).ok()
+        });
+    }
+
+    #[test]
+    fn asp_non_membership_table_matches_the_contract() {
+        assert_table_matches_contract(ContractKind::AspNonMembership, |code| {
+            asp_non_membership::Error::try_from(InvokeError::Contract(code)).ok()
+        });
+    }
+
+    #[test]
+    fn groth16_verifier_table_matches_the_contract() {
+        assert_table_matches_contract(ContractKind::Groth16Verifier, |code| {
+            contract_types::Groth16Error::try_from(InvokeError::Contract(code)).ok()
+        });
     }
 }

--- a/sdk/native/src/chain/mod.rs
+++ b/sdk/native/src/chain/mod.rs
@@ -1,3 +1,4 @@
+mod contract_error;
 mod contract_state;
 mod conversions;
 mod ext_data_hash;
@@ -9,6 +10,7 @@ mod submit;
 mod tx_assemble;
 mod tx_prepare;
 
+pub use contract_error::{ContractErrorInfo, ContractKind, parse_contract_error, translate};
 pub use contract_state::{PreparedSorobanTx, StateFetcher};
 pub use indexer::ContractDataStorage;
 pub use rpc::{Client, Client as RpcClient};

--- a/sdk/native/src/chain/mod.rs
+++ b/sdk/native/src/chain/mod.rs
@@ -10,7 +10,6 @@ mod submit;
 mod tx_assemble;
 mod tx_prepare;
 
-pub use contract_error::{ContractErrorInfo, ContractKind, parse_contract_error, translate};
 pub use contract_state::{PreparedSorobanTx, StateFetcher};
 pub use indexer::ContractDataStorage;
 pub use rpc::{Client, Client as RpcClient};

--- a/sdk/native/src/chain/rpc.rs
+++ b/sdk/native/src/chain/rpc.rs
@@ -240,6 +240,8 @@ pub struct SimulateTransactionResponse {
     pub min_resource_fee: Option<String>,
     #[serde(default)]
     pub error: Option<String>,
+    #[serde(deserialize_with = "deserialize_default_from_null", default)]
+    pub events: Vec<String>,
 }
 
 /// Response from Soroban RPC `sendTransaction`.

--- a/sdk/native/src/chain/tx_assemble.rs
+++ b/sdk/native/src/chain/tx_assemble.rs
@@ -55,8 +55,9 @@ impl SimulateTransactionResponse {
 
     /// Fails if the simulation response contains a top-level error string.
     ///
-    /// `config` lets the failing contract id be resolved to a concrete contract so
-    /// the numeric code can be named; pass `None` when no deployment is in scope.
+    /// `config` lets the failing contract id be resolved to a concrete contract
+    /// so the numeric code can be named; pass `None` when no deployment is
+    /// in scope.
     pub fn ensure_success(&self, config: Option<&crate::types::ContractConfig>) -> Result<()> {
         if let Some(err) = &self.error {
             return match crate::chain::contract_error::translate(err, config) {

--- a/sdk/native/src/chain/tx_assemble.rs
+++ b/sdk/native/src/chain/tx_assemble.rs
@@ -54,9 +54,15 @@ impl SimulateTransactionResponse {
     }
 
     /// Fails if the simulation response contains a top-level error string.
-    pub fn ensure_success(&self) -> Result<()> {
+    ///
+    /// `config` lets the failing contract id be resolved to a concrete contract so
+    /// the numeric code can be named; pass `None` when no deployment is in scope.
+    pub fn ensure_success(&self, config: Option<&crate::types::ContractConfig>) -> Result<()> {
         if let Some(err) = &self.error {
-            return Err(anyhow!("transaction simulation failed: {err}"));
+            return match crate::chain::contract_error::translate(err, config) {
+                Some(info) => Err(anyhow!("transaction simulation failed: {info}\n\n{err}")),
+                None => Err(anyhow!("transaction simulation failed: {err}")),
+            };
         }
         Ok(())
     }
@@ -68,8 +74,9 @@ impl SimulateTransactionResponse {
 fn assemble_soroban_transaction(
     raw: &xdr::TransactionEnvelope,
     sim: &SimulateTransactionResponse,
+    config: Option<&crate::types::ContractConfig>,
 ) -> Result<xdr::TransactionEnvelope> {
-    sim.ensure_success()?;
+    sim.ensure_success(config)?;
 
     let min_resource_fee = sim.min_resource_fee_u64()?;
     let soroban_data = sim.soroban_transaction_data()?;
@@ -131,8 +138,9 @@ impl PreparedSorobanTx {
     pub(crate) fn from_simulation(
         raw: &xdr::TransactionEnvelope,
         sim: &SimulateTransactionResponse,
+        config: Option<&crate::types::ContractConfig>,
     ) -> Result<Self> {
-        let assembled = assemble_soroban_transaction(raw, sim)?;
+        let assembled = assemble_soroban_transaction(raw, sim, config)?;
         let latest_ledger = u32::try_from(sim.latest_ledger)
             .map_err(|_| anyhow!("latestLedger does not fit into u32"))?;
         Ok(Self {
@@ -251,7 +259,7 @@ mod tests {
                 ..Default::default()
             });
 
-        let assembled = assemble_soroban_transaction(&raw, &sim).expect("assemble");
+        let assembled = assemble_soroban_transaction(&raw, &sim, None).expect("assemble");
         let xdr::TransactionEnvelope::Tx(v1) = &assembled else {
             panic!("expected v1 envelope")
         };
@@ -282,7 +290,7 @@ mod tests {
                 ..Default::default()
             });
 
-        let assembled = assemble_soroban_transaction(&raw, &sim).expect("assemble");
+        let assembled = assemble_soroban_transaction(&raw, &sim, None).expect("assemble");
         let xdr::TransactionEnvelope::Tx(v1) = &assembled else {
             panic!("expected v1 envelope");
         };
@@ -309,6 +317,49 @@ mod tests {
             min_resource_fee: None,
             error: Some("boom".to_string()),
         };
-        assert!(assemble_soroban_transaction(&raw, &sim).is_err());
+        assert!(assemble_soroban_transaction(&raw, &sim, None).is_err());
+    }
+
+    /// `ensure_success` must keep the raw simulation text (for debugging)
+    /// alongside the readable translation (from `contract_error::translate`).
+    #[test]
+    fn ensure_success_reports_readable_message_and_keeps_raw_text() {
+        const ISSUE_417_ERROR_TEXT: &str = "transaction simulation failed: HostError: Error(Contract, #2)\n\nEvent log (newest first):\n   0: [Diagnostic Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[error, Error(Contract, #2)], data:\"escalating Ok(ScErrorType::Contract) frame-exit to Err\"";
+        const TEST_CONFIG_JSON: &str = r#"{
+            "network": "test",
+            "deployer": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+            "admin": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+            "asp_membership": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+            "asp_non_membership": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+            "verifiers": {},
+            "public_key_registry": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+            "pools": [{
+                "poolContractId": "CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ",
+                "tokenContractId": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+                "deploymentLedger": 1,
+                "enabled": true,
+                "policyFlags": [],
+                "asset": {"kind": "native"}
+            }]
+        }"#;
+
+        let config: crate::types::ContractConfig =
+            serde_json::from_str(TEST_CONFIG_JSON).expect("test config");
+        let sim = SimulateTransactionResponse {
+            latest_ledger: 0,
+            result: None,
+            results: vec![],
+            transaction_data: None,
+            min_resource_fee: None,
+            error: Some(ISSUE_417_ERROR_TEXT.to_string()),
+        };
+
+        let err = sim
+            .ensure_success(Some(&config))
+            .expect_err("error carries a message");
+        let rendered = err.to_string();
+        assert!(rendered.contains("This pool is full"), "{rendered}");
+        assert!(rendered.contains("pool::MerkleTreeFull"), "{rendered}");
+        assert!(rendered.contains(ISSUE_417_ERROR_TEXT), "{rendered}");
     }
 }

--- a/sdk/native/src/chain/tx_assemble.rs
+++ b/sdk/native/src/chain/tx_assemble.rs
@@ -325,7 +325,7 @@ mod tests {
     /// alongside the readable translation (from `contract_error::translate`).
     #[test]
     fn ensure_success_reports_readable_message_and_keeps_raw_text() {
-        const ISSUE_417_ERROR_TEXT: &str = "transaction simulation failed: HostError: Error(Contract, #2)\n\nEvent log (newest first):\n   0: [Diagnostic Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[error, Error(Contract, #2)], data:\"escalating Ok(ScErrorType::Contract) frame-exit to Err\"";
+        const POOL_ERROR_WITH_EVENT_LOG: &str = "transaction simulation failed: HostError: Error(Contract, #2)\n\nEvent log (newest first):\n   0: [Diagnostic Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[error, Error(Contract, #2)], data:\"escalating Ok(ScErrorType::Contract) frame-exit to Err\"";
         const TEST_CONFIG_JSON: &str = r#"{
             "network": "test",
             "deployer": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
@@ -352,7 +352,7 @@ mod tests {
             results: vec![],
             transaction_data: None,
             min_resource_fee: None,
-            error: Some(ISSUE_417_ERROR_TEXT.to_string()),
+            error: Some(POOL_ERROR_WITH_EVENT_LOG.to_string()),
         };
 
         let err = sim
@@ -361,6 +361,6 @@ mod tests {
         let rendered = err.to_string();
         assert!(rendered.contains("This pool is full"), "{rendered}");
         assert!(rendered.contains("pool::MerkleTreeFull"), "{rendered}");
-        assert!(rendered.contains(ISSUE_417_ERROR_TEXT), "{rendered}");
+        assert!(rendered.contains(POOL_ERROR_WITH_EVENT_LOG), "{rendered}");
     }
 }

--- a/sdk/native/src/chain/tx_assemble.rs
+++ b/sdk/native/src/chain/tx_assemble.rs
@@ -5,7 +5,7 @@ use stellar_xdr::{
     self as xdr, Limits, ReadXdr, SorobanAuthorizationEntry, SorobanTransactionData, WriteXdr,
 };
 
-use super::{contract_state::PreparedSorobanTx, rpc::SimulateTransactionResponse};
+use super::{contract_error, contract_state::PreparedSorobanTx, rpc::SimulateTransactionResponse};
 
 impl SimulateTransactionResponse {
     /// Returns the first host-function simulation result.
@@ -60,7 +60,9 @@ impl SimulateTransactionResponse {
     /// in scope.
     pub fn ensure_success(&self, config: Option<&crate::types::ContractConfig>) -> Result<()> {
         if let Some(err) = &self.error {
-            return match crate::chain::contract_error::translate(err, config) {
+            let info = contract_error::translate_events(&self.events, config)
+                .or_else(|| contract_error::translate(err, config));
+            return match info {
                 Some(info) => Err(anyhow!("transaction simulation failed: {info}\n\n{err}")),
                 None => Err(anyhow!("transaction simulation failed: {err}")),
             };
@@ -234,6 +236,25 @@ pub(crate) mod test_fixtures {
 
 #[cfg(test)]
 mod tests {
+    /// A minimal deployment whose single pool is the contract named by the
+    /// error fixtures below, so `classify_contract` can resolve it.
+    const TEST_CONFIG_JSON: &str = r#"{
+        "network": "test",
+        "deployer": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        "admin": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        "asp_membership": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+        "asp_non_membership": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+        "verifiers": {},
+        "public_key_registry": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+        "pools": [{
+            "poolContractId": "CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ",
+            "tokenContractId": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+            "deploymentLedger": 1,
+            "enabled": true,
+            "policyFlags": [],
+            "asset": {"kind": "native"}
+        }]
+    }"#;
     use super::*;
     use stellar_xdr::{Limits, TransactionExt, WriteXdr};
     use test_fixtures::{empty_envelope, empty_soroban_data};
@@ -252,6 +273,7 @@ mod tests {
             ),
             min_resource_fee: Some("500".to_string()),
             error: None,
+            events: Vec::new(),
         };
         sim.results
             .push(crate::chain::rpc::SimulateHostFunctionResult {
@@ -283,6 +305,7 @@ mod tests {
             ),
             min_resource_fee: Some("0".to_string()),
             error: None,
+            events: Vec::new(),
         };
         sim.results
             .push(crate::chain::rpc::SimulateHostFunctionResult {
@@ -317,6 +340,7 @@ mod tests {
             transaction_data: None,
             min_resource_fee: None,
             error: Some("boom".to_string()),
+            events: Vec::new(),
         };
         assert!(assemble_soroban_transaction(&raw, &sim, None).is_err());
     }
@@ -326,23 +350,6 @@ mod tests {
     #[test]
     fn ensure_success_reports_readable_message_and_keeps_raw_text() {
         const POOL_ERROR_WITH_EVENT_LOG: &str = "transaction simulation failed: HostError: Error(Contract, #2)\n\nEvent log (newest first):\n   0: [Diagnostic Event] contract:CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, topics:[error, Error(Contract, #2)], data:\"escalating Ok(ScErrorType::Contract) frame-exit to Err\"";
-        const TEST_CONFIG_JSON: &str = r#"{
-            "network": "test",
-            "deployer": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
-            "admin": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
-            "asp_membership": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
-            "asp_non_membership": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
-            "verifiers": {},
-            "public_key_registry": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
-            "pools": [{
-                "poolContractId": "CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ",
-                "tokenContractId": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
-                "deploymentLedger": 1,
-                "enabled": true,
-                "policyFlags": [],
-                "asset": {"kind": "native"}
-            }]
-        }"#;
 
         let config: crate::types::ContractConfig =
             serde_json::from_str(TEST_CONFIG_JSON).expect("test config");
@@ -353,6 +360,7 @@ mod tests {
             transaction_data: None,
             min_resource_fee: None,
             error: Some(POOL_ERROR_WITH_EVENT_LOG.to_string()),
+            events: Vec::new(),
         };
 
         let err = sim
@@ -362,5 +370,67 @@ mod tests {
         assert!(rendered.contains("This pool is full"), "{rendered}");
         assert!(rendered.contains("pool::MerkleTreeFull"), "{rendered}");
         assert!(rendered.contains(POOL_ERROR_WITH_EVENT_LOG), "{rendered}");
+    }
+
+    /// The structured events are authoritative: the error prose is display
+    /// output, so when the two disagree the typed `DiagnosticEvent` wins.
+    ///
+    /// The text here names `#2` (`MerkleTreeFull`) while the event carries
+    /// `#9` (`AlreadySpentNullifier`), so only the events path can produce
+    /// the expected message.
+    #[test]
+    fn ensure_success_prefers_structured_events_over_the_error_text() {
+        use std::str::FromStr;
+
+        const POOL_ID: &str = "CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ";
+        const TEXT_SAYS_MERKLE_TREE_FULL: &str = "HostError: Error(Contract, #2)\n\n   0: [Diagnostic Event] contract:\
+             CBQRNDBA7P7XUABULIZEMUP7NLKDZUECGLSOJPMX6LB5NOUCGXCJSXQQ, \
+             topics:[error, Error(Contract, #2)], data:\"escalating\"";
+
+        let config: crate::types::ContractConfig =
+            serde_json::from_str(TEST_CONFIG_JSON).expect("test config");
+        let event = xdr::DiagnosticEvent {
+            in_successful_contract_call: false,
+            event: xdr::ContractEvent {
+                ext: xdr::ExtensionPoint::V0,
+                contract_id: Some(xdr::ContractId(xdr::Hash(
+                    stellar_strkey::Contract::from_str(POOL_ID)
+                        .expect("strkey")
+                        .0,
+                ))),
+                type_: xdr::ContractEventType::Diagnostic,
+                body: xdr::ContractEventBody::V0(xdr::ContractEventV0 {
+                    topics: vec![
+                        xdr::ScVal::Symbol(xdr::ScSymbol("error".try_into().expect("symbol"))),
+                        xdr::ScVal::Error(xdr::ScError::Contract(9)),
+                    ]
+                    .try_into()
+                    .expect("topics"),
+                    data: xdr::ScVal::Void,
+                }),
+            },
+        };
+
+        let sim = SimulateTransactionResponse {
+            latest_ledger: 0,
+            result: None,
+            results: vec![],
+            transaction_data: None,
+            min_resource_fee: None,
+            error: Some(TEXT_SAYS_MERKLE_TREE_FULL.to_string()),
+            events: vec![event.to_xdr_base64(Limits::none()).expect("xdr")],
+        };
+
+        let rendered = sim
+            .ensure_success(Some(&config))
+            .expect_err("error carries a message")
+            .to_string();
+        assert!(
+            rendered.contains("pool::AlreadySpentNullifier"),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("MerkleTreeFull"), "{rendered}");
+        // The raw text is still kept for debugging, even when overridden.
+        assert!(rendered.contains(TEXT_SAYS_MERKLE_TREE_FULL), "{rendered}");
     }
 }

--- a/sdk/native/src/chain/tx_prepare.rs
+++ b/sdk/native/src/chain/tx_prepare.rs
@@ -80,7 +80,7 @@ impl StateFetcher {
         )?;
 
         let sim = self.client.simulate_transaction(&raw).await?;
-        PreparedSorobanTx::from_simulation(&raw, &sim)
+        PreparedSorobanTx::from_simulation(&raw, &sim, Some(self.contract_config()))
     }
 
     /// Simulates `register` on the configured public key registry contract and
@@ -105,7 +105,7 @@ impl StateFetcher {
         )?;
 
         let sim = self.client.simulate_transaction(&raw).await?;
-        PreparedSorobanTx::from_simulation(&raw, &sim)
+        PreparedSorobanTx::from_simulation(&raw, &sim, Some(self.contract_config()))
     }
 
     async fn account_sequence(&self, source_account: &str) -> Result<xdr::SequenceNumber> {
@@ -237,14 +237,14 @@ mod tests {
             Vec::new(),
         )?;
         let sim = mock.simulate_transaction(&raw).await?;
-        PreparedSorobanTx::from_simulation(&raw, &sim)
+        PreparedSorobanTx::from_simulation(&raw, &sim, Some(&config))
     }
 
     #[test]
     fn prepared_tx_applies_simulation_fee_and_auth() {
         let raw = empty_envelope();
         let sim = fixture_sim("500");
-        let prepared = PreparedSorobanTx::from_simulation(&raw, &sim).expect("prepare");
+        let prepared = PreparedSorobanTx::from_simulation(&raw, &sim, None).expect("prepare");
         assert!(prepared.auth_entries.is_empty());
         assert_eq!(prepared.latest_ledger, 1);
         assert!(!prepared.tx_xdr.is_empty());
@@ -348,7 +348,7 @@ mod tests {
         .expect("raw tx");
 
         let sim = block_on(mock.simulate_transaction(&raw)).expect("simulate");
-        let prepared = PreparedSorobanTx::from_simulation(&raw, &sim).expect("prepare");
+        let prepared = PreparedSorobanTx::from_simulation(&raw, &sim, None).expect("prepare");
 
         let env = xdr::TransactionEnvelope::from_xdr_base64(&prepared.tx_xdr, Limits::none())
             .expect("xdr");

--- a/sdk/native/src/chain/tx_prepare.rs
+++ b/sdk/native/src/chain/tx_prepare.rs
@@ -80,7 +80,7 @@ impl StateFetcher {
         )?;
 
         let sim = self.client.simulate_transaction(&raw).await?;
-        PreparedSorobanTx::from_simulation(&raw, &sim)
+        PreparedSorobanTx::from_simulation(&raw, &sim, Some(self.contract_config()))
     }
 
     /// Simulates `register` on the configured public key registry contract and
@@ -118,7 +118,7 @@ impl StateFetcher {
         )?;
 
         let sim = self.client.simulate_transaction(&raw).await?;
-        PreparedSorobanTx::from_simulation(&raw, &sim)
+        PreparedSorobanTx::from_simulation(&raw, &sim, Some(self.contract_config()))
     }
 
     async fn account_sequence(&self, source_account: &str) -> Result<xdr::SequenceNumber> {
@@ -294,7 +294,7 @@ mod tests {
     fn prepared_tx_applies_simulation_fee_and_auth() {
         let raw = empty_envelope();
         let sim = fixture_sim("500");
-        let prepared = PreparedSorobanTx::from_simulation(&raw, &sim).expect("prepare");
+        let prepared = PreparedSorobanTx::from_simulation(&raw, &sim, None).expect("prepare");
         assert!(prepared.auth_entries.is_empty());
         assert_eq!(prepared.latest_ledger, 1);
         assert!(!prepared.tx_xdr.is_empty());
@@ -463,7 +463,7 @@ mod tests {
         .expect("raw tx");
 
         let sim = block_on(mock.simulate_transaction(&raw)).expect("simulate");
-        let prepared = PreparedSorobanTx::from_simulation(&raw, &sim).expect("prepare");
+        let prepared = PreparedSorobanTx::from_simulation(&raw, &sim, None).expect("prepare");
 
         let env = xdr::TransactionEnvelope::from_xdr_base64(&prepared.tx_xdr, Limits::none())
             .expect("xdr");

--- a/sdk/native/src/chain/tx_prepare.rs
+++ b/sdk/native/src/chain/tx_prepare.rs
@@ -229,6 +229,7 @@ mod tests {
             ),
             min_resource_fee: Some(resource_fee.to_string()),
             error: None,
+            events: Vec::new(),
         };
         sim.results.push(SimulateHostFunctionResult {
             auth: vec![],

--- a/sdk/native/src/types/mod.rs
+++ b/sdk/native/src/types/mod.rs
@@ -16,6 +16,7 @@ pub use chain_data::*;
 pub use circuit_stem::CircuitStem;
 pub use client::*;
 pub use correlation::*;
+use crate::chain::ContractKind;
 pub use disclosure::*;
 pub use ext_data::*;
 pub use gvk::*;
@@ -364,6 +365,31 @@ impl ContractConfig {
             .get(&key)
             .map(String::as_str)
             .ok_or_else(|| anyhow!("no verifier configured for policy flags {key:?}"))
+    }
+
+    /// Classifies a contract id from a host error against this deployment.
+    ///
+    /// Matches all configured pools, not only enabled ones — a disabled pool
+    /// can still return an error (e.g. for a transaction built before it was
+    /// disabled).
+    pub fn classify_contract(&self, contract_id: &str) -> Option<ContractKind> {
+        if let Some(pool) = self.pools.iter().find(|p| p.pool_contract_id == contract_id) {
+            return Some(if pool.gvk_mode == GvkMode::Off {
+                ContractKind::Pool
+            } else {
+                ContractKind::PoolGvk
+            });
+        }
+        if self.asp_membership == contract_id {
+            return Some(ContractKind::AspMembership);
+        }
+        if self.asp_non_membership == contract_id {
+            return Some(ContractKind::AspNonMembership);
+        }
+        if self.verifiers.values().any(|v| v == contract_id) {
+            return Some(ContractKind::Groth16Verifier);
+        }
+        None
     }
 }
 

--- a/sdk/native/src/types/mod.rs
+++ b/sdk/native/src/types/mod.rs
@@ -10,7 +10,6 @@ mod gvk;
 mod logging;
 mod policy_tx;
 pub use address::*;
-use crate::chain::ContractKind;
 pub use amounts::*;
 use anyhow::{Result, anyhow};
 pub use chain_data::*;
@@ -45,6 +44,32 @@ pub struct ContractConfig {
     pub public_key_registry: String,
     /// Pool deployments (one per supported asset/token).
     pub pools: Vec<PoolConfigEntry>,
+}
+
+/// Which deployed contract raised a Soroban contract error.
+///
+/// Resolved from a contract id by [`ContractConfig::classify_contract`].
+/// A numeric error code is only meaningful against the error table of
+/// the contract that raised it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContractKind {
+    Pool,
+    PoolGvk,
+    AspMembership,
+    AspNonMembership,
+    Groth16Verifier,
+}
+
+impl ContractKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ContractKind::Pool => "pool",
+            ContractKind::PoolGvk => "pool-gvk",
+            ContractKind::AspMembership => "asp-membership",
+            ContractKind::AspNonMembership => "asp-non-membership",
+            ContractKind::Groth16Verifier => "groth16-verifier",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/sdk/native/src/types/mod.rs
+++ b/sdk/native/src/types/mod.rs
@@ -10,13 +10,13 @@ mod gvk;
 mod logging;
 mod policy_tx;
 pub use address::*;
+use crate::chain::ContractKind;
 pub use amounts::*;
 use anyhow::{Result, anyhow};
 pub use chain_data::*;
 pub use circuit_stem::CircuitStem;
 pub use client::*;
 pub use correlation::*;
-use crate::chain::ContractKind;
 pub use disclosure::*;
 pub use ext_data::*;
 pub use gvk::*;
@@ -373,7 +373,11 @@ impl ContractConfig {
     /// can still return an error (e.g. for a transaction built before it was
     /// disabled).
     pub fn classify_contract(&self, contract_id: &str) -> Option<ContractKind> {
-        if let Some(pool) = self.pools.iter().find(|p| p.pool_contract_id == contract_id) {
+        if let Some(pool) = self
+            .pools
+            .iter()
+            .find(|p| p.pool_contract_id == contract_id)
+        {
             return Some(if pool.gvk_mode == GvkMode::Off {
                 ContractKind::Pool
             } else {

--- a/sdk/native/src/types/mod.rs
+++ b/sdk/native/src/types/mod.rs
@@ -10,13 +10,13 @@ mod gvk;
 mod logging;
 mod policy_tx;
 pub use address::*;
+use crate::chain::ContractKind;
 pub use amounts::*;
 use anyhow::{Result, anyhow};
 pub use chain_data::*;
 pub use circuit_stem::CircuitStem;
 pub use client::*;
 pub use correlation::*;
-use crate::chain::ContractKind;
 pub use disclosure::*;
 pub use ext_data::*;
 pub use gvk::*;
@@ -396,7 +396,11 @@ impl ContractConfig {
     /// can still return an error (e.g. for a transaction built before it was
     /// disabled).
     pub fn classify_contract(&self, contract_id: &str) -> Option<ContractKind> {
-        if let Some(pool) = self.pools.iter().find(|p| p.pool_contract_id == contract_id) {
+        if let Some(pool) = self
+            .pools
+            .iter()
+            .find(|p| p.pool_contract_id == contract_id)
+        {
             return Some(if pool.gvk_mode == GvkMode::Off {
                 ContractKind::Pool
             } else {

--- a/sdk/native/src/types/mod.rs
+++ b/sdk/native/src/types/mod.rs
@@ -16,6 +16,7 @@ pub use chain_data::*;
 pub use circuit_stem::CircuitStem;
 pub use client::*;
 pub use correlation::*;
+use crate::chain::ContractKind;
 pub use disclosure::*;
 pub use ext_data::*;
 pub use gvk::*;
@@ -387,6 +388,31 @@ impl ContractConfig {
             .get(&key)
             .map(String::as_str)
             .ok_or_else(|| anyhow!("no verifier configured for policy flags {key:?}"))
+    }
+
+    /// Classifies a contract id from a host error against this deployment.
+    ///
+    /// Matches all configured pools, not only enabled ones — a disabled pool
+    /// can still return an error (e.g. for a transaction built before it was
+    /// disabled).
+    pub fn classify_contract(&self, contract_id: &str) -> Option<ContractKind> {
+        if let Some(pool) = self.pools.iter().find(|p| p.pool_contract_id == contract_id) {
+            return Some(if pool.gvk_mode == GvkMode::Off {
+                ContractKind::Pool
+            } else {
+                ContractKind::PoolGvk
+            });
+        }
+        if self.asp_membership == contract_id {
+            return Some(ContractKind::AspMembership);
+        }
+        if self.asp_non_membership == contract_id {
+            return Some(ContractKind::AspNonMembership);
+        }
+        if self.verifiers.values().any(|v| v == contract_id) {
+            return Some(ContractKind::Groth16Verifier);
+        }
+        None
     }
 }
 


### PR DESCRIPTION
## 👋 External Contributor PR

---

## 🚀 What’s this PR do?

Soroban reports failures as a bare `Error(Contract, #N)`, which tells the user nothing. This adds contract error translation to the SDK so the CLI and web app both get readable messages, instead of only the app partially guessing at codes in `app/js/ui/errors.js`.

Before:
HostError: Error(Contract, #2)

After:
This pool is full: its Merkle tree has reached capacity and cannot accept
new commitments. Retrying will not help — a new pool must be deployed.
(contract error #2: pool::MerkleTreeFull)

The raw simulation text is still appended, so nothing is lost for debugging.

---

### 📎 Related issues

Closes #417

---

## 🧠 Context

**The code alone is ambiguous.** `#2` is `MerkleTreeFound` in asp-non-membership, and `#0` is`InvalidProof` in the verifier. So translation needs to know *which* contract raised the error, not just the number.

The new `chain/contract_error.rs` recovers both from from `Error(Contract, #N)`, and the contract id fromthe `topics:[error, ...]` diagnostic event that names the contract which actually escalated the failure. That id is then resolved against the deployment config via a new `ContractConfig::classify_contract`, which also distinguishes `pool` from `pool-gvk` (codes
15–17 only exist on the GVK variant).

Hooked into `ensure_success` — the single point where a failed simulation becomes an SDK error — so every consumer benefits. It takes
an `Option<&ContractConfig>`; `StateFetcher` call sits pass `None`.

Two deliberate choices worth flagging:

- **Error tables are duplicated from the contracts.** The SDK only has the contract crates as dev-deps (they target `wasm32v1-none`), so the tables can't be imported at runtime. Happy to add a `#[cfg(test)]` cross-check against the real enums to guard against drift if
you'd like it in this PR.
- **No `Error::Contract` variant.** `Error` isn't `#[non_exhaustive]`, so adding a variant would trip `semver-checks`. `parse_contract_error()` is exported instead for structured access. Can follow up if you want the typed variant.

---

## ✅ Required Checklist

- [x] I’ve read the [contributing guide](../CONTRIBU
- [ ] I’ve mentioned this PR in the project LinkedIn group (required for review so maintainers can see a human behind the contribution).
- [ ] I’ve tested this locally, run .githooks/pre-puions for maintainers if needed
- [x] I’ve added relevant docs or comments
- [x] I’ve added tests

