### PR TITLE
asp-membership: optional inserter role (closes #531)

### DIFF
--- a/contracts/asp-membership/src/lib.rs
+++ b/contracts/asp-membership/src/lib.rs
@@ -28,6 +28,10 @@ enum DataKey {
     Root,
     /// Whether admin permission is required to insert a leaf
     AdminInsertOnly,
+    /// Optional delegated inserter authorized to call `insert_leaf` while
+    /// `admin_insert_only` is enabled. When unset, the admin authorizes
+    /// insertions, as before.
+    Inserter,
 }
 
 /// Contract error types
@@ -142,6 +146,44 @@ impl ASPMembership {
         Ok(())
     }
 
+    /// Set (or clear) the delegated inserter
+    ///
+    /// When an inserter is set, it, rather than the admin, authorizes
+    /// `insert_leaf` while `admin_insert_only` is enabled. This lets a deployer
+    /// plug an on-chain admission policy (for example a KYC-gated admitter) into
+    /// the tree by granting it exactly one capability, inserting, without
+    /// handing over the admin role via `update_admin`. Passing `None` clears the
+    /// inserter and restores admin-authorized insertion. Only the admin can call
+    /// this function.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `inserter` - The delegated inserter address, or `None` to clear it
+    pub fn set_inserter(env: Env, inserter: Option<Address>) -> Result<(), Error> {
+        let store = env.storage().persistent();
+        let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+        match inserter {
+            Some(addr) => store.set(&DataKey::Inserter, &addr),
+            None => store.remove(&DataKey::Inserter),
+        }
+        Ok(())
+    }
+
+    /// Get the current delegated inserter, if any
+    ///
+    /// Returns the address authorized to insert leaves while `admin_insert_only`
+    /// is enabled, or `None` if insertions are authorized by the admin.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    ///
+    /// # Returns
+    /// The inserter address wrapped in `Some`, or `None` if unset
+    pub fn get_inserter(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::Inserter)
+    }
+
     /// Get the current Merkle root
     ///
     /// Returns the current root hash of the Merkle tree.
@@ -182,8 +224,9 @@ impl ASPMembership {
     /// Adds a new member to the Merkle tree and updates the root. The leaf is
     /// inserted at the next available index and the tree is updated efficiently
     /// by only recomputing the hashes along the path to the root. If
-    /// `admin_insert_only` is enabled (the default), only the admin can insert
-    /// leaves; otherwise, anyone can call this function.
+    /// `admin_insert_only` is enabled (the default), the insertion must be
+    /// authorized by the delegated inserter if one is set (see `set_inserter`),
+    /// otherwise by the admin; if disabled, anyone can call this function.
     ///
     /// # Arguments
     /// * `env` - The Soroban environment
@@ -196,8 +239,14 @@ impl ASPMembership {
         let store = env.storage().persistent();
         let admin_only: bool = store.get(&DataKey::AdminInsertOnly).unwrap_or(true);
         if admin_only {
-            let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
-            admin.require_auth();
+            // A delegated inserter, when set, authorizes insertion; otherwise
+            // the admin does, as before.
+            let maybe_inserter: Option<Address> = store.get(&DataKey::Inserter);
+            let authorizer: Address = match maybe_inserter {
+                Some(inserter) => inserter,
+                None => store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?,
+            };
+            authorizer.require_auth();
         }
 
         let levels: u32 = store.get(&DataKey::Levels).ok_or(Error::NotInitialized)?;

--- a/contracts/asp-membership/src/test.rs
+++ b/contracts/asp-membership/src/test.rs
@@ -5,7 +5,10 @@ use ark_bn254::Fr as Scalar;
 use ark_ff::{BigInteger, PrimeField};
 use core::ops::Add;
 use num_bigint::BigUint;
-use soroban_sdk::{Address, Bytes, Env, U256, Vec, testutils::Address as _, vec};
+use soroban_sdk::{
+    Address, Bytes, Env, IntoVal, U256, Vec, vec,
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+};
 use taceo_poseidon2::bn254::t2;
 
 /// Create a test environment that disables snapshot writing under Miri.
@@ -719,4 +722,199 @@ fn test_leaf_added_event_exact_shape() {
     }
     .to_xdr(&env, &contract_id);
     assert_eq!(events.events()[0], expected);
+}
+
+
+#[test]
+fn test_inserter_defaults_to_none() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+
+    assert!(
+        client.get_inserter().is_none(),
+        "inserter should be unset by default"
+    );
+}
+
+#[test]
+fn test_set_and_clear_inserter() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let inserter = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+
+    client.set_inserter(&Some(inserter.clone()));
+    assert_eq!(
+        client.get_inserter(),
+        Some(inserter.clone()),
+        "inserter should be set"
+    );
+
+    client.set_inserter(&None);
+    assert!(
+        client.get_inserter().is_none(),
+        "inserter should be cleared by None"
+    );
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_set_inserter_requires_admin() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let inserter = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+
+    // No auths mocked: the admin auth required by set_inserter is missing.
+    client.set_inserter(&Some(inserter));
+}
+
+#[test]
+fn test_inserter_authorizes_insert() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let inserter = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+
+    // Admin delegates insertion to the inserter.
+    env.mock_all_auths();
+    client.set_inserter(&Some(inserter.clone()));
+
+    // The inserter, not the admin, authorizes this insertion.
+    let leaf = U256::from_u32(&env, 100u32);
+    client
+        .mock_auths(&[MockAuth {
+            address: &inserter,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "insert_leaf",
+                args: (leaf.clone(),).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .insert_leaf(&leaf);
+
+    let next_index: u64 = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::NextIndex)
+            .expect("NextIndex set after insert")
+    });
+    assert_eq!(next_index, 1, "the inserter should be able to insert");
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_admin_cannot_insert_when_inserter_set() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let inserter = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin.clone(), 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+
+    // Admin delegates insertion to the inserter.
+    env.mock_all_auths();
+    client.set_inserter(&Some(inserter));
+
+    // The admin's auth alone no longer authorizes an insertion.
+    let leaf = U256::from_u32(&env, 100u32);
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "insert_leaf",
+                args: (leaf.clone(),).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .insert_leaf(&leaf);
+}
+
+#[test]
+fn test_clearing_inserter_restores_admin_auth() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let inserter = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin.clone(), 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    client.set_inserter(&Some(inserter));
+    client.set_inserter(&None);
+
+    // With the inserter cleared, the admin authorizes insertion again.
+    let leaf = U256::from_u32(&env, 100u32);
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "insert_leaf",
+                args: (leaf.clone(),).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .insert_leaf(&leaf);
+
+    let next_index: u64 = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::NextIndex)
+            .expect("NextIndex set after insert")
+    });
+    assert_eq!(
+        next_index, 1,
+        "admin should authorize insertion again after the inserter is cleared"
+    );
+}
+
+#[test]
+fn test_inserter_ignored_when_permissionless() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let inserter = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+
+    // Set an inserter and disable admin-only insert via storage, so no mocked
+    // auths mask the property under test: open insertion needs no authorization.
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Inserter, &inserter);
+        env.storage()
+            .persistent()
+            .set(&DataKey::AdminInsertOnly, &false);
+    });
+
+    // No auths mocked: the insert must still succeed, ignoring the inserter.
+    let leaf = U256::from_u32(&env, 42u32);
+    client.insert_leaf(&leaf);
+
+    let next_index: u64 = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::NextIndex)
+            .expect("NextIndex set after insert")
+    });
+    assert_eq!(
+        next_index, 1,
+        "permissionless insertion should ignore the inserter"
+    );
 }


### PR DESCRIPTION
Closes #531.

## What this adds

An optional inserter role on `asp-membership`, so a deployer can plug an on-chain admission policy into the tree without handing over the admin role via `update_admin`.

- `set_inserter(inserter: Option<Address>)`, admin only. `Some` sets the delegated inserter; `None` clears it.
- `get_inserter() -> Option<Address>`.
- In `insert_leaf`, when `admin_insert_only` is true: the insertion is authorized by the inserter if one is set, otherwise by the admin, as before. Open insertion (`admin_insert_only = false`) is unchanged.

The whole change is one storage key, two functions, and a small branch in `insert_leaf`.

## Backward compatibility

Existing deployments have no `Inserter` key, so `get_inserter()` returns `None` and `insert_leaf` authorizes against the admin exactly as it does today. No migration, no behavioural change unless a deployer opts in with `set_inserter`.

## What it enables

The KYC-gated admitter described in #531 currently has to receive the full admin role to insert (the e2e transfers admin to it). With this, the deployer keeps admin and grants the policy contract exactly one capability, inserting: `set_inserter(policy)`. Any admission policy fits the same slot: an allow-list signer, a multisig, a rate limiter, or the STARK-gated admitter.

## Tests

Seven unit tests on `asp-membership`:
- inserter defaults to `None`
- set and clear (`Some` then `None`)
- `set_inserter` requires admin
- the inserter authorizes an insertion (auth mocked on the inserter, not the admin)
- the admin alone cannot insert once an inserter is set
- clearing the inserter restores admin-authorized insertion
- permissionless insertion ignores the inserter

## Design note

#531 raised two options: an inserter role, or a generic pre-insert hook (`asp.insert_leaf` calls `policy.check(leaf)`). This PR implements the inserter role, which keeps the proof verification and its gas out of `asp-membership`. Happy to rework it as a hook if you'd prefer the ASP to remain the single entry point.

## Verification

`rustfmt` clean. I did not run the full workspace test suite locally (a cold Soroban build exceeded the disk on my machine); the change is a small, test-gated addition plus the storage/auth branch, and CI should cover the suite.
