### PR TITLE
fix(pool-gvk): report verifier rejections as InvalidProof

### DIFF
--- a/contracts/pool-gvk/src/pool_gvk.rs
+++ b/contracts/pool-gvk/src/pool_gvk.rs
@@ -593,7 +593,8 @@ impl PoolGvkContract {
         // `try_verify`, not `verify`. `Groth16Error` and this contract's
         // `Error` are separate `#[repr(u32)]` enums whose codes overlap.
         // Catch verifier rejections here so callers always receive pool-gvk's
-        // own error domain rather than decoding a verifier code as a pool error.
+        // own error domain rather than decoding a verifier code as a pool
+        // error.
         match client.try_verify(&proof.proof, &public_inputs) {
             Ok(Ok(is_valid)) => Ok(is_valid),
             _ => Err(Error::InvalidProof),

--- a/contracts/pool-gvk/src/pool_gvk.rs
+++ b/contracts/pool-gvk/src/pool_gvk.rs
@@ -590,9 +590,14 @@ impl PoolGvkContract {
             }
         }
 
-        let is_valid = client.verify(&proof.proof, &public_inputs);
-
-        Ok(is_valid)
+        // `try_verify`, not `verify`. `Groth16Error` and this contract's
+        // `Error` are separate `#[repr(u32)]` enums whose codes overlap.
+        // Catch verifier rejections here so callers always receive pool-gvk's
+        // own error domain rather than decoding a verifier code as a pool error.
+        match client.try_verify(&proof.proof, &public_inputs) {
+            Ok(Ok(is_valid)) => Ok(is_valid),
+            _ => Err(Error::InvalidProof),
+        }
     }
 
     /// Get the GVK mode, for internal use where the getter's `Result`

--- a/contracts/pool-gvk/src/test.rs
+++ b/contracts/pool-gvk/src/test.rs
@@ -582,9 +582,9 @@ fn assert_policy_transact_skips_ignored_asp_root_validation(flags: u32, nullifie
     assert!(
         !matches!(
             pool.try_transact(&proof, &ext, &sender),
-            Err(Ok(Error::InvalidProof))
+            Err(Ok(Error::NonCanonicalPublicInput))
         ),
-        "flags={flags} should not require ASP root validation for the ignored field(s)"
+        "expected ASP root field to be skipped for flags={flags}"
     );
 }
 
@@ -1730,5 +1730,50 @@ fn transact_rejects_replayed_nullifier() {
     assert!(
         matches!(second, Err(Ok(Error::AlreadySpentNullifier))),
         "expected replaying the same nullifier to be rejected, got {second:?}"
+    );
+}
+
+/// A verifier rejection must reach the caller as pool-gvk's own `InvalidProof`.
+/// The verifier error enum and this contract's error enum use overlapping
+/// numeric codes, so an untrapped verifier rejection can otherwise surface
+/// as an unrelated pool-gvk error.
+#[test]
+fn transact_reports_verifier_rejection_as_invalid_proof() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+
+    // Policy flags 0: neither ASP root is compared, so neither can produce
+    // the InvalidProof asserted by this test.
+    let pool_id = register_pool_gvk(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        0,
+        mk_point(&env, 1, 2),
+        VIEW_ONLY,
+    );
+    let pool = PoolGvkContractClient::new(&env, &pool_id);
+    let (member_root, non_member_root) = asp_roots(&setup);
+
+    // Authorization is mocked, so NotAuthorized cannot be a genuine answer.
+    env.mock_all_auths();
+
+    let (proof, ext) =
+        mk_transact_proof(&env, &pool, member_root, non_member_root, 0xE5, VIEW_ONLY);
+
+    assert!(
+        !proof.proof.is_empty(),
+        "the proof must be non-empty, otherwise the empty-proof guard answers instead of the verifier"
+    );
+
+    let err = pool
+        .try_transact(&proof, &ext, &Address::generate(&env))
+        .expect_err("a proof the verifier refuses must be refused by pool-gvk");
+
+    assert_eq!(
+        err,
+        Ok(Error::InvalidProof),
+        "a verifier rejection must be reported as pool-gvk's InvalidProof"
     );
 }


### PR DESCRIPTION
## 👋 External Contributor PR



## 🚀 What’s this PR do?

Aligns pool-gvk verifier error handling with the existing hardened behavior in pool.

pool-gvk was using client.verify(...), allowing Groth16Error values to cross the contract boundary directly. Because the verifier and pool-gvk error enums use overlapping numeric codes, a verifier rejection such as MalformedPublicInputs could surface as an unrelated pool error such as NotAuthorized.

This PR:

- replaces client.verify(...) with client.try_verify(...)
- maps verifier rejections to Error::InvalidProof
- adds a regression test reproducing the previous NotAuthorized / InvalidProof mismatch
- updates the ASP-root canonicalization test so it only asserts the intended pre-verifier invariant

The previous ASP-root assertion passed for the wrong reason: the verifier error-code collision surfaced NotAuthorized, so !matches!(..., InvalidProof) was vacuously true. The updated assertion now checks the intended NonCanonicalPublicInput invariant directly.


Before the fix:

left:  Ok(NotAuthorized)
right: Ok(InvalidProof)

After the fix, the verifier rejection is reported as Error::InvalidProof.

Validation:

cargo test -p pool-gvk --lib

37 passed
0 failed

The change is limited to pool-gvk verifier error translation and regression coverage. 
No circuit, SDK, deployment, or protocol behavior is changed.

---

### 📎 Related issues (optional)
None

---

## 🧠 Context

`pool` already handles verifier rejections through `try_verify(...)` and maps them to its own `Error::InvalidProof`.

`pool-gvk` still used `verify(...)`, so verifier contract error codes could cross the contract boundary and be decoded against the `pool-gvk` error enum. Because the numeric codes overlap, `Groth16Error::MalformedPublicInputs` could surface as `Error::NotAuthorized`.

This change intentionally mirrors the existing `pool` behavior rather than introducing a new error-handling model.

Risk is limited to error translation: rejected proofs still fail closed before and after this change. No circuit, proof format, or successful transaction path is modified.

---

## ✅ Required Checklist

- [x] I’ve read the [contributing guide](../CONTRIBUTING.md).
- [ ] I’ve mentioned this PR in the project LinkedIn group (required for review so maintainers can see a human behind the contribution).
- [x] I’ve tested this locally, run .githooks/pre-push and provided test instructions for maintainers if needed
- [x] I’ve added relevant docs or comments
- [x] I’ve updated or created tests if needed
