### PR TITLE
remove relaxed ASP insertion and update_admin panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,6 @@ This is [the administrative control panel](https://nethermindeth.github.io/stell
 
 This provides **illicit activity safeguards** while maintaining user privacy. The ASP membership trees work with the zero-knowledge proofs to prove that deposits either belong to approved accounts or don't belong to blocked accounts—without compromising privacy.
 
-The admin has the option of toggling the "Admin-Only Leaf Insert", It's enabled by default which restricts only the admin to insert membership leaves but when disabled by the admin, anyone can insert membership leaves.
-
-> [!WARNING]
-> Disabling "Admin-Only Leaf Insert" removes the access-control safeguard on the ASP membership tree. Any party will be able to add themselves (or others) to the approved set without admin approval, bypassing the intended illicit-activity safeguards. Only disable this in a controlled demo or testing environment—never in production.
-
 #### Zero-Knowledge Circuits
 
 The main transaction circuit proves:

--- a/app/admin.html
+++ b/app/admin.html
@@ -128,33 +128,6 @@
                         </div>
                     </div>
                 </div>
-
-                <!-- Admin Insert Only Toggle -->
-                <div class="rounded-2xl border border-white/8 bg-ink-900/70 p-5 mt-4">
-                    <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-                        <div>
-                            <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-500">Admin-Only Leaf Insert</p>
-                            <p class="mt-1 text-xs text-slate-400">When enabled, only the admin can insert membership leaves.</p>
-                        </div>
-                        <div class="flex items-center gap-4 flex-shrink-0">
-                            <span id="adminInsertOnlyStatus" class="font-mono text-sm text-slate-400">--</span>
-                            <button
-                                type="button"
-                                id="toggleAdminInsertOnlyBtn"
-                                class="rounded-full border border-white/10 px-4 py-2 text-sm font-medium text-slate-300 transition hover:border-cyan-300/30 hover:text-cyan-100 disabled:opacity-50 disabled:cursor-not-allowed"
-                                disabled
-                                title="Please connect your wallet first"
-                            >
-                                Toggle
-                            </button>
-                        </div>
-                    </div>
-                    <!-- Warning shown when admin-only insert is disabled -->
-                    <div id="openInsertWarning" class="hidden mt-4 rounded-xl border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
-                        <span class="font-semibold uppercase tracking-wide text-amber-400 text-xs mr-1">Warning:</span>
-                        Admin-only insert is disabled. Anyone can now add membership leaves to the ASP. This bypasses the intended access-control safeguard.
-                    </div>
-                </div>
             </section>
 
             <!-- 2. Allowlist Tab -->

--- a/app/js/admin.js
+++ b/app/js/admin.js
@@ -26,11 +26,6 @@ const membershipLevelsEl = document.getElementById('membershipLevels');
 const membershipNextIndexEl = document.getElementById('membershipNextIndex');
 const nonMembershipRootEl = document.getElementById('nonMembershipRoot');
 
-// Admin insert only toggle
-const adminInsertOnlyStatusEl = document.getElementById('adminInsertOnlyStatus');
-const toggleAdminInsertOnlyBtn = document.getElementById('toggleAdminInsertOnlyBtn');
-const openInsertWarningEl = document.getElementById('openInsertWarning');
-
 // Inputs & Action Buttons
 const allowlistPublicKeyInput = document.getElementById('allowlistPublicKey');
 const allowlistAspSecretInput = document.getElementById('allowlistAspSecret');
@@ -50,7 +45,6 @@ const state = {
   membershipClientId: null,
   nonMembershipClientId: null,
   cryptoReady: false,
-  adminInsertOnly: null,
 };
 
 // -----------------------------
@@ -265,7 +259,6 @@ async function connect() {
     state.membershipClient = null;
     state.nonMembershipClient = null;
 
-    updateAdminInsertOnlyDisplay(state.adminInsertOnly);
     setStatus('Wallet connected', 'ok');
     showToast(`Connected: ${shortAddress(address)}`, 'success');
 
@@ -296,13 +289,12 @@ function disconnect() {
   connectBtn.classList.remove('bg-white/[0.05]', 'text-slate-100');
 
   // Disable Action Buttons & restore tooltips
-  const actionBtns = [addToAllowlistBtn, addToBlocklistBtn, removeFromBlocklistBtn, toggleAdminInsertOnlyBtn];
+  const actionBtns = [addToAllowlistBtn, addToBlocklistBtn, removeFromBlocklistBtn];
   actionBtns.forEach(btn => {
     btn.disabled = true;
     btn.title = "Please connect your wallet first";
   });
 
-  updateAdminInsertOnlyDisplay(state.adminInsertOnly);
   setStatus('Wallet disconnected', 'info');
   showToast('Wallet disconnected', 'info');
 }
@@ -332,69 +324,12 @@ async function refreshState() {
     membershipLevelsEl.href = membershipStorageUrl;
     membershipNextIndexEl.textContent = membershipState.nextIndex ?? '--';
     membershipNextIndexEl.href = membershipStorageUrl;
-    updateAdminInsertOnlyDisplay(membershipState.adminInsertOnly);
     nonMembershipRootEl.textContent = nonMembershipState.root || '--';
     nonMembershipRootEl.href = nonMembershipStorageUrl;
 
     setStatus('State loaded', 'ok');
   } catch (err) {
-    updateAdminInsertOnlyDisplay(undefined);
     setStatus('State load error', 'error');
-  }
-}
-
-function updateAdminInsertOnlyDisplay(value) {
-  if (value === undefined || value === null) {
-    adminInsertOnlyStatusEl.textContent = '--';
-    toggleAdminInsertOnlyBtn.disabled = true;
-    openInsertWarningEl.classList.add('hidden');
-    return;
-  }
-  state.adminInsertOnly = value;
-  adminInsertOnlyStatusEl.textContent = value ? 'Enabled' : 'Disabled';
-  adminInsertOnlyStatusEl.className = value ? 'font-mono text-sm text-emerald-400' : 'font-mono text-sm text-amber-400';
-  toggleAdminInsertOnlyBtn.textContent = value ? 'Disable' : 'Enable';
-
-  if (state.address) {
-    toggleAdminInsertOnlyBtn.disabled = false;
-    toggleAdminInsertOnlyBtn.removeAttribute('title');
-  } else {
-    toggleAdminInsertOnlyBtn.disabled = true;
-    toggleAdminInsertOnlyBtn.title = "Please connect your wallet first";
-  }
-
-  openInsertWarningEl.classList.toggle('hidden', value);
-}
-
-async function toggleAdminInsertOnly() {
-  const originalText = toggleAdminInsertOnlyBtn.textContent;
-  try {
-    ensureWalletConnected();
-    const contractId = membershipContractInput.value.trim();
-    if (!contractId) throw new Error('Membership contract ID is required');
-    if (state.adminInsertOnly === null || state.adminInsertOnly === undefined) {
-      throw new Error('Cannot toggle: state unknown. Refresh first.');
-    }
-
-    toggleAdminInsertOnlyBtn.disabled = true;
-    toggleAdminInsertOnlyBtn.textContent = 'Processing...';
-
-    const newValue = !state.adminInsertOnly;
-    setStatus(`Setting admin-only insert to ${newValue ? 'enabled' : 'disabled'}...`, 'info');
-
-    const mClient = await getMembershipClient(contractId);
-    const tx = await mClient.set_admin_insert_only({ admin_only: newValue });
-    await tx.signAndSend();
-
-    setStatus('Setting updated', 'ok');
-    showToast(`Admin-only insert ${newValue ? 'enabled' : 'disabled'}`, 'success');
-    await refreshState();
-  } catch (err) {
-    setStatus('Toggle failed', 'error');
-    showToast('Failed to toggle admin-only insert', 'error');
-  } finally {
-    if (state.address) toggleAdminInsertOnlyBtn.disabled = false;
-    toggleAdminInsertOnlyBtn.textContent = originalText;
   }
 }
 
@@ -540,7 +475,6 @@ connectBtn.addEventListener('click', () => {
   }
 });
 refreshBtn.addEventListener('click', refreshState);
-toggleAdminInsertOnlyBtn.addEventListener('click', toggleAdminInsertOnly);
 
 addToAllowlistBtn.addEventListener('click', insertMembershipLeaf);
 addToBlocklistBtn.addEventListener('click', insertNonMembershipLeaf);

--- a/contracts/asp-membership/src/lib.rs
+++ b/contracts/asp-membership/src/lib.rs
@@ -117,12 +117,14 @@ impl ASPMembership {
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `new_admin` - Address of the new administrator
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the contract has no admin address
+    /// stored.
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
-        if !env.storage().persistent().has(&DataKey::Admin) {
-            return Err(Error::NotInitialized);
-        }
-        soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin);
-        Ok(())
+        soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin)
+            .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
     }
 
     /// Set whether admin permission is required to insert a leaf

--- a/contracts/asp-membership/src/lib.rs
+++ b/contracts/asp-membership/src/lib.rs
@@ -26,8 +26,6 @@ enum DataKey {
     NextIndex,
     /// Current Merkle root
     Root,
-    /// Whether admin permission is required to insert a leaf
-    AdminInsertOnly,
 }
 
 /// Contract error types
@@ -92,7 +90,6 @@ impl ASPMembership {
         store.set(&DataKey::Admin, &admin);
         store.set(&DataKey::Levels, &levels);
         store.set(&DataKey::NextIndex, &0u64);
-        store.set(&DataKey::AdminInsertOnly, &true);
 
         // Initialize an empty tree with zero hashes at each level
         let zeros: Vec<U256> = get_zeroes(&env);
@@ -125,23 +122,6 @@ impl ASPMembership {
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
         soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin)
             .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
-    }
-
-    /// Set whether admin permission is required to insert a leaf
-    ///
-    /// When `admin_only` is true (default), only the admin can insert leaves.
-    /// When false, anyone can insert leaves. Only the admin can change this
-    /// setting.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment
-    /// * `admin_only` - Whether admin permission is required for leaf insertion
-    pub fn set_admin_insert_only(env: Env, admin_only: bool) -> Result<(), Error> {
-        let store = env.storage().persistent();
-        let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
-        admin.require_auth();
-        store.set(&DataKey::AdminInsertOnly, &admin_only);
-        Ok(())
     }
 
     /// Get the current Merkle root
@@ -183,24 +163,23 @@ impl ASPMembership {
     ///
     /// Adds a new member to the Merkle tree and updates the root. The leaf is
     /// inserted at the next available index and the tree is updated efficiently
-    /// by only recomputing the hashes along the path to the root. If
-    /// `admin_insert_only` is enabled (the default), only the admin can insert
-    /// leaves; otherwise, anyone can call this function.
+    /// by only recomputing the hashes along the path to the root. The admin
+    /// must authorize the call.
     ///
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `leaf` - The leaf value to insert (typically a commitment or hash)
     ///
-    /// # Returns
-    /// Returns `Ok(())` on success, or `MerkleTreeFull` if the tree is at
-    /// capacity
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the contract is missing the admin
+    /// address or any tree state the insertion reads,
+    /// [`Error::MerkleTreeFull`] if the tree is at capacity, and
+    /// [`Error::Overflow`] if the next leaf index would exceed `u64::MAX`.
     pub fn insert_leaf(env: Env, leaf: U256) -> Result<(), Error> {
         let store = env.storage().persistent();
-        let admin_only: bool = store.get(&DataKey::AdminInsertOnly).unwrap_or(true);
-        if admin_only {
-            let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
-            admin.require_auth();
-        }
+        let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
+        admin.require_auth();
 
         let levels: u32 = store.get(&DataKey::Levels).ok_or(Error::NotInitialized)?;
         let actual_index: u64 = store

--- a/contracts/asp-membership/src/test.rs
+++ b/contracts/asp-membership/src/test.rs
@@ -337,50 +337,37 @@ fn test_multiple_insertions() {
 }
 
 #[test]
-fn test_admin_insert_only_defaults_to_true() {
-    let env = test_env();
-    let admin = Address::generate(&env);
-    let contract_id = env.register(ASPMembership, (admin, 3u32));
-
-    let stored: bool = env.as_contract(&contract_id, || {
-        env.storage()
-            .persistent()
-            .get(&DataKey::AdminInsertOnly)
-            .expect("AdminInsertOnly set in constructor")
-    });
-    assert!(stored, "AdminInsertOnly should default to true");
-}
-
-#[test]
-fn test_set_admin_insert_only() {
+fn test_insert_leaf_errors_when_admin_unset() {
     let env = test_env();
     let admin = Address::generate(&env);
     let contract_id = env.register(ASPMembership, (admin, 3u32));
     let client = ASPMembershipClient::new(&env, &contract_id);
 
-    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().remove(&DataKey::Admin);
+    });
 
-    // Disable admin-only insert
-    client.set_admin_insert_only(&false);
+    let leaf = U256::from_u32(&env, 100u32);
+    assert!(matches!(
+        client.try_insert_leaf(&leaf),
+        Err(Ok(Error::NotInitialized))
+    ));
 
-    let stored: bool = env.as_contract(&contract_id, || {
+    let next_index: u64 = env.as_contract(&contract_id, || {
         env.storage()
             .persistent()
-            .get(&DataKey::AdminInsertOnly)
-            .expect("AdminInsertOnly updated")
+            .get(&DataKey::NextIndex)
+            .expect("NextIndex set in constructor")
     });
-    assert!(!stored, "AdminInsertOnly should be false after setting it");
+    assert_eq!(next_index, 0, "a rejected insert must not advance the tree");
+}
 
-    // Re-enable admin-only insert
-    client.set_admin_insert_only(&true);
-
-    let stored: bool = env.as_contract(&contract_id, || {
-        env.storage()
-            .persistent()
-            .get(&DataKey::AdminInsertOnly)
-            .expect("AdminInsertOnly re-enabled")
-    });
-    assert!(stored, "AdminInsertOnly should be true after re-enabling");
+/// Key shape of the removed `AdminInsertOnly` flag, so a stale entry can be
+/// written.
+#[contracttype]
+#[derive(Clone)]
+enum LegacyDataKey {
+    AdminInsertOnly,
 }
 
 /// This test is skipped under Miri because the panic formatting path triggers
@@ -389,129 +376,20 @@ fn test_set_admin_insert_only() {
 #[test]
 #[cfg_attr(miri, ignore)]
 #[should_panic(expected = "Error(Auth, InvalidAction)")]
-fn test_set_admin_insert_only_requires_admin() {
+fn test_legacy_admin_insert_only_flag_is_ignored() {
     let env = test_env();
     let admin = Address::generate(&env);
     let contract_id = env.register(ASPMembership, (admin, 3u32));
     let client = ASPMembershipClient::new(&env, &contract_id);
 
-    // Should fail without mock_all_auths
-    client.set_admin_insert_only(&false);
-}
-
-#[test]
-fn test_insert_leaf_without_admin_when_permissionless() {
-    let env = test_env();
-    let admin = Address::generate(&env);
-    let contract_id = env.register(ASPMembership, (admin, 3u32));
-    let client = ASPMembershipClient::new(&env, &contract_id);
-
-    // Admin disables admin-only insert via direct storage manipulation
-    // to avoid needing mock_all_auths (which would mask the auth check
-    // we're trying to verify is skipped).
     env.as_contract(&contract_id, || {
         env.storage()
             .persistent()
-            .set(&DataKey::AdminInsertOnly, &false);
+            .set(&LegacyDataKey::AdminInsertOnly, &false);
     });
 
-    // Insert a leaf WITHOUT mock_all_auths — should succeed because
-    // admin_insert_only is false
-    let leaf = U256::from_u32(&env, 42u32);
+    let leaf = U256::from_u32(&env, 100u32);
     client.insert_leaf(&leaf);
-
-    let next_index: u64 = env.as_contract(&contract_id, || {
-        env.storage()
-            .persistent()
-            .get(&DataKey::NextIndex)
-            .expect("NextIndex set after insert")
-    });
-    assert_eq!(next_index, 1, "Leaf should be inserted without admin auth");
-}
-
-/// This test is skipped under Miri because the panic formatting path triggers
-/// undefined behavior in the `ethnum` crate's unsafe formatting code.
-/// See: https://github.com/nlordell/ethnum-rs/issues/34
-#[test]
-#[cfg_attr(miri, ignore)]
-#[should_panic(expected = "Error(Auth, InvalidAction)")]
-fn test_insert_leaf_requires_admin_when_re_enabled() {
-    let env = test_env();
-    let admin = Address::generate(&env);
-    let contract_id = env.register(ASPMembership, (admin, 3u32));
-    let client = ASPMembershipClient::new(&env, &contract_id);
-
-    // Disable admin-only insert via storage so we don't need mock_all_auths
-    env.as_contract(&contract_id, || {
-        env.storage()
-            .persistent()
-            .set(&DataKey::AdminInsertOnly, &false);
-    });
-
-    // Insert a leaf permissionlessly (should succeed)
-    let leaf1 = U256::from_u32(&env, 100u32);
-    client.insert_leaf(&leaf1);
-
-    // Re-enable admin-only insert via storage
-    env.as_contract(&contract_id, || {
-        env.storage()
-            .persistent()
-            .set(&DataKey::AdminInsertOnly, &true);
-    });
-
-    // This should panic — admin auth is required again and no auths are mocked
-    let leaf2 = U256::from_u32(&env, 200u32);
-    client.insert_leaf(&leaf2);
-}
-
-#[test]
-fn test_permissionless_insert_multiple_leaves() {
-    let env = test_env();
-    let admin = Address::generate(&env);
-    let contract_id = env.register(ASPMembership, (admin, 3u32));
-    let client = ASPMembershipClient::new(&env, &contract_id);
-
-    env.mock_all_auths();
-    client.set_admin_insert_only(&false);
-
-    // Insert multiple leaves
-    for i in 0..5 {
-        let leaf = U256::from_u32(&env, (i + 1) * 10u32);
-        client.insert_leaf(&leaf);
-    }
-
-    let next_index: u64 = env.as_contract(&contract_id, || {
-        env.storage()
-            .persistent()
-            .get(&DataKey::NextIndex)
-            .expect("NextIndex set after inserts")
-    });
-    assert_eq!(
-        next_index, 5,
-        "Should have 5 leaves after permissionless insertions"
-    );
-}
-
-#[test]
-fn test_permissionless_insert_updates_root() {
-    let env = test_env();
-    let admin = Address::generate(&env);
-    let contract_id = env.register(ASPMembership, (admin, 3u32));
-    let client = ASPMembershipClient::new(&env, &contract_id);
-
-    env.mock_all_auths();
-    client.set_admin_insert_only(&false);
-
-    let root_before = client.get_root();
-
-    let leaf = U256::from_u32(&env, 42u32);
-    client.insert_leaf(&leaf);
-
-    let root_after = client.get_root();
-    assert_ne!(
-        root_before, root_after,
-        "Root should change after permissionless insert"
-    );
 }
 
 /// Poseidon2 compression function (same as in

--- a/contracts/asp-membership/src/test.rs
+++ b/contracts/asp-membership/src/test.rs
@@ -260,6 +260,24 @@ fn test_update_admin() {
 }
 
 #[test]
+fn test_update_admin_errors_when_admin_unset() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().remove(&DataKey::Admin);
+    });
+
+    assert!(matches!(
+        client.try_update_admin(&new_admin),
+        Err(Ok(Error::NotInitialized))
+    ));
+}
+
+#[test]
 fn test_new_admin_can_insert_after_update() {
     let env = test_env();
     let admin = Address::generate(&env);

--- a/contracts/asp-membership/src/test.rs
+++ b/contracts/asp-membership/src/test.rs
@@ -5,7 +5,11 @@ use ark_bn254::Fr as Scalar;
 use ark_ff::{BigInteger, PrimeField};
 use core::ops::Add;
 use num_bigint::BigUint;
-use soroban_sdk::{Address, Bytes, Env, U256, Vec, testutils::Address as _, vec};
+use soroban_sdk::{
+    Address, Bytes, Env, IntoVal, U256, Vec,
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    vec,
+};
 use taceo_poseidon2::bn254::t2;
 
 /// Create a test environment that disables snapshot writing under Miri.
@@ -306,6 +310,50 @@ fn test_new_admin_can_insert_after_update() {
         next_index, 1,
         "NextIndex should be 1 after insertion by new admin"
     );
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_update_admin_requires_admin() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+
+    client.update_admin(&Address::generate(&env));
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_old_admin_cannot_insert_after_update() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin.clone(), 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    client.update_admin(&new_admin);
+
+    let leaf = U256::from_u32(&env, 100u32);
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "insert_leaf",
+            args: (leaf.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.insert_leaf(&leaf);
 }
 
 #[test]

--- a/contracts/asp-non-membership/src/lib.rs
+++ b/contracts/asp-non-membership/src/lib.rs
@@ -119,8 +119,14 @@ impl ASPNonMembership {
     ///
     /// * `env` - The Soroban environment
     /// * `new_admin` - New address that will have permission to modify the tree
-    pub fn update_admin(env: Env, new_admin: Address) {
-        soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin);
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the contract has no admin address
+    /// stored.
+    pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
+        soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin)
+            .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
     }
 
     /// Hash a leaf node using Poseidon2

--- a/contracts/asp-non-membership/src/test.rs
+++ b/contracts/asp-non-membership/src/test.rs
@@ -1,7 +1,10 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{Address, Bytes, Env, U256, testutils::Address as _};
+use soroban_sdk::{
+    Address, Bytes, Env, IntoVal, U256,
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+};
 
 /// Create a test environment that disables snapshot writing under Miri.
 /// Miri's isolation mode blocks filesystem operations, which the Soroban SDK
@@ -934,4 +937,119 @@ fn test_update_admin_errors_when_admin_unset() {
         client.try_update_admin(&new_admin),
         Err(Ok(Error::NotInitialized))
     ));
+}
+
+#[test]
+fn test_update_admin() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    client.update_admin(&new_admin);
+
+    let stored_admin: Address = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Admin updated")
+    });
+    assert_eq!(stored_admin, new_admin);
+
+    let key = U256::from_u32(&env, 1u32);
+    let value = U256::from_u32(&env, 42u32);
+    env.mock_auths(&[MockAuth {
+        address: &new_admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "insert_leaf",
+            args: (key.clone(), value.clone()).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.insert_leaf(&key, &value);
+
+    assert_ne!(client.get_root(), U256::from_u32(&env, 0u32));
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_update_admin_requires_admin() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+
+    client.update_admin(&Address::generate(&env));
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_insert_leaf_requires_admin() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+
+    client.insert_leaf(&U256::from_u32(&env, 1u32), &U256::from_u32(&env, 42u32));
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_delete_leaf_requires_admin() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    let key = U256::from_u32(&env, 1u32);
+    client.insert_leaf(&key, &U256::from_u32(&env, 42u32));
+
+    env.mock_auths(&[]);
+    client.delete_leaf(&key);
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_old_admin_cannot_insert_after_update() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin.clone(),));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    client.update_admin(&new_admin);
+
+    let key = U256::from_u32(&env, 1u32);
+    let value = U256::from_u32(&env, 42u32);
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "insert_leaf",
+            args: (key.clone(), value.clone()).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.insert_leaf(&key, &value);
 }

--- a/contracts/asp-non-membership/src/test.rs
+++ b/contracts/asp-non-membership/src/test.rs
@@ -917,3 +917,21 @@ fn test_leaf_inserted_and_deleted_event_exact_shapes() {
     .to_xdr(&env, &contract_id);
     assert_eq!(events_after_delete.events()[0], expected_deleted);
 }
+
+#[test]
+fn test_update_admin_errors_when_admin_unset() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().remove(&DataKey::Admin);
+    });
+
+    assert!(matches!(
+        client.try_update_admin(&new_admin),
+        Err(Ok(Error::NotInitialized))
+    ));
+}

--- a/contracts/pool-gvk/src/pool_gvk.rs
+++ b/contracts/pool-gvk/src/pool_gvk.rs
@@ -330,12 +330,14 @@ impl PoolGvkContract {
 
     /// Update the contract administrator. Requires authorization from the
     /// current admin.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the contract has no admin address
+    /// stored.
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
-        if !env.storage().persistent().has(&DataKey::Admin) {
-            return Err(Error::NotInitialized);
-        }
-        soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin);
-        Ok(())
+        soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin)
+            .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
     }
 
     // ========== ASP Contract Functions ==========

--- a/contracts/pool-gvk/src/test.rs
+++ b/contracts/pool-gvk/src/test.rs
@@ -388,6 +388,29 @@ fn update_admin_errors_when_admin_unset() {
     ));
 }
 
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn update_admin_requires_admin() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool_gvk(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        0,
+        mk_point(&env, 1, 1),
+        VIEW_ONLY,
+    );
+    let pool = PoolGvkContractClient::new(&env, &pool_id);
+
+    pool.update_admin(&Address::generate(&env));
+}
+
 fn mk_bytesn32(env: &Env, fill: u8) -> BytesN<32> {
     BytesN::from_array(env, &[fill; 32])
 }

--- a/contracts/pool-gvk/src/test.rs
+++ b/contracts/pool-gvk/src/test.rs
@@ -362,6 +362,32 @@ fn pool_gvk_update_admin_transfers_control() {
     assert_eq!(stored_admin, new_admin);
 }
 
+#[test]
+fn update_admin_errors_when_admin_unset() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool_gvk(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        0,
+        mk_point(&env, 1, 1),
+        VIEW_ONLY,
+    );
+    let pool = PoolGvkContractClient::new(&env, &pool_id);
+    let new_admin = Address::generate(&env);
+
+    env.as_contract(&pool_id, || {
+        env.storage().persistent().remove(&DataKey::Admin);
+    });
+
+    assert!(matches!(
+        pool.try_update_admin(&new_admin),
+        Err(Ok(Error::NotInitialized))
+    ));
+}
+
 fn mk_bytesn32(env: &Env, fill: u8) -> BytesN<32> {
     BytesN::from_array(env, &[fill; 32])
 }

--- a/contracts/pool/src/pool.rs
+++ b/contracts/pool/src/pool.rs
@@ -647,12 +647,14 @@ impl PoolContract {
     ///
     /// * `env` - The Soroban environment
     /// * `new_admin` - New address that will have administrative permissions
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the contract has no admin address
+    /// stored.
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
-        if !env.storage().persistent().has(&DataKey::Admin) {
-            return Err(Error::NotInitialized);
-        }
-        soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin);
-        Ok(())
+        soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin)
+            .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
     }
 
     // ========== ASP Contract Functions ==========

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -818,6 +818,46 @@ fn get_policy_flags_errors_when_unset() {
 }
 
 #[test]
+fn update_admin_errors_when_admin_unset() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 3, 0u32);
+    let pool = PoolContractClient::new(&env, &pool_id);
+    let new_admin = Address::generate(&env);
+
+    env.as_contract(&pool_id, || {
+        env.storage()
+            .persistent()
+            .remove(&crate::pool::DataKey::Admin);
+    });
+
+    assert!(matches!(
+        pool.try_update_admin(&new_admin),
+        Err(Ok(Error::NotInitialized))
+    ));
+}
+
+#[test]
+fn update_admin_transfers_control() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 3, 0u32);
+    let pool = PoolContractClient::new(&env, &pool_id);
+    let new_admin = Address::generate(&env);
+
+    env.mock_all_auths();
+    pool.update_admin(&new_admin);
+
+    let stored_admin: Address = env.as_contract(&pool_id, || {
+        env.storage()
+            .persistent()
+            .get(&crate::pool::DataKey::Admin)
+            .expect("Admin set in constructor")
+    });
+    assert_eq!(stored_admin, new_admin);
+}
+
+#[test]
 #[cfg_attr(miri, ignore)]
 fn transact_errors_when_policy_flags_unset() {
     let env = test_env();

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -837,6 +837,51 @@ fn update_admin_errors_when_admin_unset() {
     ));
 }
 
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn update_admin_requires_admin() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 3, 0u32);
+    let pool = PoolContractClient::new(&env, &pool_id);
+
+    pool.update_admin(&Address::generate(&env));
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn update_asp_membership_requires_admin() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 3, 0u32);
+    let pool = PoolContractClient::new(&env, &pool_id);
+
+    pool.update_asp_membership(&Address::generate(&env));
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn update_asp_non_membership_requires_admin() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 3, 0u32);
+    let pool = PoolContractClient::new(&env, &pool_id);
+
+    pool.update_asp_non_membership(&Address::generate(&env));
+}
+
 #[test]
 fn update_admin_transfers_control() {
     let env = test_env();

--- a/contracts/soroban-utils/src/utils.rs
+++ b/contracts/soroban-utils/src/utils.rs
@@ -3,28 +3,38 @@ use ark_ff::{BigInteger, fields::PrimeField};
 use contract_types::VerificationKeyBytes;
 use soroban_sdk::{Address, BytesN, Env, IntoVal, TryFromVal, Val, Vec, contract, contractimpl};
 
-/// Update the contract administrator
+/// Error returned by the shared admin helpers.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum AdminError {
+    /// No admin address is stored under the given key.
+    NotInitialized,
+}
+
+/// Replaces the administrator stored under `admin_key` with `new_admin`.
 ///
-/// Changes the admin address to a new address. Only the current admin
-/// can call this function.
+/// The address already stored under `admin_key` must authorize the call. Each
+/// contract passes its own storage key, so contracts sharing this helper keep
+/// separate admin entries.
 ///
-/// # Arguments
-/// * `env` - The Soroban environment
-/// * `admin_key` - Storage key for the admin address (e.g., `DataKey::Admin`)
-/// * `new_admin` - Address of the new administrator
+/// # Errors
+///
+/// Returns [`AdminError::NotInitialized`] if no address is stored under
+/// `admin_key`.
 ///
 /// # Panics
-/// Panics if the caller is not the current admin
-pub fn update_admin<K>(env: &Env, admin_key: &K, new_admin: &Address)
+///
+/// Panics if the address stored under `admin_key` does not authorize the call,
+/// because `require_auth` raises a host error rather than returning.
+pub fn update_admin<K>(env: &Env, admin_key: &K, new_admin: &Address) -> Result<(), AdminError>
 where
     K: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
 {
     let store = env.storage().persistent();
-    let admin: Address = store.get(admin_key).expect("admin not initialized");
+    let admin: Address = store.get(admin_key).ok_or(AdminError::NotInitialized)?;
     admin.require_auth();
 
-    // Update admin address
     store.set(admin_key, new_admin);
+    Ok(())
 }
 
 /// Mock token contract for testing purposes

--- a/sdk/native/src/chain/contract_state.rs
+++ b/sdk/native/src/chain/contract_state.rs
@@ -233,7 +233,7 @@ impl StateFetcher {
 
         requests.push(ContractDataBulkRequest {
             contract_id: self.config.asp_membership.as_str(),
-            enum_keys: vec!["Root", "Levels", "NextIndex", "Admin", "AdminInsertOnly"],
+            enum_keys: vec!["Root", "Levels", "NextIndex", "Admin"],
             optional_enum_keys: vec![],
             valued_keys: vec![],
         });
@@ -434,11 +434,6 @@ impl StateFetcher {
                 admin: scval_to_address_string(get_state!(
                     asp_membership_state,
                     "Admin",
-                    asp_membership_id
-                )?)?,
-                admin_insert_only: scval_to_bool(get_state!(
-                    asp_membership_state,
-                    "AdminInsertOnly",
                     asp_membership_id
                 )?)?,
                 capacity: asp_mem_capacity,

--- a/sdk/native/src/types/chain_data.rs
+++ b/sdk/native/src/types/chain_data.rs
@@ -84,7 +84,6 @@ pub struct AspMembership {
     pub levels: u32,
     pub next_index: String,
     pub admin: String,
-    pub admin_insert_only: bool,
     pub capacity: u64,
     pub used_slots: String, //num_bigint::BigUint,
 }


### PR DESCRIPTION
## What changed

Two authorization defects in the ASP contracts, plus the SDK and admin-page changes that
follow from removing the first one.

**The allowlist could be written by anyone.** `asp-membership` exposed
`set_admin_insert_only`, which wrote a boolean `AdminInsertOnly` into persistent storage.
`insert_leaf` read that flag and, when it was `false`, skipped `require_auth` entirely:

```rust
let admin_only: bool = store.get(&DataKey::AdminInsertOnly).unwrap_or(true);
if admin_only {
    let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
    admin.require_auth();
}
```

Any key could then append itself to the membership tree. Because a pool with `ALLOWLIST_BIT`
set proves deposits against that tree's root, every such pool would accept deposits from
arbitrary accounts for as long as the flag stayed off. One admin call opened it, and nothing
closed it automatically.

The flag is removed rather than pinned to `true`. The setter, the `DataKey` variant, and the
constructor write are all gone, because a stored boolean that gates an authorization check is
one setter away from being a bypass again. `insert_leaf` now has a single path with no branch:
load `Admin`, return `NotInitialized` if it is absent, then `require_auth`.

**Admin rotation panicked instead of returning an error.** `soroban_utils::update_admin`
loaded the stored admin with `.expect("admin not initialized")`, so a contract whose `Admin`
entry was missing aborted the invocation with a string panic rather than a contract error.
Three of the four callers papered over this with a `has(&DataKey::Admin)` pre-check, a second
storage read whose exact sequence had already drifted between the copies. The fourth,
`asp-non-membership::update_admin`, had no pre-check and returned `()`, leaving it the one
rotation entry point that still panicked. The helper now returns `Result<(), AdminError>`,
every caller maps that to its own `Error::NotInitialized`, and the pre-checks are deleted, so
there is one load-and-require sequence to audit instead of four variants of one.

Where to look: `contracts/asp-membership/src/lib.rs` carries the bypass removal and is the
highest-risk file in the diff. `contracts/soroban-utils/src/utils.rs` carries the helper
change that the other three contracts depend on. The remaining contract changes are
mechanical, and the SDK, app, and README changes only drop the field and the UI that the
removed flag fed.

Test coverage grew from 117 to 128 across the four contract crates. Every privileged entry
point in all four now has a test that it refuses an unauthorized caller, which none of
`asp-non-membership`'s had before, and each ASP has a test that a rotated-out admin loses
insert rights. Each of those tests was checked by deleting the `require_auth` it covers and
confirming the test fails.

## Breaking changes

1. `asp-membership::set_admin_insert_only` is gone from the contract interface, and the
   `AdminInsertOnly` ledger entry is no longer written. A client calling that method must drop
   the call.
2. `asp-non-membership::update_admin` returns `Result<(), Error>` instead of `()`. Clients
   generated from the old contract spec need regenerating; none are checked in.
3. `types::AspMembership` no longer carries `admin_insert_only`. This is semver-major for the
   SDK crates. The `check` job in `release.yml` runs `cargo-semver-checks` only when the
   version line in `sdk/native/Cargo.toml` changes, so CI does not flag it on this branch; the
   next version bump will.

Removing `AdminInsertOnly` from the `DataKey` enum does not move the other keys. Soroban
encodes a `#[contracttype]` unit variant by its symbol name rather than by ordinal, so `Root`,
`Levels`, `NextIndex`, and `Admin` keep the same ledger keys on an existing deployment. A
stale `AdminInsertOnly` entry left behind by an already-deployed contract is simply never read
again. `test_legacy_admin_insert_only_flag_is_ignored` writes such an entry under the old key
shape and confirms `insert_leaf` still demands admin authorization.

## Design notes

`soroban_utils::update_admin` keeps a `# Panics` section even though it now returns a
`Result`. `require_auth` still traps when the stored admin does not authorize the call, and
that is worth stating on a shared helper four contracts route their rotation through.

The four call sites destructure the error rather than discarding it:

```rust
.map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
```

`AdminError` has one variant today, so this is irrefutable and costs nothing. Adding a second
variant later fails to compile at all four sites instead of silently reporting the new case as
`NotInitialized` on an authorization path.

Closes #370
