### PR TITLE
Gate soroban-utils::MockToken behind a testutils feature (fixes production wasm exports)

### DIFF
--- a/contracts/pool-gvk/Cargo.toml
+++ b/contracts/pool-gvk/Cargo.toml
@@ -24,6 +24,7 @@ soroban-sdk.workspace = true
 asp-membership = { workspace = true }
 asp-non-membership = { workspace = true }
 circom-groth16-verifier = { workspace = true }
+soroban-utils = { workspace = true, features = ["testutils"] }
 
 # external
 ark-bn254 = { workspace = true }

--- a/contracts/pool/Cargo.toml
+++ b/contracts/pool/Cargo.toml
@@ -24,6 +24,7 @@ soroban-sdk.workspace = true
 asp-membership = { workspace = true }
 asp-non-membership = { workspace = true }
 circom-groth16-verifier = { workspace = true }
+soroban-utils = { workspace = true, features = ["testutils"] }
 
 # external
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/soroban-utils/Cargo.toml
+++ b/contracts/soroban-utils/Cargo.toml
@@ -20,5 +20,8 @@ ark-ff = { workspace = true }
 ark-groth16 = { workspace = true }
 soroban-sdk = { workspace = true }
 
+[features]
+testutils = []
+
 [lints]
 workspace = true

--- a/contracts/soroban-utils/src/utils.rs
+++ b/contracts/soroban-utils/src/utils.rs
@@ -1,7 +1,9 @@
 use ark_bn254::{G1Affine as ArkG1Affine, G2Affine as ArkG2Affine};
 use ark_ff::{BigInteger, fields::PrimeField};
 use contract_types::VerificationKeyBytes;
-use soroban_sdk::{Address, BytesN, Env, IntoVal, TryFromVal, Val, Vec, contract, contractimpl};
+use soroban_sdk::{Address, BytesN, Env, IntoVal, TryFromVal, Val, Vec};
+#[cfg(any(test, feature = "testutils"))]
+use soroban_sdk::{contract, contractimpl};
 
 /// Update the contract administrator
 ///
@@ -28,9 +30,11 @@ where
 }
 
 /// Mock token contract for testing purposes
+#[cfg(any(test, feature = "testutils"))]
 #[contract]
 pub struct MockToken;
 
+#[cfg(any(test, feature = "testutils"))]
 #[contractimpl]
 impl MockToken {
     pub fn balance(_env: Env, _id: Address) -> i128 {

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -23,7 +23,7 @@ num-bigint = { workspace = true }
 pool = { workspace = true }
 soroban-sdk = { workspace = true, features = ["testutils"] }
 # Shared deps
-soroban-utils = { workspace = true }
+soroban-utils = { workspace = true, features = ["testutils"] }
 stellar-private-payments = { workspace = true }
 
 [lints]


### PR DESCRIPTION
Closes #528.

`contracts/soroban-utils/src/utils.rs` defines `MockToken`, a test helper, with unconditional `#[contract]` / `#[contractimpl]`. Because `soroban-utils` is a regular dependency, every contract built on it exported the mock's five functions (`allowance`, `approve`, `balance`, `transfer`, `transfer_from`) as no-ops. The deployed testnet `asp_membership`, `asp_non_membership` and pool contracts show these exports today; on the pool, `transfer` returns success without moving anything.

## Change

- `soroban-utils/Cargo.toml`: new opt-in feature `testutils = []` (off by default).
- `soroban-utils/src/utils.rs`: `MockToken` struct, its `contractimpl`, and the `contract`/`contractimpl` macro imports are gated behind `#[cfg(any(test, feature = "testutils"))]`. The cfg sits on the items themselves so the contract macros never expand in production builds.
- `pool/Cargo.toml`, `pool-gvk/Cargo.toml`, `e2e-tests/Cargo.toml`: the crates that use `MockToken` in tests enable the feature in their dev-dependencies only. Normal dependencies are unchanged.

5 files, +11 / -2.

## Verification

`stellar contract build` (stellar CLI 26.0.0, target `wasm32v1-none`, release) for `contracts/asp-membership`, then `stellar contract inspect --wasm`:

- before (upstream `main` @ `cb79f817`): 11 exported functions, including `allowance approve balance transfer transfer_from`
- after: 6 exported functions: `__constructor get_root hash_pair insert_leaf set_admin_insert_only update_admin`

`cargo fmt --all --check` clean. I did not run the full workspace test suite locally (the dependency build exceeded the disk on my machine); CI should cover it, and the only code that moves is the test-gated mock plus the feature wiring for the three crates that use it.
