### PR TITLE
Clear unowned Chrome singleton locks before every profile launch

### DIFF
--- a/e2e-freighter/src/chrome-locks.mjs
+++ b/e2e-freighter/src/chrome-locks.mjs
@@ -1,0 +1,68 @@
+// Remove Chrome's single-instance locks from a user-data-dir, but only when
+// nothing still holds them.
+//
+// Chrome writes SingletonLock — a symlink to "<hostname>-<pid>" — plus
+// SingletonSocket and SingletonCookie while a profile is open, and removes
+// them on a clean exit. A killed run leaves them behind, and the next launch
+// reads them as "open elsewhere" and quietly switches to a throwaway profile:
+// the extension loads with no wallet.
+//
+// The rule enforced here: locks are removed only when the target names a dead
+// pid or a different host. A live owner, or a target that cannot be read as
+// "<hostname>-<pid>", throws — an aborted launch is diagnosable, two browsers
+// on one profile is not.
+import { lstatSync, readlinkSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const SINGLETON_NAMES = ['SingletonLock', 'SingletonSocket', 'SingletonCookie'];
+
+function defaultIsProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM: it exists and belongs to someone else.
+    return err.code === 'EPERM';
+  }
+}
+
+function readOwner(lockPath, stats) {
+  if (!stats.isSymbolicLink()) throw new Error('SingletonLock is not a symlink');
+  const target = readlinkSync(lockPath);
+  const match = /^(.+)-(\d+)$/.exec(target);
+  if (!match) throw new Error(`SingletonLock target '${target}' is not <hostname>-<pid>`);
+  return { host: match[1], pid: Number(match[2]) };
+}
+
+export function clearSingletonLocks(userDataDir, {
+  hostname = os.hostname(),
+  isProcessAlive = defaultIsProcessAlive,
+} = {}) {
+  if (!userDataDir) return [];
+
+  const lockPath = path.join(userDataDir, 'SingletonLock');
+  const lockStats = lstatSync(lockPath, { throwIfNoEntry: false });
+  if (lockStats) {
+    let owner;
+    try {
+      owner = readOwner(lockPath, lockStats);
+    } catch (err) {
+      throw new Error(`refusing to clear ${lockPath}: ${err.message}`);
+    }
+    if (owner.host === hostname && isProcessAlive(owner.pid)) {
+      throw new Error(
+        `refusing to clear ${lockPath}: pid ${owner.pid} on ${owner.host} still holds this profile`,
+      );
+    }
+  }
+
+  const removed = [];
+  for (const name of SINGLETON_NAMES) {
+    const target = path.join(userDataDir, name);
+    // lstat, not exists: the SingletonLock symlink does not resolve.
+    if (lstatSync(target, { throwIfNoEntry: false })) removed.push(name);
+    rmSync(target, { force: true });
+  }
+  return removed;
+}

--- a/e2e-freighter/src/runner.mjs
+++ b/e2e-freighter/src/runner.mjs
@@ -21,6 +21,7 @@ import {
   waitForWalletRuntimeReady,
 } from './appState.mjs';
 import { chromium } from 'playwright';
+import { clearSingletonLocks } from './chrome-locks.mjs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -56,6 +57,12 @@ const log = createLogger('runner');
 
 export async function launch({ userDataDir, headless = true, video = false } = {}) {
   if (!userDataDir) throw new Error('launch: userDataDir is required');
+  // Throws rather than starting a second browser on a profile that something
+  // else still holds.
+  const clearedLocks = clearSingletonLocks(userDataDir);
+  if (clearedLocks.length > 0) {
+    log.warn(`launch: cleared Chrome locks with no live owner (${clearedLocks.join(', ')})`);
+  }
   const contextOptions = {
     headless,
     executablePath: CHROMIUM_PATH,

--- a/e2e-freighter/tests/unit/chrome-locks.test.mjs
+++ b/e2e-freighter/tests/unit/chrome-locks.test.mjs
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { clearSingletonLocks } from '../../src/chrome-locks.mjs';
+
+const ALL_THREE = ['SingletonLock', 'SingletonSocket', 'SingletonCookie'];
+
+function profileDir(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'chrome-locks-'));
+  t.after(() => fs.rmSync(dir, { force: true, recursive: true }));
+  return dir;
+}
+
+function plantLocks(dir, owner) {
+  fs.symlinkSync(owner, path.join(dir, 'SingletonLock'));
+  fs.writeFileSync(path.join(dir, 'SingletonSocket'), '');
+  fs.writeFileSync(path.join(dir, 'SingletonCookie'), '');
+}
+
+test('removes locks whose owning process is gone', (t) => {
+  const dir = profileDir(t);
+  plantLocks(dir, 'thishost-12345');
+
+  const removed = clearSingletonLocks(dir, { hostname: 'thishost', isProcessAlive: () => false });
+
+  assert.deepEqual(removed, ALL_THREE);
+  assert.deepEqual(fs.readdirSync(dir), []);
+});
+
+test('removes locks belonging to another host, live pid or not', (t) => {
+  const dir = profileDir(t);
+  plantLocks(dir, 'someotherhost-12345');
+
+  const removed = clearSingletonLocks(dir, { hostname: 'thishost', isProcessAlive: () => true });
+
+  assert.deepEqual(removed, ALL_THREE);
+  assert.deepEqual(fs.readdirSync(dir), []);
+});
+
+test('refuses, and removes nothing, while a live process on this host holds the profile', (t) => {
+  const dir = profileDir(t);
+  plantLocks(dir, 'thishost-12345');
+
+  assert.throws(
+    () => clearSingletonLocks(dir, { hostname: 'thishost', isProcessAlive: () => true }),
+    /pid 12345 on thishost still holds this profile/,
+  );
+  assert.deepEqual(fs.readdirSync(dir).sort(), [...ALL_THREE].sort());
+});
+
+test('the real liveness check refuses on a lock naming this process', (t) => {
+  const dir = profileDir(t);
+  plantLocks(dir, `${os.hostname()}-${process.pid}`);
+
+  assert.throws(() => clearSingletonLocks(dir), /still holds this profile/);
+  assert.deepEqual(fs.readdirSync(dir).sort(), [...ALL_THREE].sort());
+});
+
+test('refuses when the lock is not a symlink naming a host and pid', (t) => {
+  const asFile = profileDir(t);
+  fs.writeFileSync(path.join(asFile, 'SingletonLock'), 'thishost-12345');
+  assert.throws(() => clearSingletonLocks(asFile), /is not a symlink/);
+  assert.deepEqual(fs.readdirSync(asFile), ['SingletonLock']);
+
+  const asDir = profileDir(t);
+  fs.mkdirSync(path.join(asDir, 'SingletonLock'));
+  fs.writeFileSync(path.join(asDir, 'SingletonLock', 'surprise'), '');
+  assert.throws(() => clearSingletonLocks(asDir), /is not a symlink/);
+  assert.deepEqual(fs.readdirSync(path.join(asDir, 'SingletonLock')), ['surprise']);
+
+  const unparsable = profileDir(t);
+  fs.symlinkSync('no-pid-here', path.join(unparsable, 'SingletonLock'));
+  assert.throws(() => clearSingletonLocks(unparsable), /is not <hostname>-<pid>/);
+  assert.deepEqual(fs.readdirSync(unparsable), ['SingletonLock']);
+});
+
+test('a socket and cookie with no lock claim no owner and are removed', (t) => {
+  const dir = profileDir(t);
+  fs.writeFileSync(path.join(dir, 'SingletonSocket'), '');
+  fs.writeFileSync(path.join(dir, 'SingletonCookie'), '');
+
+  const removed = clearSingletonLocks(dir, { hostname: 'thishost', isProcessAlive: () => true });
+
+  assert.deepEqual(removed, ['SingletonSocket', 'SingletonCookie']);
+  assert.deepEqual(fs.readdirSync(dir), []);
+});
+
+test('leaves the rest of the profile alone', (t) => {
+  const dir = profileDir(t);
+  plantLocks(dir, 'thishost-12345');
+  fs.writeFileSync(path.join(dir, 'Local State'), '{}');
+  fs.mkdirSync(path.join(dir, 'Default'));
+  fs.writeFileSync(path.join(dir, 'Default', 'Preferences'), '{}');
+
+  clearSingletonLocks(dir, { hostname: 'thishost', isProcessAlive: () => false });
+
+  assert.deepEqual(fs.readdirSync(dir).sort(), ['Default', 'Local State']);
+  assert.equal(fs.readFileSync(path.join(dir, 'Default', 'Preferences'), 'utf8'), '{}');
+});
+
+test('a profile with no locks and a profile that does not exist are both no-ops', (t) => {
+  const dir = profileDir(t);
+  assert.deepEqual(clearSingletonLocks(dir), []);
+  assert.deepEqual(fs.readdirSync(dir), []);
+
+  assert.deepEqual(clearSingletonLocks(path.join(dir, 'never-provisioned')), []);
+});


### PR DESCRIPTION
Chrome writes `SingletonLock` — a symlink to `<hostname>-<pid>` — plus
`SingletonSocket` and `SingletonCookie` at the root of a user-data-dir while it
runs, and removes them on a clean exit. A killed run leaves them behind. The
next launch does not fail on them: it decides the profile is in use elsewhere
and quietly switches to a throwaway one. The extension loads but has no wallet,
so the app reports Freighter as not detected while the provisioned profile sits
intact on disk.

The profile this reaches is the live `e2e-freighter/.chrome-profile`.
`provision.sh --verify`, and plain `provision.sh` when a snapshot already
exists, both run `provision.mjs --verify`, which launches Chrome against that
directory directly (`scripts/provision.sh:69-74`, `scripts/provision.mjs:264`).
Nothing on that path removes a lock. The rebuild path is not affected — it
starts with `rm -rf "$PROFILE_DIR"` — and a restored profile cannot carry one,
because the snapshot tar already excludes all three names.

## Change

`src/chrome-locks.mjs` exports `clearSingletonLocks(userDataDir)`, and
`launch()` in `src/runner.mjs` calls it before
`chromium.launchPersistentContext`.

The presence of a lock does not prove its owner is gone, so removal is
conditional. `SingletonLock`'s target is read and compared against this host
and the live process table:

- target names a dead pid, or a host that is not this one → all three files are
  removed, and `launch()` warns with the names it removed;
- target names a live process on this host → throws, and removes nothing;
- target cannot be read as `<hostname>-<pid>` — a regular file, a directory, an
  unparseable link → throws, and removes nothing.

Refusing is the point of the last two. Two browsers sharing one profile
corrupts it silently; an aborted launch names the pid and the path that
stopped it. The hostname and liveness probe are injectable so the refusal
paths are testable without a browser; the default probe is `process.kill(pid, 0)`,
treating `EPERM` as alive.

`launch()` is the only place this package starts a browser: `provision.mjs` uses
it for both the `--verify` launch and the headed provisioning launch, and
`runner.mjs` uses it for every test run. Putting the cleanup there covers the
live profile and the restored temp copy without either script needing to know
about locks.

`tests/unit/chrome-locks.test.mjs` covers both halves. Removal: a dead pid, and
another host's live pid, both clear all three files; a socket and cookie with no
lock claim no owner; unrelated profile contents survive; an absent profile is a
no-op. Refusal: a live pid on this host, a lock that is a regular file, a lock
that is a directory, and an unparseable target each throw with nothing removed —
including one case that plants this test process's own pid, so the real liveness
probe is exercised rather than a stub.