### PR TITLE
Require both account identities at session open and refuse a divergent pair

### DIFF
--- a/app/ARCHITECTURE.md
+++ b/app/ARCHITECTURE.md
@@ -25,7 +25,7 @@ The web SDK runs Rust on the main thread via WASM, with blocking work offloaded 
 ### Lifecycle
 
 ```
-init() → Storage.open() → bootnodeRequired() → Client.new() → backgroundSync() → client.account(signer) → account.pool() → PrivatePool ops
+init() → Storage.open() → bootnodeRequired() → Client.new() → backgroundSync() → client.account(options, signer) → account.pool() → PrivatePool ops
 ```
 
 The app wraps this in `wasm-facade.js` and `ui/pool.js`: `bootnodeRequired` → `initializeRuntime` → `client().backgroundSync` → `client().openAccount` → `account().pool()` via `createAppPool()` / `ensureAppPool()`.

--- a/cli/src/session.rs
+++ b/cli/src/session.rs
@@ -9,7 +9,10 @@ use anyhow::Result;
 use stellar_private_payments::{
     Handle, LocalProver, LocalStorage, Prover, Signer,
     blocking::{Account as SdkAccount, Client, PrivatePool},
-    types::{EncryptionPublicKey, NoteAmount, NotePublicKey, TransferRecipient},
+    types::{
+        EncryptionPublicKey, NoteAmount, NoteOwnerAddress, NotePublicKey, SignerAddress,
+        TransferRecipient,
+    },
 };
 
 /// SDK `Client` → `Account` session; open pools via [`Self::pool`].
@@ -62,7 +65,8 @@ impl ClientSession {
         };
         let sdk_account = client
             .account(
-                account.address.as_str(),
+                NoteOwnerAddress::new(account.address.as_str()),
+                SignerAddress::new(account.address.as_str()),
                 alias_signer(config, account, network),
             )
             .map_err(|e| anyhow::anyhow!("open account session: {e}"))?;
@@ -81,7 +85,8 @@ impl ClientSession {
         let client = disclosure_client(config, network)?;
         let sdk_account = client
             .account(
-                account.address.as_str(),
+                NoteOwnerAddress::new(account.address.as_str()),
+                SignerAddress::new(account.address.as_str()),
                 alias_signer(config, account, network),
             )
             .map_err(|e| anyhow::anyhow!("open account session: {e}"))?;

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -25,7 +25,7 @@ The web SDK runs Rust on the main thread via WASM, with blocking work offloaded 
 ### Lifecycle
 
 ```
-init() → Storage.open() → bootnodeRequired() → Client.new() → backgroundSync() → client.account(signer) → account.pool() → PrivatePool ops
+init() → Storage.open() → bootnodeRequired() → Client.new() → backgroundSync() → client.account(options, signer) → account.pool() → PrivatePool ops
 ```
 
 The app wraps this in `wasm-facade.js` and `ui/pool.js`: `bootnodeRequired` → `initializeRuntime` → `client().backgroundSync` → `client().openAccount` → `account().pool()` via `createAppPool()` / `ensureAppPool()`.

--- a/sdk/native/README.md
+++ b/sdk/native/README.md
@@ -6,7 +6,7 @@ Native Rust client for privacy pool deposits, transfers, withdrawals, and local 
 
 ```
 Client (deployment: sync, operational_feed, recipient_lookup)
-  └─ account(signer) → Account (portfolio, user_notes, user_public_keys, is_registered, register_public_keys, sync, pool)
+  └─ account(user_address, signer_address, signer) → Account (portfolio, user_notes, user_public_keys, is_registered, register_public_keys, sync, pool)
        └─ pool(id) → PrivatePool (deposit / transfer / withdraw / balance / notes)
 ```
 
@@ -19,7 +19,7 @@ Client (deployment: sync, operational_feed, recipient_lookup)
 ```rust
 use stellar_private_payments::{
     CircuitStore, Client, Handle, LocalProver, LocalSigner, LocalStorage, Prover,
-    types::ContractConfig,
+    types::{ContractConfig, NoteOwnerAddress, SignerAddress},
 };
 
 let deployment: ContractConfig = /* load from deployments/ */;
@@ -45,7 +45,12 @@ let signer = Handle::from_box(
         as Box<dyn stellar_private_payments::Signer>,
 );
 
-let account = client.account("G...", signer)?;
+// Note owner first, then the signing account.
+let account = client.account(
+    NoteOwnerAddress::new("G..."),
+    SignerAddress::new("G..."),
+    signer,
+)?;
 let pool = account.pool("C...")?;
 
 pool.deposit(10_000_000u128.into()).await?;
@@ -147,9 +152,14 @@ For CLI and synchronous hosts, use `stellar_private_payments::blocking`:
 
 ```rust
 use stellar_private_payments::blocking::{Client, Account};
+use stellar_private_payments::types::{NoteOwnerAddress, SignerAddress};
 
 let client = Client::init(rpc_url, storage, prover, deployment, None)?;
-let account = client.account("G...", signer)?;
+let account = client.account(
+    NoteOwnerAddress::new("G..."),
+    SignerAddress::new("G..."),
+    signer,
+)?;
 let portfolio = account.portfolio()?;
 ```
 

--- a/sdk/native/examples/SETUP.md
+++ b/sdk/native/examples/SETUP.md
@@ -221,8 +221,8 @@ pool admin must insert that wallet's ASP membership leaf into the
    Run it with `cargo run --release --example <name>`, once per wallet with that
    wallet's `SPP_WALLET_PATH` and `STELLAR_SECRET_KEY` exported, then delete the
    file. Note there is no `Client::account_for_secret`; an account session is
-   opened with `Client::account(&address, signer)`, which is what
-   `common::build_account` wraps.
+   opened with `Client::account(user_address, signer_address, signer)`, which
+   is what `common::build_account` wraps.
 
 3. As the pool admin, invoke `insert_leaf` once per participant:
 

--- a/sdk/native/examples/common/mod.rs
+++ b/sdk/native/examples/common/mod.rs
@@ -35,7 +35,10 @@ use stellar_private_payments::{
     CircuitStore, Handle, LocalProver, LocalSigner, LocalStorage, Prover, Signer,
     blocking::{Account, Client, PrivatePool},
     chain::LocalSigner as StellarSigner,
-    types::{AssetDescriptor, ContractConfig, NoteAmount, PoolConfigEntry, ProverArtifacts},
+    types::{
+        AssetDescriptor, ContractConfig, NoteAmount, NoteOwnerAddress, PoolConfigEntry,
+        ProverArtifacts, SignerAddress,
+    },
 };
 
 /// Initialize a `tracing_subscriber` formatter driven by `RUST_LOG`.
@@ -226,7 +229,11 @@ pub fn build_account(client: &Client) -> Result<Account, String> {
     })?;
     let signer = build_signer(&secret, &passphrase, &user_address)?;
     client
-        .account(user_address.as_str(), signer)
+        .account(
+            NoteOwnerAddress::new(user_address.as_str()),
+            SignerAddress::new(user_address.as_str()),
+            signer,
+        )
         .map_err(|e| format!("open account session: {e}"))
 }
 

--- a/sdk/native/src/blocking/client.rs
+++ b/sdk/native/src/blocking/client.rs
@@ -1,6 +1,8 @@
 //! Sync wrapper around [`crate::Client`] via a shared Tokio runtime.
 
-use crate::types::{ContractConfig, NoteOwnerAddress, OperationalFeedItem, RecipientLookup};
+use crate::types::{
+    ContractConfig, NoteOwnerAddress, OperationalFeedItem, RecipientLookup, SignerAddress,
+};
 
 use crate::{
     BackgroundSync, Error, Handle, Prover, Signer, chain::StateFetcher,
@@ -70,14 +72,19 @@ impl Client {
         block_on(self.inner.recipient_lookup(address))
     }
 
+    /// Blocking mirror of [`crate::Client::account`]; the same
+    /// owner-must-equal-signer rule applies.
     pub fn account(
         &self,
-        user_address: impl Into<NoteOwnerAddress>,
+        user_address: NoteOwnerAddress,
+        signer_address: SignerAddress,
         signer: Handle<dyn Signer>,
     ) -> Result<Account, Error> {
-        Ok(Account::from_inner(
-            self.inner.account(user_address, signer)?,
-        ))
+        Ok(Account::from_inner(self.inner.account(
+            user_address,
+            signer_address,
+            signer,
+        )?))
     }
 
     pub fn state_fetcher(&self) -> Result<StateFetcher, Error> {

--- a/sdk/native/src/client.rs
+++ b/sdk/native/src/client.rs
@@ -136,6 +136,11 @@ impl<S: Storage> Client<S> {
     }
 
     /// Create an [`Account`] session.
+    ///
+    /// # Errors
+    /// Returns [`Error::SignerIsNotNoteOwner`] if `signer_address` is not the
+    /// same account as `user_address`, or a storage error if the session's
+    /// storage handle cannot be forked.
     #[tracing::instrument(
         name = "client_account",
         skip_all,
@@ -143,13 +148,11 @@ impl<S: Storage> Client<S> {
     )]
     pub fn account(
         &self,
-        user_address: impl Into<NoteOwnerAddress>,
+        user_address: NoteOwnerAddress,
+        signer_address: SignerAddress,
         signer: Handle<dyn Signer>,
     ) -> Result<Account<S>, Error> {
-        let user_address = user_address.into();
-        // The signing account is the note owner until a caller can choose
-        // otherwise.
-        let signer_address = SignerAddress::new(user_address.as_str());
+        ensure_signer_is_note_owner(&user_address, &signer_address)?;
         Ok(Account::new(
             self.rpc.clone(),
             self.storage.fork()?,
@@ -172,5 +175,136 @@ impl<S: Storage> Client<S> {
         self.sync
             .ensure_synced(&self.rpc, &self.storage, &self.contract_config)
             .await
+    }
+}
+
+/// Reject a session whose signing account is not the note owner. See
+/// [`Error::SignerIsNotNoteOwner`] for why the two may not differ.
+fn ensure_signer_is_note_owner(
+    user_address: &NoteOwnerAddress,
+    signer_address: &SignerAddress,
+) -> Result<(), Error> {
+    if signer_address.as_str() == user_address.as_str() {
+        return Ok(());
+    }
+    Err(Error::SignerIsNotNoteOwner {
+        owner: user_address.as_str().to_string(),
+        signer: signer_address.as_str().to_string(),
+    })
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod signer_is_note_owner_tests {
+    use super::*;
+    use crate::{LocalSigner, LocalStorage};
+
+    const OWNER: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+    const DELEGATE: &str = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB6BQ";
+    /// Ed25519 secret for `SigningKey::from_bytes(&[7u8; 32])`.
+    const SECRET: &str = "SADQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQP54X";
+    const PASSPHRASE: &str = "Test SDF Network ; September 2015";
+
+    #[test]
+    fn the_owner_signing_for_itself_is_accepted() {
+        let result =
+            ensure_signer_is_note_owner(&NoteOwnerAddress::new(OWNER), &SignerAddress::new(OWNER));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn a_delegate_signing_for_the_owner_is_refused() {
+        let error = ensure_signer_is_note_owner(
+            &NoteOwnerAddress::new(OWNER),
+            &SignerAddress::new(DELEGATE),
+        )
+        .expect_err("a signer that is not the note owner must not open a session");
+
+        match &error {
+            Error::SignerIsNotNoteOwner { owner, signer } => {
+                assert_eq!(owner, OWNER);
+                assert_eq!(signer, DELEGATE);
+            }
+            other => panic!("expected SignerIsNotNoteOwner, got {other:?}"),
+        }
+
+        // Both addresses stay available to code; the rendered string redacts
+        // them. Not asserted here: the reveal flag is a process global that
+        // logging.rs's own tests toggle under a mutex this module cannot reach.
+    }
+
+    #[test]
+    fn the_comparison_is_exact() {
+        // Strkeys are canonical; near-misses are different accounts.
+        let owner = NoteOwnerAddress::new(OWNER);
+        for near_miss in [
+            OWNER.to_ascii_lowercase(),
+            format!(" {OWNER}"),
+            String::new(),
+        ] {
+            assert!(
+                ensure_signer_is_note_owner(&owner, &SignerAddress::new(near_miss.as_str()))
+                    .is_err(),
+                "near-miss signer {near_miss:?} must be refused"
+            );
+        }
+    }
+
+    fn test_client() -> Client<LocalStorage> {
+        static RUN: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let db = std::env::temp_dir().join(format!(
+            "spp-signer-owner-{}-{}.sqlite",
+            std::process::id(),
+            RUN.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_file(&db);
+        Client::init_readonly(
+            "https://soroban-testnet.stellar.org",
+            LocalStorage::open(db.to_string_lossy().as_ref()).expect("open storage"),
+            ContractConfig {
+                network: PASSPHRASE.to_string(),
+                deployer: String::new(),
+                admin: String::new(),
+                asp_membership: String::new(),
+                asp_non_membership: String::new(),
+                verifiers: Default::default(),
+                public_key_registry: String::new(),
+                pools: Vec::new(),
+            },
+            None,
+        )
+        .expect("init client")
+    }
+
+    fn test_signer(address: &str) -> Handle<dyn Signer> {
+        Handle::from_box(Box::new(
+            LocalSigner::new(SECRET, PASSPHRASE, address).expect("build signer"),
+        ) as Box<dyn Signer>)
+    }
+
+    // Through the public API, so moving or dropping the guard fails here too.
+    #[test]
+    fn client_account_refuses_a_divergent_pair() {
+        let error = test_client()
+            .account(
+                NoteOwnerAddress::new(OWNER),
+                SignerAddress::new(DELEGATE),
+                test_signer(DELEGATE),
+            )
+            .err()
+            .expect("Client::account must refuse a signer that is not the note owner");
+        assert!(matches!(error, Error::SignerIsNotNoteOwner { .. }));
+    }
+
+    #[test]
+    fn client_account_opens_when_the_owner_signs_for_itself() {
+        let account = test_client()
+            .account(
+                NoteOwnerAddress::new(OWNER),
+                SignerAddress::new(OWNER),
+                test_signer(OWNER),
+            )
+            .expect("the owner signing for itself must open a session");
+        assert_eq!(account.user_address().as_str(), OWNER);
+        assert_eq!(account.signer_address().as_str(), OWNER);
     }
 }

--- a/sdk/native/src/error.rs
+++ b/sdk/native/src/error.rs
@@ -29,6 +29,20 @@ pub enum Error {
     #[error("wallet request rejected by user: {0}")]
     UserRejected(String),
 
+    /// The signing account is not the note owner.
+    ///
+    /// The two transaction paths disagree on which identity drives them:
+    /// transact sources the envelope, `sender` and sequence number from the
+    /// signer, registration from the owner. Which is right when they differ is
+    /// unsettled, so a divergent pair is refused rather than resolved here.
+    // Escapes to a UI toast, the telemetry ring buffer and CLI logs.
+    #[error(
+        "signing account {} is not the note owner {}; a session where they differ is not supported",
+        crate::types::Sensitive(signer),
+        crate::types::Sensitive(owner)
+    )]
+    SignerIsNotNoteOwner { owner: String, signer: String },
+
     #[error("{0}")]
     Other(String),
 }

--- a/sdk/native/src/lib.rs
+++ b/sdk/native/src/lib.rs
@@ -7,7 +7,7 @@
 //! ```no_run
 //! use stellar_private_payments::{
 //!     CircuitStore, Client, Handle, LocalProver, LocalSigner, LocalStorage, Prover,
-//!     types::{CircuitStem, ContractConfig, PolicyFlags},
+//!     types::{CircuitStem, ContractConfig, NoteOwnerAddress, PolicyFlags, SignerAddress},
 //! };
 //!
 //! # async fn example(deployment: ContractConfig) -> Result<(), Box<dyn std::error::Error>> {
@@ -31,7 +31,12 @@
 //!     deployment,
 //!     None,
 //! )?;
-//! let account = client.account("G...", signer)?;
+//! // Note owner first, then the signing account.
+//! let account = client.account(
+//!     NoteOwnerAddress::new("G..."),
+//!     SignerAddress::new("G..."),
+//!     signer,
+//! )?;
 //! let pool = account.pool("CA2TZ...")?;
 //!
 //! pool.deposit(10_000_000u128.into()).await?;

--- a/sdk/native/src/types/address.rs
+++ b/sdk/native/src/types/address.rs
@@ -17,9 +17,26 @@ pub struct NoteOwnerAddress(String);
 /// number is read, the transaction envelope's source, and the address a
 /// wallet is asked to sign with. It has no relationship to any note.
 ///
-/// There is deliberately no conversion to or from [`NoteOwnerAddress`]: the
-/// compiler's refusal is what keeps each call site classified. A caller that
-/// wants both to be the same account constructs each from the same string.
+/// There is deliberately no conversion to or from [`NoteOwnerAddress`], and
+/// neither type is constructible from a bare string by `From`. A caller that
+/// wants both to be the same account names each type:
+///
+/// ```
+/// use stellar_private_payments::types::{NoteOwnerAddress, SignerAddress};
+///
+/// let owner = NoteOwnerAddress::new("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF");
+/// let signer = SignerAddress::new(owner.as_str());
+/// assert_eq!(owner.as_str(), signer.as_str());
+/// ```
+///
+/// Crossing without naming the destination does not compile:
+///
+/// ```compile_fail
+/// use stellar_private_payments::types::{NoteOwnerAddress, SignerAddress};
+///
+/// let owner = NoteOwnerAddress::new("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF");
+/// let signer: SignerAddress = owner.into_string().into();
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct SignerAddress(String);
 
@@ -55,17 +72,8 @@ macro_rules! address_newtype {
             }
         }
 
-        impl From<String> for $t {
-            fn from(address: String) -> Self {
-                Self(address)
-            }
-        }
-
-        impl From<&str> for $t {
-            fn from(address: &str) -> Self {
-                Self(address.to_string())
-            }
-        }
+        // No `From<String>`/`From<&str>`: they let an owner-derived value
+        // become a `SignerAddress` through an `.into()` naming neither type.
 
         impl AsRef<str> for $t {
             fn as_ref(&self) -> &str {
@@ -94,14 +102,45 @@ mod tests {
         assert!(NoteOwnerAddress::new("").is_empty());
     }
 
-    /// The two types are equal-valued but not interchangeable. This test
-    /// documents the intent; the guarantee is enforced by the absence of any
-    /// `From` impl between them, which a compile-fail test cannot express
-    /// without a trybuild dependency this workspace does not carry.
+    /// `EXISTS` is true iff `T: From<F>`: inherent associated items win over
+    /// trait ones, so it falls back to `NoConversion` when the bound fails.
+    struct ConversionProbe<F, T>(core::marker::PhantomData<(F, T)>);
+
+    trait NoConversion {
+        const EXISTS: bool = false;
+    }
+
+    impl<F, T> NoConversion for ConversionProbe<F, T> {}
+
+    impl<F, T: From<F>> ConversionProbe<F, T> {
+        const EXISTS: bool = true;
+    }
+
+    // `const _` rather than `#[test]`: resolved at type-check, so a reinstated
+    // impl fails to compile rather than reporting a test failure.
+    const _: () = assert!(
+        ConversionProbe::<&str, String>::EXISTS,
+        "probe is broken: it fails to see String: From<&str>"
+    );
+
+    const _: () = assert!(
+        !ConversionProbe::<NoteOwnerAddress, SignerAddress>::EXISTS,
+        "a note owner must not convert into a signing account"
+    );
+    const _: () = assert!(
+        !ConversionProbe::<SignerAddress, NoteOwnerAddress>::EXISTS,
+        "a signing account must not convert into a note owner"
+    );
+
+    const _: () = assert!(!ConversionProbe::<String, NoteOwnerAddress>::EXISTS);
+    const _: () = assert!(!ConversionProbe::<&str, NoteOwnerAddress>::EXISTS);
+    const _: () = assert!(!ConversionProbe::<String, SignerAddress>::EXISTS);
+    const _: () = assert!(!ConversionProbe::<&str, SignerAddress>::EXISTS);
+
     #[test]
-    fn same_string_yields_two_unrelated_values() {
+    fn crossing_deliberately_still_works_and_names_the_target_type() {
         let owner = NoteOwnerAddress::new(ADDR);
-        let signer = SignerAddress::new(ADDR);
+        let signer = SignerAddress::new(owner.as_str());
         assert_eq!(owner.as_str(), signer.as_str());
     }
 }

--- a/sdk/tests/src/pool.rs
+++ b/sdk/tests/src/pool.rs
@@ -8,7 +8,7 @@ use stellar_private_payments::{
     blocking::{Account, Client, PrivatePool},
     types::{
         CircuitStem, ContractConfig, EncryptionPublicKey, Field, GvkMode, NoteAmount,
-        NotePublicKey, PolicyFlags, TransferRecipient,
+        NoteOwnerAddress, NotePublicKey, PolicyFlags, SignerAddress, TransferRecipient,
     },
 };
 
@@ -94,7 +94,11 @@ fn test_client_and_account(wallet: Option<&[u64]>) -> Result<(Client, Account)> 
     {
         let _ = client.background_sync()?;
     }
-    let account = client.account(USER_ADDRESS, test_signer()?)?;
+    let account = client.account(
+        NoteOwnerAddress::new(USER_ADDRESS),
+        SignerAddress::new(USER_ADDRESS),
+        test_signer()?,
+    )?;
 
     Ok((client, account))
 }

--- a/sdk/web/js/types/api-types.d.ts
+++ b/sdk/web/js/types/api-types.d.ts
@@ -102,6 +102,10 @@ export interface ClientNewOptions {
 export interface AccountOptions {
   networkPassphrase: string;
   userAddress?: string;
+  /**
+   * Defaults to `userAddress`. A value differing from `userAddress` is refused
+   * before the wallet is prompted.
+   */
   signerAddress?: string;
 }
 

--- a/sdk/web/src/client/account.rs
+++ b/sdk/web/src/client/account.rs
@@ -38,8 +38,10 @@ impl Account {
         self.inner.user_address().to_string()
     }
 
-    /// The account that signs and pays. Equal to [`Self::user_address`] until
-    /// a caller supplies a different `signerAddress`.
+    /// The account that signs and pays. Always equal to
+    /// [`Self::user_address`]: a `signerAddress` that differs does not open a
+    /// session at all, so this never reports an address the rest of the stack
+    /// will not use.
     #[wasm_bindgen(getter, js_name = signerAddress)]
     pub fn signer_address(&self) -> String {
         self.inner.signer_address().to_string()

--- a/sdk/web/src/client/mod.rs
+++ b/sdk/web/src/client/mod.rs
@@ -16,8 +16,8 @@ use stellar_private_payments::{
     crypto::derive_asp_user_leaf as derive_asp_user_leaf_native,
     disclosure::verify_disclosure_receipt,
     types::{
-        ContractConfig, DisclosureReceipt, Field, KeyDerivationSignature, NotePublicKey,
-        SignerAddress,
+        ContractConfig, DisclosureReceipt, Field, KeyDerivationSignature, NoteOwnerAddress,
+        NotePublicKey, SignerAddress,
     },
 };
 use wasm_bindgen::prelude::*;
@@ -214,11 +214,13 @@ impl Client {
             let opts = AccountOptions::from_value(options)?;
             let user_address =
                 resolve_user_address(&signer, opts.user_address().map(str::to_string)).await?;
+            // Defaults to the note owner. The wallet signs with this account.
             let signer_address = SignerAddress::new(
                 opts.signer_address()
                     .map(str::to_string)
                     .unwrap_or_else(|| user_address.clone()),
             );
+            ensure_signer_is_note_owner(&user_address, &signer_address).map_err(pool_err)?;
             let wallet_signer = WalletSigner::new(
                 signer,
                 opts.network_passphrase().to_string(),
@@ -391,9 +393,14 @@ impl Client {
         wallet_signer: WalletSigner,
         user_address: String,
     ) -> Result<NativeAccount<StorageBridge>, JsError> {
+        // Read off the signer rather than AccountOptions: this is the address
+        // the wallet will actually be asked to sign with.
+        let signer_address = wallet_signer.signer_address().clone();
         let signer: Handle<dyn stellar_private_payments::Signer> =
             Handle::from_box(Box::new(wallet_signer) as Box<dyn stellar_private_payments::Signer>);
-        self.inner.account(user_address, signer).map_err(pool_err)
+        self.inner
+            .account(NoteOwnerAddress::new(user_address), signer_address, signer)
+            .map_err(pool_err)
     }
 
     async fn user_keys_exist(&self, address: &str) -> Result<bool, JsError> {
@@ -432,6 +439,26 @@ impl Client {
             .await
             .map_err(|e| JsError::new(&format!("storage worker error: {e}")))
     }
+}
+
+/// Refuse a session whose signing account is not the note owner.
+///
+/// The native client refuses the same pair, but only once the wallet has
+/// already been asked to sign the derivation message and the resulting keys
+/// have been filed under the owner. This runs first, so a rejected pair costs
+/// no signature request and writes nothing. It raises the native error rather
+/// than a parallel message, so the two cannot drift.
+fn ensure_signer_is_note_owner(
+    user_address: &str,
+    signer_address: &SignerAddress,
+) -> Result<(), Error> {
+    if signer_address.as_str() == user_address {
+        return Ok(());
+    }
+    Err(Error::SignerIsNotNoteOwner {
+        owner: user_address.to_string(),
+        signer: signer_address.as_str().to_string(),
+    })
 }
 
 async fn resolve_user_address(
@@ -473,4 +500,30 @@ async fn resolve_user_address(
     resolved
         .as_string()
         .ok_or_else(|| JsError::new("getPublicKey did not return a string"))
+}
+
+#[cfg(test)]
+mod signer_is_note_owner_tests {
+    use super::*;
+
+    const OWNER: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+    const DELEGATE: &str = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB6BQ";
+
+    #[test]
+    fn the_owner_signing_for_itself_is_accepted() {
+        assert!(ensure_signer_is_note_owner(OWNER, &SignerAddress::new(OWNER)).is_ok());
+    }
+
+    #[test]
+    fn a_delegate_signing_for_the_owner_is_refused() {
+        let error = ensure_signer_is_note_owner(OWNER, &SignerAddress::new(DELEGATE))
+            .expect_err("a signer that is not the note owner must not open a session");
+        match &error {
+            Error::SignerIsNotNoteOwner { owner, signer } => {
+                assert_eq!(owner, OWNER);
+                assert_eq!(signer, DELEGATE);
+            }
+            other => panic!("expected SignerIsNotNoteOwner, got {other:?}"),
+        }
+    }
 }

--- a/sdk/web/src/signer.rs
+++ b/sdk/web/src/signer.rs
@@ -50,6 +50,11 @@ impl WalletSigner {
         })
     }
 
+    /// The account this signer asks the wallet to sign with.
+    pub(crate) fn signer_address(&self) -> &SignerAddress {
+        &self.signer_address
+    }
+
     pub(crate) async fn sign_wallet_message(&self, message: &str) -> Result<String, JsError> {
         self.call("signMessage", &[message.into()]).await
     }


### PR DESCRIPTION
`AccountOptions.signerAddress` is accepted but not honoured. `Client::account`
in `sdk/web/src/client/mod.rs` builds a `WalletSigner` from it, so the wallet is
asked to sign as that account — but `open_native_account` passes only
`userAddress` to the native client, and `sdk/native/src/client.rs` then discards
whatever was supplied and sets `signer_address = SignerAddress::new(user_address)`.

A caller passing `userAddress: A` with `signerAddress: B` therefore gets a
session where the wallet signs as B while the envelope source, the pool
contract's `sender`, the sequence-number lookup and the auth entries are all
built for A. The `Account.signerAddress` getter reports A, contradicting its own
doc comment, so nothing on screen or in the API reveals which account is
actually signing.

The first session for an account compounds it. `Client::account` derives privacy
keys when none exist: it signs `KEY_DERIVATION_MESSAGE` with `signerAddress` and
files the result under `userAddress`. Those keys are gated by a
`user_keys_exist` check, so they are never re-derived — one divergent open
permanently files A's privacy keys as a function of B's signature, and every
later session for A reuses them.

The two identities already have distinct types, and
`sdk/native/src/types/address.rs` states in its own doc comment that there is
deliberately no conversion between them. There is: `address_newtype!` implements
`From<String>` and `From<&str>` for both. With `Client::account` taking
`impl Into<NoteOwnerAddress>`, an owner-derived string crossed into either type
through an `.into()` naming neither, which is how the two came to be conflated.

## Change

`Client::account` and its blocking mirror take `user_address: NoteOwnerAddress`
and `signer_address: SignerAddress` as separate arguments. A pair naming two
different accounts is refused with `Error::SignerIsNotNoteOwner`, which carries
both addresses as structured fields.

Refusing rather than resolving is deliberate: the two transaction paths disagree
about which identity drives them. `prepare_pool_transact` takes the signer as
its `source_account`, so transact builds the envelope, the contract's `sender`
and the sequence-number lookup from the signing account; `prepare_register` uses
the note owner for both the registry key and the transaction source, and says in
its own comment that which it should be when the two differ is unsettled. A
divergent pair would file a registration under one account and spend under
another with no rule saying which is right, so it fails instead of silently
picking one.

`sdk/web/src/client/mod.rs` performs the same check as soon as both addresses
are resolved — before `WalletSigner::new`, before the `user_keys_exist` read,
before the wallet is prompted and before `derive_save_user_keys` runs. It raises
the native `Error` variant rather than a parallel message, so the two cannot
drift. The native check remains the authoritative one.

Both addresses are wrapped in `Sensitive` when the error renders. Addresses are
Tier-1 in this crate and this message reaches a UI toast, the telemetry ring
buffer and CLI logs; the structured fields stay in the clear for code that needs
to distinguish the pair.

`From<String>` and `From<&str>` are removed from `address_newtype!`. `new` is
now the only constructor, so every crossing writes its destination type down at
the site where it happens. Call sites in the CLI, the examples, the SDK
fixtures and the browser client construct both wrappers explicitly from the one
address they hold; behaviour there is unchanged, since all four already used a
single account for both roles.

`WalletSigner` gains a `signer_address()` accessor so `open_native_account`
reads the address the wallet will actually be asked to sign with, rather than
re-reading `AccountOptions`.

The `Account.signerAddress` getter doc no longer claims it can differ from
`userAddress`, and `AccountOptions.signerAddress` in `options.d.ts` records that
a differing value is refused before the wallet is prompted.

Tests cover the guard directly (accepted, refused, and an exactness check over
case, leading whitespace and empty), through the public `Client::account` on
both the accept and refuse paths, and on the browser guard. The type invariant
is held by const assertions that resolve during type-checking — a reinstated
`From` impl fails to compile rather than reporting a test failure — plus a
`compile_fail` doctest showing the `.into()` crossing the split exists to
prevent, and a passing doctest showing the explicit construction that replaces
it.