### PR TITLE
Fix NPM release CI toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
         if: steps.registry.outputs.publish == 'true'
         with:
+          toolchain: stable
           targets: wasm32-unknown-unknown
       - if: steps.registry.outputs.publish == 'true'
         run: cargo install wasm-bindgen-cli --version 0.2.126 --locked --force


### PR DESCRIPTION
Fix for:
```
> Run dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
Run : parse toolchain version
0s
Run : parse toolchain version
  'toolchain' is a required input
  Error: Process completed with exit code 1.
```