### PR TITLE
bench(sdk): measure the prefix-tree rebuild before changing it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,6 +1099,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,6 +1723,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -2905,6 +2972,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -5990,6 +6068,7 @@ dependencies = [
  "circom-witness-rs",
  "circuit-keys",
  "contract-types",
+ "criterion",
  "crypto_secretbox",
  "ed25519-dalek",
  "flate2",
@@ -6403,6 +6482,16 @@ checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/sdk/native/Cargo.toml
+++ b/sdk/native/Cargo.toml
@@ -75,6 +75,9 @@ rusqlite = { workspace = true }
 hex = { workspace = true }
 sha2 = { workspace = true }
 
+[dev-dependencies]
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 circuit-keys = { workspace = true }
 contract-types = { workspace = true }
@@ -93,3 +96,7 @@ wasm-bindgen-test = { workspace = true }
 
 [lints]
 workspace = true
+
+[[bench]]
+harness = false
+name = "merkle_build"

--- a/sdk/native/benches/merkle_build.rs
+++ b/sdk/native/benches/merkle_build.rs
@@ -1,0 +1,61 @@
+//! What `build_membership_proof` and `build_pool_inputs` actually cost.
+//!
+//! Both call `MerklePrefixTree::new(depth, &leaves).into_built()` once per transaction
+//! (`sdk/native/src/transact.rs:236` for the ASP membership tree, `:313` for the pool tree),
+//! so the whole prefix is re-hashed every time. Issue #167 asks how many leaves correspond to
+//! how much build time before deciding whether to build once and append.
+//!
+//! Depths are the ones the SDK actually uses, not round numbers.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use stellar_private_payments::zk::merkle::MerklePrefixTree;
+use stellar_private_payments::types::Field;
+
+/// Distinct leaves. Values do not affect the shape of the work, only the count does, but
+/// making them distinct avoids any chance of a hash cache flattering the result.
+fn leaves(n: usize) -> Vec<Field> {
+    (0..n)
+        .map(|i| {
+            let mut le = [0u8; 32];
+            le[..8].copy_from_slice(&(i as u64 + 1).to_le_bytes());
+            Field::try_from_le_bytes(le).expect("field element")
+        })
+        .collect()
+}
+
+fn bench_build(c: &mut Criterion) {
+    // ASP membership tree and pool tree depths, read from the SDK rather than assumed.
+    // Depths as actually deployed, from `deployments/scripts/deploy.sh`: --asp-levels 10,
+    // --pool-levels 20. Not the 8 and 10 the contract and e2e tests use.
+    for (label, depth) in [("asp_membership_d10", 10u32), ("pool_d20", 20u32)] {
+        let mut group = c.benchmark_group(format!("prefix_tree_build/{label}"));
+        for n in [0usize, 1, 16, 256, 1_024, 4_096, 16_384] {
+            let l = leaves(n);
+            group.throughput(Throughput::Elements(n.max(1) as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(n), &l, |b, l| {
+                b.iter(|| {
+                    MerklePrefixTree::new(depth, l)
+                        .expect("new")
+                        .into_built()
+                })
+            });
+        }
+        group.finish();
+    }
+}
+
+/// `new` on its own, to separate the empty-subtree chain from the level walk. If `new` is flat
+/// and `into_built` is linear then caching the built tree is the only thing worth doing.
+fn bench_new_only(c: &mut Criterion) {
+    let mut group = c.benchmark_group("prefix_tree_new_only");
+    for n in [0usize, 1_024, 16_384] {
+        let l = leaves(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &l, |b, l| {
+            b.iter(|| MerklePrefixTree::new(20, l).expect("new"))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_build, bench_new_only);
+criterion_main!(benches);


### PR DESCRIPTION
## 👋 External Contributor PR

## 🚀 What's this PR do?

Adds a criterion bench over `MerklePrefixTree::new(..).into_built()` for both rebuild sites, so #167's first question has an answer before anyone proposes a cache. No behaviour changes.

### 📎 Related issues

Refs #167

## 🧠 Context

The issue names one rebuild site at a path that no longer exists. There are two, both in `sdk/native/src/transact.rs`: `:236` for the ASP membership tree and `:313` for the pool tree. Depths here are the deployed ones from `deployments/scripts/deploy.sh` (`--asp-levels 10`, `--pool-levels 20`), not the 8 and 10 the contract and e2e tests use.

Numbers and the reading of them are on the issue. Short version: `new` is flat in leaf count and linear in depth, `into_built` carries the cost at roughly 100k leaves/sec, depth stops mattering above a few hundred leaves, and this runs twice per transaction.

The issue asks for wasm and this is native. The `#[wasm_bindgen_test]` that would produce the wasm figure is written but I could not run it: the documented wasm command fails on macOS because `sqlite-wasm-rs` needs a clang with a wasm backend and Apple clang has none. Detail on the issue. Say the word and I will include it as a target-gated test.

## ✅ Required Checklist

- [x] I've read the [contributing guide](../CONTRIBUTING.md).
- [ ] I've mentioned this PR in the project LinkedIn group — **not done yet, doing this next**
- [x] I've tested this locally. `cargo bench -p stellar-private-payments --bench merkle_build` runs clean. On `.githooks/pre-push` I ran `cargo sort --workspace -g --check` and `cargo shear`, both pass; I did not run `cargo deny` or the JS license audit, so please treat those as unverified by me.
- [x] I've added relevant docs or comments
- [x] I've updated or created tests if needed — this is the test