### PR TITLE
docs: add Community solutions section with asp-admitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ SPP core is agnostic to the compliance layer: the contracts provide the building
 deployer builds the onboarding process that fits its use case. Solutions already built on top by the
 community:
 
-- [**asp-admitter**](https://github.com/Galmanus/spp-compliance-layer) — a contract that acts as admin
+- [**asp-admitter**](https://github.com/Galmanus/spp-compliance-layer/tree/main/asp-admitter) — a contract that acts as admin
   over `asp-membership` and wraps the admission step with an auditable on-chain receipt, so an operator
   can run KYC-gated onboarding without managing the Association Set by hand. Deployed and exercised on
   testnet; design notes and receipts in the repository.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,17 @@ If you compile, build, or deploy this project (e.g., hosting the `dist/` folder 
 
 The maintainers of this repository provide the source code "as is" and assume no responsibility for the downstream builds or deployments.
 
+## Community solutions
+
+SPP core is agnostic to the compliance layer: the contracts provide the building blocks, and each
+deployer builds the onboarding process that fits its use case. Solutions already built on top by the
+community:
+
+- [**asp-admitter**](https://github.com/Galmanus/spp-compliance-layer) — a contract that acts as admin
+  over `asp-membership` and wraps the admission step with an auditable on-chain receipt, so an operator
+  can run KYC-gated onboarding without managing the Association Set by hand. Deployed and exercised on
+  testnet; design notes and receipts in the repository.
+
 ## Would like to contribute?
 
 Please check [the issues](https://github.com/NethermindEth/stellar-private-payments/issues).


### PR DESCRIPTION
Follow-up to #532.

There, the ASP admission design was confirmed as intentionally admin-driven, with SPP core kept agnostic to the compliance layer, and a mention of existing community-built solutions in the README was suggested so people know some already exist.

This adds a short **Community solutions** section (before *Would like to contribute?*) that states that framing and lists one such solution:

- [asp-admitter](https://github.com/Galmanus/spp-compliance-layer/tree/main/asp-admitter) — a contract that acts as admin over `asp-membership` and wraps the admission step with an auditable on-chain receipt, so an operator can run KYC-gated onboarding without managing the Association Set by hand. Deployed and exercised on testnet; design notes and receipts are in the repository.

Docs-only change, 11 lines. Happy to adjust wording, placement, or format (a one-liner instead of a section) to whatever fits the README best.
