### PR TITLE
Wrap the account address in the missing-keys errors

### DIFF
--- a/sdk/native/src/storage/mod.rs
+++ b/sdk/native/src/storage/mod.rs
@@ -40,8 +40,10 @@ pub(crate) fn map_user_keys(
         .get_user_keys(user_address)
         .map_err(|e| Error::Other(e.to_string()))?
         .ok_or_else(|| {
+            // Escapes to CLI output and logs.
             Error::Other(format!(
-                "address {user_address} should generate privacy keys and ASP secret first"
+                "address {} should generate privacy keys and ASP secret first",
+                crate::types::Sensitive(user_address)
             ))
         })
 }
@@ -211,4 +213,28 @@ pub trait Storage: crate::chain::ContractDataStorage {
         pool_contract_id: &str,
         commitments: &[Field],
     ) -> Result<HashSet<Field>, Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_user_keys;
+    use crate::{
+        state::SqliteStorage,
+        types::{lock_reveal_flag, set_reveal_sensitive},
+    };
+
+    const ADDRESS: &str = "GTESTACCOUNTWITHNOSTOREDKEYS";
+
+    #[test]
+    fn missing_user_keys_error_redacts_the_address() {
+        let _guard = lock_reveal_flag();
+        set_reveal_sensitive(false);
+        let storage = SqliteStorage::connect_in_memory().expect("in-memory storage");
+
+        let err = map_user_keys(&storage, ADDRESS).expect_err("no keys are stored");
+        let rendered = err.to_string();
+
+        assert!(!rendered.contains(ADDRESS), "address leaked: {rendered}");
+        assert!(rendered.contains("<redacted>"), "not redacted: {rendered}");
+    }
 }

--- a/sdk/native/src/transact.rs
+++ b/sdk/native/src/transact.rs
@@ -215,7 +215,11 @@ pub(crate) fn load_user_key_material(
         },
         membership_blinding,
     } = storage.get_user_keys(user_address)?.ok_or_else(|| {
-        anyhow::anyhow!("address {user_address} should generate privacy keys and ASP secret first")
+        // Escapes to a UI toast and the telemetry ring buffer.
+        anyhow::anyhow!(
+            "address {} should generate privacy keys and ASP secret first",
+            crate::types::Sensitive(user_address)
+        )
     })?;
 
     Ok((private, note_pub, enc_pub, membership_blinding))
@@ -348,4 +352,28 @@ fn build_pool_input_note(
         merkle_path_elements: path_elements,
         merkle_path_indices: path_indices,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::load_user_key_material;
+    use crate::{
+        state::SqliteStorage,
+        types::{lock_reveal_flag, set_reveal_sensitive},
+    };
+
+    const ADDRESS: &str = "GTESTACCOUNTWITHNOSTOREDKEYS";
+
+    #[test]
+    fn missing_user_keys_error_redacts_the_address() {
+        let _guard = lock_reveal_flag();
+        set_reveal_sensitive(false);
+        let storage = SqliteStorage::connect_in_memory().expect("in-memory storage");
+
+        let err = load_user_key_material(&storage, ADDRESS).expect_err("no keys are stored");
+        let rendered = format!("{err:#}");
+
+        assert!(!rendered.contains(ADDRESS), "address leaked: {rendered}");
+        assert!(rendered.contains("<redacted>"), "not redacted: {rendered}");
+    }
 }

--- a/sdk/native/src/types/amounts.rs
+++ b/sdk/native/src/types/amounts.rs
@@ -118,8 +118,13 @@ impl TryFrom<ExtAmount> for NoteAmount {
     type Error = anyhow::Error;
 
     fn try_from(value: ExtAmount) -> Result<Self> {
-        let v =
-            u128::try_from(value.0).map_err(|_| anyhow!("NoteAmount out of range: {}", value.0))?;
+        let v = u128::try_from(value.0).map_err(|_| {
+            // Escapes to a UI toast and the telemetry ring buffer.
+            anyhow!(
+                "NoteAmount out of range: {}",
+                crate::types::Sensitive(value.0)
+            )
+        })?;
         Ok(NoteAmount(v))
     }
 }
@@ -595,6 +600,18 @@ mod tests {
         assert_eq!(max.checked_add(NoteAmount(1)), None);
         assert_eq!(z.checked_sub(NoteAmount(1)), None);
         Ok(())
+    }
+
+    #[test]
+    fn note_amount_out_of_range_error_redacts_the_amount() {
+        let _guard = crate::types::lock_reveal_flag();
+        crate::types::set_reveal_sensitive(false);
+
+        let err = NoteAmount::try_from(ExtAmount(-4242)).expect_err("negative is out of range");
+        let rendered = format!("{err:#}");
+
+        assert!(!rendered.contains("4242"), "amount leaked: {rendered}");
+        assert!(rendered.contains("<redacted>"), "not redacted: {rendered}");
     }
 
     #[test]

--- a/sdk/native/src/types/logging.rs
+++ b/sdk/native/src/types/logging.rs
@@ -153,19 +153,30 @@ impl<T: zeroize::Zeroize> zeroize::Zeroize for Secret<T> {
     }
 }
 
+/// Serializes tests that read or write the process-global `REVEAL_SENSITIVE`
+/// flag; unit tests share one process.
+#[cfg(test)]
+static REVEAL_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Acquires the reveal-flag lock, ignoring poisoning: every caller sets the
+/// flag it needs, so a panicking test leaves no invariant for the next to
+/// repair, and cascading poison errors would hide the real failure.
+#[cfg(test)]
+pub(crate) fn lock_reveal_flag() -> std::sync::MutexGuard<'static, ()> {
+    REVEAL_TEST_MUTEX
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::types::{EncryptionPrivateKey, KeyDerivationSignature, NotePrivateKey};
-    use std::sync::Mutex;
     use zeroize::Zeroize;
-
-    /// Serializes tests that touch the process-global `REVEAL_SENSITIVE` flag.
-    static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_tier1_sensitive_redaction() {
-        let _guard = TEST_MUTEX.lock().expect("test mutex poisoned");
+        let _guard = lock_reveal_flag();
         let val = Sensitive::new("sensitive_data".to_string());
 
         // By default, reveal_sensitive should be false
@@ -190,7 +201,7 @@ mod tests {
 
     #[test]
     fn test_tier0_secret_redaction() {
-        let _guard = TEST_MUTEX.lock().expect("test mutex poisoned");
+        let _guard = lock_reveal_flag();
         let secret_bytes = Secret::new([42u8; 32]);
         let secret_str = Secret::new("very_secret_key".to_string());
 
@@ -206,7 +217,7 @@ mod tests {
 
     #[test]
     fn test_key_types_redaction() {
-        let _guard = TEST_MUTEX.lock().expect("test mutex poisoned");
+        let _guard = lock_reveal_flag();
         let enc_key = EncryptionPrivateKey([1u8; 32]);
         let note_key = NotePrivateKey([2u8; 32]);
         let signature = KeyDerivationSignature(vec![3u8; 10]);
@@ -232,7 +243,7 @@ mod tests {
 
     #[test]
     fn test_telemetry_config_gating() {
-        let _guard = TEST_MUTEX.lock().expect("test mutex poisoned");
+        let _guard = lock_reveal_flag();
         let config_reveal = TelemetryConfig {
             level: "debug".to_string(),
             sink: TelemetrySink::Console,


### PR DESCRIPTION
`Sensitive` wraps addresses and amounts at every logging site in `sdk/native`.
Three error constructors were the exception:

- `sdk/native/src/transact.rs:218` — prints the account address when no privacy
  keys are stored. Runs in the browser storage worker, so it reaches a UI toast
  and the telemetry ring buffer.
- `sdk/native/src/types/amounts.rs:122` — prints the amount on an out-of-range
  conversion, reaching the same two sinks.
- `sdk/native/src/storage/mod.rs:42` — a byte-identical copy of the missing-keys
  message for the `LocalStorage` path, reaching CLI output and logs.

## Change

All three are wrapped in `Sensitive`, so the value renders as `<redacted>` unless
the reveal flag is set in a debug build. The CLI operator already knows which
address failed — these commands take one account from config and print it — and
the flag restores the value when debugging.

`REVEAL_SENSITIVE` is a process global, so a redaction assertion in any module
races the tests in `types/logging.rs` that toggle it. The mutex serialising those
tests moves beside the flag as `lock_reveal_flag()` and is shared. It ignores
poisoning: each caller sets the flag it needs, and a cascading poison error would
hide the real failure. All `#[cfg(test)]`, so nothing ships.

One test per site asserts against the rendered error string that the raw value is
absent and `<redacted>` is present.