### PR TITLE
Scope the archive endpoint and logging posture per account

### DIFF
--- a/app/js/admin.js
+++ b/app/js/admin.js
@@ -200,11 +200,11 @@ async function ensureCryptoReady() {
     try {
       const storage = await ensureStorage();
       if (await bootnodeRequired(sorobanRpcUrl)) {
-        if (!(await storage.getStoredBootnodeUrl())) {
+        if (!(await storage.getStoredBootnodeUrl(state.address))) {
           throw new Error('RPC_SYNC_GAP: bootnode required');
         }
       }
-      await initializeRuntime(sorobanRpcUrl);
+      await initializeRuntime(sorobanRpcUrl, { address: state.address });
       await client().backgroundSync();
     } catch (e) {
       if (isDbLockedError(e?.message)) showDbLockedModal(e.message);

--- a/app/js/app-storage.js
+++ b/app/js/app-storage.js
@@ -5,6 +5,36 @@
 
 const SETTING_EXPLORER = 'explorer';
 const SETTING_BOOTNODE_CONFIG = 'bootnode_config';
+const SETTING_TELEMETRY_CONFIG = 'telemetry_config';
+
+// A setting is account-scoped if its value can reveal something about the
+// account it is applied under; global if it is a presentation preference that
+// is the same for everyone.
+//
+// bootnode_config: its operator sees which account is syncing, so sharing one
+// endpoint across accounts links them.
+// telemetry_config: revealSensitive un-redacts this account's amounts and
+// addresses, and level decides how much of its activity is kept.
+// explorer: public infrastructure, identical for every account.
+const ACCOUNT_SCOPED_SETTINGS = new Set([SETTING_BOOTNODE_CONFIG, SETTING_TELEMETRY_CONFIG]);
+
+/**
+ * Storage key for a setting under a given account.
+ *
+ * Scoped settings are namespaced by address and require one — falling back to
+ * the unscoped key is the inheritance this prevents. Legacy unscoped values are
+ * not migrated: they belonged to whichever account was active when they were
+ * written.
+ */
+function settingKey(key, address) {
+    if (!ACCOUNT_SCOPED_SETTINGS.has(key)) return key;
+    if (typeof address !== 'string' || address.length === 0) {
+        throw new Error(`Setting "${key}" is account-scoped and requires an address`);
+    }
+    return `${key}::${address}`;
+}
+
+export { ACCOUNT_SCOPED_SETTINGS, SETTING_BOOTNODE_CONFIG, SETTING_TELEMETRY_CONFIG, SETTING_EXPLORER, settingKey };
 
 /** Suggested archive URL when none is stored yet (wizard + sync-gap consent). */
 export const DEFAULT_BOOTNODE_URL = 'https://bootnode.dev-nethermind.xyz';
@@ -38,17 +68,26 @@ export class AppStorage {
         return storageCall(this.#storage, request, timeoutMs);
     }
 
-    async getSetting(key) {
-        const response = await this.#call({ GetSetting: key });
+    /**
+     * @param {string} key
+     * @param {string} [address] - required for account-scoped keys (see settingKey).
+     */
+    async getSetting(key, address) {
+        const response = await this.#call({ GetSetting: settingKey(key, address) });
         const raw = response.Setting;
         if (raw == null) return null;
         return JSON.parse(raw);
     }
 
-    async setSetting(key, value) {
+    /**
+     * @param {string} key
+     * @param {unknown} value
+     * @param {string} [address] - required for account-scoped keys (see settingKey).
+     */
+    async setSetting(key, value, address) {
         await this.#call({
             SetSetting: {
-                key,
+                key: settingKey(key, address),
                 value_json: JSON.stringify(value),
             },
         });
@@ -58,12 +97,20 @@ export class AppStorage {
         return this.getSetting(SETTING_EXPLORER);
     }
 
-    async getBootnodeConfig() {
-        return this.getSetting(SETTING_BOOTNODE_CONFIG);
+    async getBootnodeConfig(address) {
+        return this.getSetting(SETTING_BOOTNODE_CONFIG, address);
     }
 
-    async setBootnodeConfig(url) {
-        await this.setSetting(SETTING_BOOTNODE_CONFIG, { enabled: true, url });
+    async setBootnodeConfig(url, address) {
+        await this.setSetting(SETTING_BOOTNODE_CONFIG, { enabled: true, url }, address);
+    }
+
+    async getTelemetryConfig(address) {
+        return this.getSetting(SETTING_TELEMETRY_CONFIG, address);
+    }
+
+    async setTelemetryConfig(config, address) {
+        await this.setSetting(SETTING_TELEMETRY_CONFIG, config, address);
     }
 
     async getDisclaimerState(address) {
@@ -102,11 +149,29 @@ export class AppStorage {
         return response.Operations ?? [];
     }
 
-    async getStoredBootnodeUrl() {
-        const config = await this.getBootnodeConfig();
+    /**
+     * The configured archive URL for `address`, or undefined.
+     *
+     * Unlike getBootnodeConfig this tolerates a missing address, for the admin
+     * page, which probes for an endpoint before any wallet is connected. With no
+     * account to scope to it reads the pre-scoping global value; nothing writes
+     * that key any more, so the fallback only ever sees data from before this
+     * change and can go when the admin page opens an account first.
+     */
+    async getStoredBootnodeUrl(address) {
+        const config = address
+            ? await this.getBootnodeConfig(address)
+            : await this.#getUnscopedBootnodeConfig();
         if (config?.enabled && config.url) {
             return config.url;
         }
         return undefined;
+    }
+
+    async #getUnscopedBootnodeConfig() {
+        const response = await this.#call({ GetSetting: SETTING_BOOTNODE_CONFIG });
+        const raw = response.Setting;
+        if (raw == null) return null;
+        return JSON.parse(raw);
     }
 }

--- a/app/js/ui/navigation.js
+++ b/app/js/ui/navigation.js
@@ -117,9 +117,12 @@ function setMoveFlow(flow) {
     });
 }
 
-async function bootnodeCheck(rpcUrl) {
+async function bootnodeCheck(rpcUrl, address) {
     const storage = await ensureStorage();
-    const stored = await storage.getStoredBootnodeUrl();
+    // The archive endpoint is account-scoped. Passed explicitly rather
+    // than read from App.state here, so the caller is forced to have an
+    // account in hand before this can ask for one account's bootnode.
+    const stored = await storage.getStoredBootnodeUrl(address);
     const required = await bootnodeRequired(rpcUrl);
 
     if (required && !stored) {
@@ -131,7 +134,7 @@ async function bootnodeCheck(rpcUrl) {
         if (!modal.accepted || !modal.url) {
             throw new Error('RPC_SYNC_GAP: bootnode required');
         }
-        await storage.setBootnodeConfig(modal.url);
+        await storage.setBootnodeConfig(modal.url, address);
     }
 
     return { bootnodeRequired: required };
@@ -157,10 +160,13 @@ async function loadRuntimeState() {
     const explorerSetting = await storage.getExplorerSetting();
     App.state.settings.explorerBaseUrl = explorerSetting?.baseUrl || Utils.defaultExplorerBaseUrl;
 
-    const bootnodeSetting = await storage.getBootnodeConfig();
+    // Both are account-scoped, so they follow whichever account is live now
+    // rather than a value captured earlier in the connect sequence.
+    const settingsAddress = App.state.wallet.address;
+    const bootnodeSetting = await storage.getBootnodeConfig(settingsAddress);
     App.state.settings.bootnode = bootnodeSetting || { enabled: false, url: '' };
 
-    const telemetrySetting = await storage.getSetting('telemetry_config');
+    const telemetrySetting = await storage.getTelemetryConfig(settingsAddress);
     App.state.settings.telemetry = telemetrySetting || { level: 'info', revealSensitive: false };
     try {
         await configureTelemetrySettings({
@@ -435,8 +441,8 @@ export const Wallet = {
                 App.state.wallet.networkPassphrase = networkPassphrase;
                 renderWallet();
 
-                const { bootnodeRequired } = await bootnodeCheck(rpcUrl);
-                await initializeRuntime(rpcUrl);
+                const { bootnodeRequired } = await bootnodeCheck(rpcUrl, address);
+                await initializeRuntime(rpcUrl, { address });
                 await client().backgroundSync();
 
                 await runOnboardingWizard({
@@ -506,6 +512,17 @@ export const Wallet = {
             networkPassphrase: null,
         };
         App.state.keys = { notePublicKey: null, encryptionPublicKey: null };
+        // Cleared, not just re-read on the next connect: the settings drawer
+        // is reachable while connecting, so a stale value would be shown to the
+        // next account. `explorer` is global and stays.
+        App.state.settings.bootnode = { enabled: false, url: '' };
+        App.state.settings.telemetry = { level: 'info', revealSensitive: false };
+        // revealSensitive is a process-global inside the wasm, not part of the
+        // client this teardown disposes, so it would stay armed for the next
+        // account. Fire-and-forget: it must not reject the teardown.
+        void Promise.resolve(
+            configureTelemetrySettings({ level: 'info', revealSensitive: false }),
+        ).catch((e) => console.warn('[Wallet] failed to reset telemetry posture:', e));
         document.body.dataset.walletState = 'disconnected';
         renderWallet();
         this.closeSettings();
@@ -539,12 +556,18 @@ export const Wallet = {
             const revealSensitive = debugSupported && !!document.getElementById('settings-reveal-sensitive')?.checked;
 
             const storage = client().storage();
+            // `explorer` is global; bootnode and telemetry are written
+            // under the account currently in front of the user.
+            const settingsAddress = App.state.wallet.address;
+            if (!settingsAddress) {
+                throw new Error('Connect a wallet before saving account settings.');
+            }
             await storage.setSetting('explorer', { baseUrl: explorerBaseUrl });
             await storage.setSetting('bootnode_config', {
                 enabled: !!bootnodeEnabled,
                 url: bootnodeEnabled ? bootnodeUrl : '',
-            });
-            await storage.setSetting('telemetry_config', { level: logLevel, revealSensitive });
+            }, settingsAddress);
+            await storage.setTelemetryConfig({ level: logLevel, revealSensitive }, settingsAddress);
 
             App.state.settings.explorerBaseUrl = explorerBaseUrl;
             App.state.settings.bootnode = { enabled: !!bootnodeEnabled, url: bootnodeEnabled ? bootnodeUrl : '' };

--- a/app/js/ui/onboarding-wizard.js
+++ b/app/js/ui/onboarding-wizard.js
@@ -277,7 +277,9 @@ export async function runOnboardingWizard({
     const storedPublicKeys = await storage.getUserPublicKeys(address).catch(() => null);
     const keysExist = !!storedPublicKeys?.noteKeypair?.public;
     const explorerSetting = await storage.getExplorerSetting();
-    const bootnodeSetting = await storage.getBootnodeConfig();
+    // Scoped to the address this wizard is running for, so the bootnode shown
+    // is the one belonging to the account being onboarded.
+    const bootnodeSetting = await storage.getBootnodeConfig(address);
     const registryLookup = await client().recipientLookup(address).catch(() => null);
 
     const storageAvailable = hasStorageManager();
@@ -286,9 +288,16 @@ export async function runOnboardingWizard({
     const needsStorageStep = storageAvailable && (!persisted || !storagePrompted);
     const needsNotificationStep = notificationStepNeeded();
 
+    // A missing bootnode record does not mean the user was never asked: the
+    // record is per-account, so an already-onboarded account simply has none.
+    // Gate on completed onboarding instead. A new account still gets the step,
+    // and a real sync gap still forces it via bootnodeRequired.
+    const hasCompletedOnboarding = !!disclaimerState?.accepted && keysExist;
+    const retentionNeverAsked = !bootnodeSetting && !hasCompletedOnboarding;
+
     const steps = [
         ...(!disclaimerState?.accepted ? ['disclaimer'] : []),
-        ...(needsNotificationStep || !bootnodeSetting || bootnodeRequired ? ['retention'] : []),
+        ...(needsNotificationStep || retentionNeverAsked || bootnodeRequired ? ['retention'] : []),
         ...(needsStorageStep ? ['storage'] : []),
         ...(!keysExist ? ['keys'] : []),
         [explorerSetting?.baseUrl ? null : 'explorer'].filter(Boolean),
@@ -583,7 +592,7 @@ export async function runOnboardingWizard({
                             if (enableNotifications && Notification.permission === 'default') {
                                 await requestNotificationPermission();
                             }
-                            await storage.setSetting('bootnode_config', { enabled, url });
+                            await storage.setSetting('bootnode_config', { enabled, url }, address);
                             state.bootnode = { enabled, url };
                             if (enableNotifications) {
                                 setNotificationsPrompted();

--- a/app/js/wasm-facade.js
+++ b/app/js/wasm-facade.js
@@ -192,9 +192,10 @@ export async function bootnodeRequired(rpcUrl) {
  * Prefer resolving bootnode (via {@link bootnodeRequired} + settings/modal)
  * before this so the Client is built once with the right URL.
  * @param {string} rpcUrl
- * @param {{ bootnodeUrl?: string|null }} [options]
+ * @param {{ bootnodeUrl?: string|null, address?: string|null }} [options] -
+ *   `address` scopes the stored-bootnode fallback; without it none is resolved.
  */
-export async function initializeRuntime(rpcUrl, { bootnodeUrl } = {}) {
+export async function initializeRuntime(rpcUrl, { bootnodeUrl, address } = {}) {
     await ensureStorage();
 
     if (currentRpcUrl !== rpcUrl) {
@@ -205,7 +206,10 @@ export async function initializeRuntime(rpcUrl, { bootnodeUrl } = {}) {
 
     let resolvedBootnode = bootnodeUrl;
     if (resolvedBootnode === undefined && appStorageInstance) {
-        resolvedBootnode = await appStorageInstance.getStoredBootnodeUrl();
+        // The stored bootnode is account-scoped. Without an address there
+        // is no account whose endpoint this could be, so the fallback yields
+        // undefined rather than reaching for whatever was stored globally.
+        resolvedBootnode = await appStorageInstance.getStoredBootnodeUrl(address);
     }
 
     if (

--- a/e2e-freighter/tests/unit/settings-scope.test.mjs
+++ b/e2e-freighter/tests/unit/settings-scope.test.mjs
@@ -1,0 +1,110 @@
+// Coverage for the setting-scoping rule.
+//
+// app-storage.js is import-free apart from its own constants, so unlike
+// navigation.js or the wizard it loads directly under `node --test` and the
+// rule can be asserted behaviourally rather than by reading source.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    ACCOUNT_SCOPED_SETTINGS,
+    SETTING_BOOTNODE_CONFIG,
+    SETTING_EXPLORER,
+    SETTING_TELEMETRY_CONFIG,
+    settingKey,
+} from '../../../app/js/app-storage.js';
+
+const ADDR_A = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const ADDR_B = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+test('the archive endpoint and logging posture are account-scoped', () => {
+    // A bootnode operator observes which account
+    // is syncing, and revealSensitive un-redacts that account's Tier-1 values.
+    assert.ok(ACCOUNT_SCOPED_SETTINGS.has(SETTING_BOOTNODE_CONFIG));
+    assert.ok(ACCOUNT_SCOPED_SETTINGS.has(SETTING_TELEMETRY_CONFIG));
+});
+
+test('the block explorer stays global', () => {
+    // Public infrastructure, identical for every account, reveals nothing about
+    // who is signed in. Scoping it would cost the user a re-entry per account
+    // and buy nothing.
+    assert.ok(!ACCOUNT_SCOPED_SETTINGS.has(SETTING_EXPLORER));
+    assert.equal(settingKey(SETTING_EXPLORER, ADDR_A), SETTING_EXPLORER);
+    assert.equal(
+        settingKey(SETTING_EXPLORER, ADDR_A),
+        settingKey(SETTING_EXPLORER, ADDR_B),
+        'a global setting must resolve to one key regardless of the account',
+    );
+});
+
+test('two accounts never share a scoped key', () => {
+    // The defect, stated directly: account B must not read account A's value.
+    for (const key of ACCOUNT_SCOPED_SETTINGS) {
+        assert.notEqual(settingKey(key, ADDR_A), settingKey(key, ADDR_B), key);
+        assert.ok(settingKey(key, ADDR_A).includes(ADDR_A));
+    }
+});
+
+test('a scoped read without an account is refused, not silently unscoped', () => {
+    // Falling back to the bare key is precisely how account B inherited
+    // account A's archive endpoint, so an absent address must throw rather
+    // than quietly resolve to the shared key.
+    for (const key of ACCOUNT_SCOPED_SETTINGS) {
+        for (const missing of [undefined, null, '']) {
+            assert.throws(
+                () => settingKey(key, missing),
+                /account-scoped and requires an address/,
+                `${key} with address=${JSON.stringify(missing)}`,
+            );
+        }
+    }
+});
+
+test('the legacy unscoped key is never produced for a scoped setting', () => {
+    // A value written before this change belonged to whichever account was
+    // active then. Adopting it for a different account would reproduce the
+    // defect during the one upgrade the user is least likely to inspect.
+    for (const key of ACCOUNT_SCOPED_SETTINGS) {
+        assert.notEqual(settingKey(key, ADDR_A), key);
+    }
+});
+
+test('scoped keys are stable for the same account', () => {
+    assert.equal(settingKey(SETTING_BOOTNODE_CONFIG, ADDR_A), settingKey(SETTING_BOOTNODE_CONFIG, ADDR_A));
+});
+
+// The accountless fallback is the one deliberate asymmetry in the scoping
+// rule, and nothing above pins it.
+import { AppStorage } from '../../../app/js/app-storage.js';
+
+function fakeStorage(rows) {
+    const asked = [];
+    return {
+        asked,
+        async call(request) {
+            const key = request.GetSetting;
+            asked.push(key);
+            const value = rows[key];
+            return { Setting: value === undefined ? null : JSON.stringify(value) };
+        },
+    };
+}
+
+const LEGACY = { enabled: true, url: 'https://legacy.example' };
+
+test('an accountless read falls back to the pre-scoping global value', async () => {
+    // The admin page probes for an endpoint before any wallet is connected.
+    const storage = fakeStorage({ [SETTING_BOOTNODE_CONFIG]: LEGACY });
+    const app = new AppStorage(storage);
+    assert.equal(await app.getStoredBootnodeUrl(), LEGACY.url);
+    assert.deepEqual(storage.asked, [SETTING_BOOTNODE_CONFIG]);
+});
+
+test('an account with no record of its own does not inherit the global value', async () => {
+    // The fallback is for callers holding no account at all. An account that
+    // simply has not configured an endpoint must not adopt the legacy one.
+    const storage = fakeStorage({ [SETTING_BOOTNODE_CONFIG]: LEGACY });
+    const app = new AppStorage(storage);
+    assert.equal(await app.getStoredBootnodeUrl(ADDR_A), undefined);
+    assert.deepEqual(storage.asked, [settingKey(SETTING_BOOTNODE_CONFIG, ADDR_A)]);
+});


### PR DESCRIPTION
`app/js/app-storage.js` stored two settings under one key each, shared by every
account on the profile:

- `bootnode_config` — the archive endpoint used to backfill history the main RPC
  can no longer serve. Connecting a second account sent its historical sync to
  whichever endpoint the first account had chosen, without asking.
- `telemetry_config` — the log level and `revealSensitive`, which un-redacts
  amounts and addresses in the telemetry ring buffer and in UI toasts. A second
  account started with the first account's posture already armed.

`explorer` was stored the same way, but it is public infrastructure and
identical for everyone.

## Change

`settingKey(key, address)` namespaces an account-scoped setting as
`key::address`, and throws if the address is missing rather than resolving to
the bare key — the silent fallback is how the inheritance happened.
`ACCOUNT_SCOPED_SETTINGS` holds the two; `explorer` is not in it and resolves to
one key for every account.

`getSetting`/`setSetting` take the address and route through it.
`getBootnodeConfig`/`setBootnodeConfig` require one, and
`getTelemetryConfig`/`setTelemetryConfig` are added alongside them. Every call
site passes the account it is acting for: `bootnodeCheck` and the connect
sequence in `app/js/ui/navigation.js`, the wizard's plan and its retention write
in `app/js/ui/onboarding-wizard.js`, and `initializeRuntime` in
`app/js/wasm-facade.js`, which resolves the stored endpoint when the caller does
not pass one explicitly.

`Wallet.disconnect()` clears the two settings from `App.state` instead of
leaving them for the next connect to overwrite — the settings drawer is
reachable while connecting, so a stale value is visible to the next account. It
also resets the telemetry posture in the wasm, which is a process global rather
than part of the disposed client and would otherwise stay armed. `saveSettings`
refuses to write without a connected account.

Legacy unscoped values are not migrated: they belonged to whichever account was
active when they were written, and adopting them for a different account is the
defect. One caller has no account to scope to — `app/js/admin.js` probes for an
endpoint from `init()`, before any wallet is connected — so
`getStoredBootnodeUrl` reads the unscoped key when given no address. Nothing
writes that key any more, so the fallback only ever sees data from before this
change, and an account that simply has no endpoint of its own does not reach it.

The wizard showed the retention step whenever no `bootnode_config` record
existed. Per-account, an already-onboarded account has no such record and never
will, so the step would return on every connect. It is now shown when the
account has not completed onboarding (disclaimer accepted and keys derived); a
genuine sync gap still forces it through `bootnodeRequired`, which is where an
existing account is asked again at the point the endpoint is actually needed.

`e2e-freighter/tests/unit/settings-scope.test.mjs` pins the rule: both settings
scoped and `explorer` not, two accounts never sharing a scoped key, a scoped
read without an address throwing rather than silently unscoping, the bare key
never produced for a scoped setting, and the accountless fallback reading the
old value while a scoped read does not.