### PR TITLE
SDK Other error as anyhow

### DIFF
--- a/cli/src/signer.rs
+++ b/cli/src/signer.rs
@@ -6,6 +6,7 @@
 
 use std::path::PathBuf;
 
+use anyhow::Context;
 use stellar_private_payments::{
     Error, PreparedTransaction, Signer,
     chain::{Limits, PreparedSorobanTx, ReadXdr, TransactionEnvelope, WriteXdr},
@@ -34,14 +35,10 @@ impl AliasSigner {
             &self.network_passphrase,
             self.config_dir.as_deref(),
         )
-        .map_err(|e| {
-            Error::Other(format!(
-                "sign transaction for alias `{}`: {e:#}",
-                self.alias
-            ))
-        })?;
+        .with_context(|| format!("sign transaction for alias `{}`", self.alias))?;
         TransactionEnvelope::from_xdr_base64(&signed_xdr, Limits::none())
-            .map_err(|e| Error::Other(format!("decode signed transaction xdr: {e}")))
+            .context("decode signed transaction xdr")
+            .map_err(Into::into)
     }
 }
 
@@ -61,7 +58,7 @@ impl Signer for AliasSigner {
         let envelope = self.sign_prepared_transaction(prepared)?;
         let signed_xdr = envelope
             .to_xdr_base64(Limits::none())
-            .map_err(|e| Error::Other(format!("encode signed transaction xdr: {e}")))?;
+            .context("encode signed transaction xdr")?;
         Ok(SignedTransaction { signed_xdr })
     }
 }

--- a/sdk/native/src/account.rs
+++ b/sdk/native/src/account.rs
@@ -1,3 +1,5 @@
+use anyhow::Context;
+
 use crate::types::{
     ContractConfig, EncryptionPublicKey, Field, NoteOwnerAddress, NotePublicKey, PortfolioBalance,
     SignerAddress, UserNoteSummary,
@@ -155,27 +157,27 @@ impl<S: Storage> Account<S> {
                     .await?
             }
             _ => {
-                return Err(Error::Other(
-                    "note and encryption public keys must both be provided or both omitted".into(),
-                ));
+                return Err(Error::Other(anyhow::anyhow!(
+                    "note and encryption public keys must both be provided or both omitted"
+                )));
             }
         };
 
         let fetcher = StateFetcher::new(self.rpc.clone(), self.contract_config.clone())
-            .map_err(|e| Error::Other(format!("state fetcher: {e:#}")))?;
+            .context("state fetcher")?;
         let prepared = fetcher
             // Registration uses the note-owner address, which is both the
             // registry key and the transaction source. Which it should be when
             // the two identities differ is unsettled.
             .prepare_register(self.user_address.as_str(), note_pk.0, enc_pk.0)
             .await
-            .map_err(|e| Error::Other(format!("prepare register: {e:#}")))?;
+            .context("prepare register")?;
         let signed = self.signer.sign_soroban_transaction(&prepared).await?;
         let envelope = TransactionEnvelope::from_xdr_base64(&signed.signed_xdr, Limits::none())
-            .map_err(|e| Error::Other(format!("invalid signed transaction xdr: {e}")))?;
+            .context("invalid signed transaction xdr")?;
         let hash = submit_tx(fetcher.rpc(), &envelope)
             .await
-            .map_err(|e| Error::Other(format!("submit register: {e:#}")))?;
+            .context("submit register")?;
         confirm_tx(fetcher.rpc(), hash).await
     }
 

--- a/sdk/native/src/blocking/disclosure.rs
+++ b/sdk/native/src/blocking/disclosure.rs
@@ -1,5 +1,7 @@
 //! Walletless synchronous selective-disclosure verification.
 
+use anyhow::Context;
+
 use crate::types::{ContractConfig, DisclosureReceipt, DisclosureVerificationReport};
 
 use crate::{
@@ -17,10 +19,8 @@ pub fn verify_disclosure_receipt(
     receipt: &DisclosureReceipt,
     expected_vk_hash: &str,
 ) -> Result<DisclosureVerificationReport, Error> {
-    let rpc =
-        RpcClient::new(rpc_url.as_ref()).map_err(|e| Error::Other(format!("rpc error: {e:#}")))?;
-    let fetcher = StateFetcher::new(rpc, contract_config)
-        .map_err(|e| Error::Other(format!("state fetcher error: {e:#}")))?;
+    let rpc = RpcClient::new(rpc_url.as_ref()).context("rpc error")?;
+    let fetcher = StateFetcher::new(rpc, contract_config).context("state fetcher error")?;
     block_on(verify_disclosure_receipt_async(
         &fetcher,
         prover,

--- a/sdk/native/src/circuits.rs
+++ b/sdk/native/src/circuits.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeMap;
 
+use anyhow::Context;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
@@ -61,7 +62,7 @@ impl CircuitLockfile {
         let want = Self::expected_hash_hex(hashes, kind)?;
         let got = Self::sha256_hex(bytes);
         if got != want {
-            return Err(Error::other(format!(
+            return Err(Error::Other(anyhow::anyhow!(
                 "hash mismatch {stem}/{kind}: want {want} got {got}"
             )));
         }
@@ -71,10 +72,10 @@ impl CircuitLockfile {
     pub fn artifact_sha256(&self, stem: &str, kind: &str) -> Result<[u8; 32], Error> {
         let hashes = self.entry(stem)?;
         let hex = Self::expected_hash_hex(hashes, kind)?;
-        let bytes = hex::decode(hex)
-            .map_err(|e| Error::other(format!("invalid hash hex for {stem}/{kind}: {e}")))?;
+        let bytes =
+            hex::decode(hex).with_context(|| format!("invalid hash hex for {stem}/{kind}"))?;
         if bytes.len() != 32 {
-            return Err(Error::other(format!(
+            return Err(Error::Other(anyhow::anyhow!(
                 "expected 32-byte hash for {stem}/{kind}, got {} hex chars",
                 hex.len()
             )));
@@ -85,9 +86,11 @@ impl CircuitLockfile {
     }
 
     fn entry(&self, stem: &str) -> Result<&CircuitHashes, Error> {
-        self.circuits
-            .get(stem)
-            .ok_or_else(|| Error::other(format!("stem {stem} is not in embedded circuits.json")))
+        self.circuits.get(stem).ok_or_else(|| {
+            Error::Other(anyhow::anyhow!(
+                "stem {stem} is not in embedded circuits.json"
+            ))
+        })
     }
 
     fn expected_hash_hex<'a>(hashes: &'a CircuitHashes, kind: &str) -> Result<&'a str, Error> {
@@ -95,7 +98,9 @@ impl CircuitLockfile {
             "r1cs" => Ok(hashes.r1cs.as_str()),
             "graph.bin" => Ok(hashes.graph.as_str()),
             "proving_key.bin" => Ok(hashes.proving_key.as_str()),
-            other => Err(Error::other(format!("unknown artifact kind: {other}"))),
+            other => Err(Error::Other(anyhow::anyhow!(
+                "unknown artifact kind: {other}"
+            ))),
         }
     }
 
@@ -106,7 +111,8 @@ impl CircuitLockfile {
 
 pub fn circuit_lock() -> Result<CircuitLockfile, Error> {
     serde_json::from_str(CIRCUITS_JSON)
-        .map_err(|e| Error::other(format!("parse embedded circuits.json: {e}")))
+        .context("parse embedded circuits.json")
+        .map_err(Into::into)
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -118,6 +124,7 @@ mod store {
         path::{Component, Path, PathBuf},
     };
 
+    use anyhow::Context;
     use flate2::read::GzDecoder;
     use tar::Archive;
 
@@ -150,7 +157,7 @@ mod store {
 
         pub async fn ensure(&self) -> Result<(), Error> {
             let lock = circuit_lock()?;
-            fs::create_dir_all(&self.dir).map_err(|e| Error::other(e.to_string()))?;
+            fs::create_dir_all(&self.dir).context("create circuits dir")?;
             if self.ready(&lock) {
                 return Ok(());
             }
@@ -161,18 +168,18 @@ mod store {
                 .send()
                 .await
                 .and_then(|r| r.error_for_status())
-                .map_err(|e| Error::other(format!("download {url}: {e}")))?
+                .with_context(|| format!("download {url}"))?
                 .bytes()
                 .await
-                .map_err(|e| Error::other(format!("download {url}: {e}")))?;
+                .with_context(|| format!("download {url}"))?;
 
             unpack_tar_gz(&bytes, &self.dir, &allowed_names(&lock))?;
             if self.ready(&lock) {
                 Ok(())
             } else {
-                Err(Error::other(
-                    "downloaded circuit artifacts do not match embedded circuits.json",
-                ))
+                Err(Error::Other(anyhow::anyhow!(
+                    "downloaded circuit artifacts do not match embedded circuits.json"
+                )))
             }
         }
 
@@ -228,10 +235,9 @@ mod store {
     ) -> Result<ProverArtifacts, Error> {
         let read = |kind: &str| -> Result<Vec<u8>, Error> {
             let path = dir.join(CircuitLockfile::artifact_file_name(stem, kind));
-            let bytes = fs::read(&path)
-                .map_err(|e| Error::other(format!("read {}: {e}", path.display())))?;
+            let bytes = fs::read(&path).with_context(|| format!("read {}", path.display()))?;
             lock.verify_artifact(stem, kind, &bytes)
-                .map_err(|e| Error::other(format!("{}: {e}", path.display())))?;
+                .with_context(|| path.display().to_string())?;
             Ok(bytes)
         };
         Ok(ProverArtifacts {
@@ -265,15 +271,11 @@ mod store {
 
     fn unpack_tar_gz(bytes: &[u8], dest: &Path, allowed: &HashSet<String>) -> Result<(), Error> {
         let mut archive = Archive::new(GzDecoder::new(Cursor::new(bytes)));
-        let entries = archive
-            .entries()
-            .map_err(|e| Error::other(format!("read circuits.tar.gz: {e}")))?;
+        let entries = archive.entries().context("read circuits.tar.gz")?;
         for entry in entries {
-            let mut entry = entry.map_err(|e| Error::other(format!("circuits.tar.gz: {e}")))?;
+            let mut entry = entry.context("circuits.tar.gz")?;
             let name = {
-                let path = entry
-                    .path()
-                    .map_err(|e| Error::other(format!("circuits.tar.gz: {e}")))?;
+                let path = entry.path().context("circuits.tar.gz")?;
                 tar_basename(&path).map(str::to_owned)
             };
             let Some(name) = name else {
@@ -284,7 +286,7 @@ mod store {
             }
             entry
                 .unpack(dest.join(&name))
-                .map_err(|e| Error::other(format!("extract {name}: {e}")))?;
+                .with_context(|| format!("extract {name}"))?;
         }
         Ok(())
     }

--- a/sdk/native/src/client.rs
+++ b/sdk/native/src/client.rs
@@ -1,3 +1,5 @@
+use anyhow::Context;
+
 use crate::types::{
     ContractConfig, NoteOwnerAddress, OperationalFeedItem, RecipientLookup, SignerAddress,
 };
@@ -36,8 +38,7 @@ impl<S: Storage> Client<S> {
         contract_config: ContractConfig,
         bootnode_url: Option<String>,
     ) -> Result<Self, Error> {
-        let rpc = RpcClient::new(rpc_url.as_ref())
-            .map_err(|e| Error::Other(format!("rpc error: {e:#}")))?;
+        let rpc = RpcClient::new(rpc_url.as_ref()).context("rpc error")?;
         Ok(Self {
             rpc,
             storage,
@@ -168,7 +169,8 @@ impl<S: Storage> Client<S> {
     /// Chain-state accessor for this deployment.
     pub fn state_fetcher(&self) -> Result<StateFetcher, Error> {
         StateFetcher::new(self.rpc.clone(), self.contract_config.clone())
-            .map_err(|e| Error::Other(format!("state fetcher: {e:#}")))
+            .context("state fetcher")
+            .map_err(Into::into)
     }
 
     async fn ensure_synced(&self) -> Result<(), Error> {

--- a/sdk/native/src/core/mod.rs
+++ b/sdk/native/src/core/mod.rs
@@ -52,7 +52,7 @@ impl PoolCore {
             self.config.pool_contract_id.clone(),
             SpendTarget::transfer(note_public_key, encryption_public_key),
         )?;
-        PreparedTransactionPlan::from_session(session).map_err(Error::from)
+        Ok(PreparedTransactionPlan::from_session(session)?)
     }
 
     pub fn prepare_withdraw(
@@ -70,7 +70,7 @@ impl PoolCore {
             self.config.pool_contract_id.clone(),
             SpendTarget::withdraw(recipient.into()),
         )?;
-        PreparedTransactionPlan::from_session(session).map_err(Error::from)
+        Ok(PreparedTransactionPlan::from_session(session)?)
     }
 
     pub fn estimate(
@@ -90,8 +90,9 @@ impl PoolCore {
         enc_pub: EncryptionPublicKey,
         amount: NoteAmount,
     ) -> Result<Transact, Error> {
-        let ext_amount = ExtAmount::try_from(amount)
-            .map_err(|_| Error::Other("deposit amount exceeds ext_amount range".into()))?;
+        let ext_amount = ExtAmount::try_from(amount).map_err(|_| {
+            Error::Other(anyhow::anyhow!("deposit amount exceeds ext_amount range"))
+        })?;
 
         Ok(Transact::new(
             Vec::new(),

--- a/sdk/native/src/core/plan.rs
+++ b/sdk/native/src/core/plan.rs
@@ -6,13 +6,13 @@ use crate::{PreparedTransaction, error::Error, plan::PreparedTransactionPlan};
 
 pub(crate) fn transact_step_for_plan(plan: &PreparedTransactionPlan) -> Result<Transact, Error> {
     if plan.deposit_amount().is_some() {
-        return Err(Error::Other(
-            "deposit transact step requires PoolCore::deposit_transact_step".into(),
-        ));
+        return Err(Error::Other(anyhow::anyhow!(
+            "deposit transact step requires PoolCore::deposit_transact_step"
+        )));
     }
 
     plan.current_spend_step()?
-        .ok_or_else(|| Error::Other("plan tx missing".into()))
+        .ok_or_else(|| Error::Other(anyhow::anyhow!("plan tx missing")))
 }
 
 pub(crate) fn pool_transact_input(prepared: &PreparedTransaction) -> PoolTransactInput {

--- a/sdk/native/src/crypto.rs
+++ b/sdk/native/src/crypto.rs
@@ -15,6 +15,5 @@ pub fn derive_asp_user_leaf(
     note_public_key: &NotePublicKey,
     membership_blinding: &Field,
 ) -> Result<Field, Error> {
-    asp_membership_leaf(note_public_key, membership_blinding)
-        .map_err(|e| Error::Other(e.to_string()))
+    Ok(asp_membership_leaf(note_public_key, membership_blinding)?)
 }

--- a/sdk/native/src/disclosure/api.rs
+++ b/sdk/native/src/disclosure/api.rs
@@ -1,5 +1,7 @@
 //! Selective-disclosure witness building and verification helpers.
 
+use anyhow::Context;
+
 pub use crate::{
     types::DisclosureContext,
     zk::disclosure::{
@@ -135,7 +137,7 @@ pub fn build_disclosure_inputs(
 pub(crate) fn map_build_disclosure_inputs(
     result: anyhow::Result<BuildDisclosureInputs>,
 ) -> Result<Vec<DisclosureInputs>, Error> {
-    match result.map_err(|e| Error::Other(e.to_string()))? {
+    match result? {
         BuildDisclosureInputs::Ready(inputs) => Ok(inputs),
         BuildDisclosureInputs::MembershipSync(status) => Err(Error::MembershipSync(status)),
     }
@@ -153,7 +155,7 @@ pub async fn verify_disclosure_receipt(
         .verify_disclosure_proof(receipt, expected_vk_hash)
         .await?;
     let context_verified = crate::zk::disclosure::verify_receipt_context(receipt)
-        .map_err(|e| Error::Other(format!("context verification failed: {e}")))?;
+        .context("context verification failed")?;
 
     let pool_contract_id = receipt.context.pool_address.clone();
     let mut known_root_status = true;
@@ -161,7 +163,7 @@ pub async fn verify_disclosure_receipt(
         let is_known = fetcher
             .is_pool_known_root(&pool_contract_id, *root)
             .await
-            .map_err(|e| Error::Other(format!("root freshness check failed: {e:#}")))?;
+            .context("root freshness check failed")?;
         if !is_known {
             known_root_status = false;
             break;
@@ -174,13 +176,11 @@ pub async fn verify_disclosure_receipt(
         let spent = fetcher
             .is_nullifier_spent(&pool_contract_id, *nullifier)
             .await
-            .map_err(|e| Error::Other(format!("nullifier spent check failed: {e:#}")))?;
+            .context("nullifier spent check failed")?;
         if spent {
             nullifiers_unspent = false;
-            spent_nullifier_indices.push(
-                u32::try_from(index)
-                    .map_err(|_| Error::Other("nullifier index out of u32 range".to_string()))?,
-            );
+            spent_nullifier_indices
+                .push(u32::try_from(index).context("nullifier index out of u32 range")?);
         }
     }
 

--- a/sdk/native/src/error.rs
+++ b/sdk/native/src/error.rs
@@ -1,6 +1,6 @@
 use crate::{
     planner::{PlanError, SpendSessionError},
-    types::AspMembershipSync,
+    types::{AspMembershipSync, Sensitive},
 };
 
 use crate::types::TransactionResult;
@@ -25,7 +25,7 @@ pub enum Error {
     #[error(transparent)]
     PlanExecution(#[from] PlanExecutionError),
 
-    /// The user rejected the wallet signing request (SEP-0043 error code -4).
+    /// The user rejected the wallet signing request (SEP-0043 error code -4)
     #[error("wallet request rejected by user: {0}")]
     UserRejected(String),
 
@@ -38,19 +38,20 @@ pub enum Error {
     // Escapes to a UI toast, the telemetry ring buffer and CLI logs.
     #[error(
         "signing account {} is not the note owner {}; a session where they differ is not supported",
-        crate::types::Sensitive(signer),
-        crate::types::Sensitive(owner)
+        Sensitive(signer),
+        Sensitive(owner)
     )]
     SignerIsNotNoteOwner { owner: String, signer: String },
 
-    #[error("{0}")]
-    Other(String),
-}
+    /// Local storage has no privacy keys for address
+    #[error(
+        "no privacy keys found in local storage for {}",
+        Sensitive(user_address)
+    )]
+    UserKeysNotFound { user_address: String },
 
-impl Error {
-    pub fn other(msg: impl Into<String>) -> Self {
-        Self::Other(msg.into())
-    }
+    #[error("{0}")]
+    Other(#[from] anyhow::Error),
 }
 
 /// Multi-tx plan stopped after one or more steps had already confirmed

--- a/sdk/native/src/pool.rs
+++ b/sdk/native/src/pool.rs
@@ -1,5 +1,7 @@
 //! Async per-pool private payments API
 
+use anyhow::Context;
+
 use crate::{
     planner::{SpendableNote, Transact},
     types::{EncryptionPublicKey, NoteAmount, NotePublicKey, Sensitive, UserNoteSummary},
@@ -62,7 +64,7 @@ impl<S> PrivatePool<S> {
     ) -> Result<Self, Error> {
         config.validate()?;
         let fetcher = StateFetcher::new(rpc.clone(), config.contract_config.clone())
-            .map_err(|e| Error::Other(format!("state fetcher: {e:#}")))?;
+            .context("state fetcher")?;
         Ok(Self {
             rpc,
             core: PoolCore::new(config.clone())?,
@@ -90,7 +92,7 @@ impl<S: Storage> PrivatePool<S> {
             .map(|note| note.amount)
             .try_fold(NoteAmount::ZERO, |sum, amount| {
                 sum.checked_add(amount)
-                    .ok_or_else(|| Error::Other("wallet balance overflow".into()))
+                    .ok_or_else(|| Error::Other(anyhow::anyhow!("wallet balance overflow")))
             })
     }
 
@@ -116,7 +118,7 @@ impl<S: Storage> PrivatePool<S> {
         self.execute(&mut plan)
             .await?
             .pop()
-            .ok_or_else(|| Error::Other("deposit produced no transaction".into()))
+            .ok_or_else(|| Error::Other(anyhow::anyhow!("deposit produced no transaction")))
     }
 
     #[tracing::instrument(skip(self, recipient), fields(correlation_id = %correlation_id_or_new(), amount = ?Sensitive(amount)))]
@@ -152,7 +154,7 @@ impl<S: Storage> PrivatePool<S> {
         self.execute(&mut plan)
             .await?
             .pop()
-            .ok_or_else(|| Error::Other("transact produced no transaction".into()))
+            .ok_or_else(|| Error::Other(anyhow::anyhow!("transact produced no transaction")))
     }
 
     #[tracing::instrument(skip(self, req), fields(correlation_id = %correlation_id_or_new()))]
@@ -162,9 +164,9 @@ impl<S: Storage> PrivatePool<S> {
     ) -> Result<Option<DisclosureReceipt>, Error> {
         tracing::info!(selected_commitments = ?Sensitive(&req.selected_commitments), "disclose started");
         if req.selected_commitments.is_empty() || req.selected_commitments.len() > 4 {
-            return Err(Error::Other(
-                "selective disclosure requires 1..=4 selected commitments".into(),
-            ));
+            return Err(Error::Other(anyhow::anyhow!(
+                "selective disclosure requires 1..=4 selected commitments"
+            )));
         }
 
         let selected_commitments = req.selected_commitments;
@@ -174,21 +176,21 @@ impl<S: Storage> PrivatePool<S> {
                 .fetcher
                 .contracts_data_for_pool(&self.config.pool_contract_id)
                 .await
-                .map_err(|e| Error::Other(format!("fetch chain context: {e:#}")))?;
+                .context("fetch chain context")?;
 
             let pool = data.pools.into_iter().next().ok_or_else(|| {
-                Error::Other(format!(
+                Error::Other(anyhow::anyhow!(
                     "pool {} not found in contract state",
                     self.config.pool_contract_id
                 ))
             })?;
             let pool_root = pool
                 .merkle_root
-                .ok_or_else(|| Error::Other("pool merkle_root not fetched".into()))?;
+                .ok_or_else(|| Error::Other(anyhow::anyhow!("pool merkle_root not fetched")))?;
             let pool_next_index = pool
                 .merkle_next_index
                 .parse::<u32>()
-                .map_err(|e| Error::Other(format!("invalid pool merkle_next_index: {e}")))?;
+                .context("invalid pool merkle_next_index")?;
 
             let inputs_req = DisclosureInputsRequest {
                 user_address: self.config.user_address.as_str().to_string(),
@@ -259,7 +261,7 @@ impl<S: Storage> PrivatePool<S> {
                 &chain_config.signer_address,
             )
             .await
-            .map_err(|e| Error::Other(format!("simulate transaction: {e:#}")))?;
+            .context("simulate transaction")?;
 
         Ok(())
     }
@@ -339,11 +341,12 @@ impl<S: Storage> PrivatePool<S> {
 
     pub async fn submit(&self, signed_tx: SignedTransaction) -> Result<String, Error> {
         let envelope = TransactionEnvelope::from_xdr_base64(&signed_tx.signed_xdr, Limits::none())
-            .map_err(|e| Error::Other(format!("invalid signed transaction xdr: {e}")))?;
+            .context("invalid signed transaction xdr")?;
 
         submit_tx(&self.rpc, &envelope)
             .await
-            .map_err(|e| Error::Other(format!("submit transaction: {e:#}")))
+            .context("submit transaction")
+            .map_err(Into::into)
     }
 
     pub async fn confirm(&self, hash: &str) -> Result<TransactionResult, Error> {
@@ -388,7 +391,9 @@ impl<S: Storage> PrivatePool<S> {
         plan: &mut PreparedTransactionPlan,
     ) -> Result<PreparedTransaction, Error> {
         if plan.is_complete() {
-            return Err(Error::Other("transaction plan is complete".into()));
+            return Err(Error::Other(anyhow::anyhow!(
+                "transaction plan is complete"
+            )));
         }
         self.ensure_synced().await?;
 
@@ -426,7 +431,8 @@ impl<S: Storage> PrivatePool<S> {
                 self.config.user_address.as_str(),
             )
             .await
-            .map_err(|e| Error::Other(format!("fetch chain context: {e:#}")))
+            .context("fetch chain context")
+            .map_err(Into::into)
     }
 
     async fn execute(

--- a/sdk/native/src/prover/local.rs
+++ b/sdk/native/src/prover/local.rs
@@ -1,5 +1,7 @@
 use std::{cell::RefCell, collections::HashMap};
 
+use anyhow::Context;
+
 use crate::{
     types::{CircuitStem, DisclosureReceipt},
     zk::flows::TransactParams,
@@ -29,9 +31,9 @@ pub struct LocalProver {
 impl LocalProver {
     pub fn from_artifacts(artifacts: &[(CircuitStem, ProverArtifacts)]) -> Result<Self, Error> {
         if artifacts.is_empty() {
-            return Err(Error::Other(
-                "at least one transact circuit is required".into(),
-            ));
+            return Err(Error::Other(anyhow::anyhow!(
+                "at least one transact circuit is required"
+            )));
         }
         Self::from_all_artifacts(artifacts, &[])
     }
@@ -40,9 +42,9 @@ impl LocalProver {
         artifacts: &[(&'static RegisteredCircuit, ProverArtifacts)],
     ) -> Result<Self, Error> {
         if artifacts.is_empty() {
-            return Err(Error::Other(
-                "at least one disclosure circuit is required".into(),
-            ));
+            return Err(Error::Other(anyhow::anyhow!(
+                "at least one disclosure circuit is required"
+            )));
         }
         Self::from_all_artifacts(&[], artifacts)
     }
@@ -52,7 +54,9 @@ impl LocalProver {
         disclosure_artifacts: &[(&'static RegisteredCircuit, ProverArtifacts)],
     ) -> Result<Self, Error> {
         if transact_artifacts.is_empty() && disclosure_artifacts.is_empty() {
-            return Err(Error::Other("at least one circuit is required".into()));
+            return Err(Error::Other(anyhow::anyhow!(
+                "at least one circuit is required"
+            )));
         }
 
         let mut transact = HashMap::with_capacity(transact_artifacts.len());
@@ -62,9 +66,9 @@ impl LocalProver {
                 &bundle.circuit_graph,
                 &bundle.circuit_r1cs,
             )
-            .map_err(|e| Error::Other(format!("init prover for {stem}: {e:#}")))?;
+            .context(format!("init prover for {stem}"))?;
             if transact.insert(*stem, engine).is_some() {
-                return Err(Error::Other(format!(
+                return Err(Error::Other(anyhow::anyhow!(
                     "duplicate transact circuit for {stem}"
                 )));
             }
@@ -77,9 +81,9 @@ impl LocalProver {
                 &bundle.circuit_graph,
                 &bundle.circuit_r1cs,
             )
-            .map_err(|e| Error::Other(format!("init prover for {}: {e:#}", circuit.name)))?;
+            .context(format!("init prover for {}", circuit.name))?;
             if disclosure.insert(circuit.name, engine).is_some() {
-                return Err(Error::Other(format!(
+                return Err(Error::Other(anyhow::anyhow!(
                     "duplicate disclosure circuit for {}",
                     circuit.name
                 )));
@@ -97,9 +101,12 @@ impl LocalProver {
         self.transact
             .borrow_mut()
             .get_mut(&stem)
-            .ok_or_else(|| Error::Other(format!("no transact prover configured for {stem}")))?
+            .ok_or_else(|| {
+                Error::Other(anyhow::anyhow!("no transact prover configured for {stem}"))
+            })?
             .prove_transact(params)
-            .map_err(|e| Error::Other(format!("prove: {e:#}")))
+            .context("prove")
+            .map_err(Into::into)
     }
 }
 
@@ -113,23 +120,24 @@ impl Prover for LocalProver {
         &self,
         params: DisclosureProveParams,
     ) -> Result<DisclosureReceipt, Error> {
-        let note_count = u32::try_from(params.notes.len())
-            .map_err(|_| Error::Other("disclosure note count out of range".into()))?;
+        let note_count =
+            u32::try_from(params.notes.len()).context("disclosure note count out of range")?;
         let circuit = find_circuit_by_notes(note_count).ok_or_else(|| {
-            Error::Other(format!(
+            Error::Other(anyhow::anyhow!(
                 "no disclosure circuit registered for {note_count} note(s)"
             ))
         })?;
         let mut disclosure = self.disclosure.borrow_mut();
         let engine = disclosure.get_mut(circuit.name).ok_or_else(|| {
-            Error::Other(format!(
+            Error::Other(anyhow::anyhow!(
                 "no disclosure prover configured for {}",
                 circuit.name
             ))
         })?;
         engine
             .prove_disclosure(params, circuit)
-            .map_err(|e| Error::Other(format!("prove disclosure: {e:#}")))
+            .context("prove disclosure")
+            .map_err(Into::into)
     }
 
     async fn verify_disclosure_proof(
@@ -138,16 +146,17 @@ impl Prover for LocalProver {
         expected_vk_hash: &str,
     ) -> Result<bool, Error> {
         let circuit = validate_registered_receipt(receipt, expected_vk_hash)
-            .map_err(|e| Error::Other(format!("validate disclosure receipt: {e:#}")))?;
+            .context("validate disclosure receipt")?;
         let disclosure = self.disclosure.borrow();
         let engine = disclosure.get(circuit.name).ok_or_else(|| {
-            Error::Other(format!(
+            Error::Other(anyhow::anyhow!(
                 "no disclosure verifier configured for {}",
                 circuit.name
             ))
         })?;
         engine
             .verify_disclosure(receipt, expected_vk_hash)
-            .map_err(|e| Error::Other(format!("verify disclosure proof: {e:#}")))
+            .context("verify disclosure proof")
+            .map_err(Into::into)
     }
 }

--- a/sdk/native/src/prover/noop.rs
+++ b/sdk/native/src/prover/noop.rs
@@ -19,14 +19,14 @@ pub(crate) struct NoopProver;
 #[async_trait::async_trait(?Send)]
 impl Prover for NoopProver {
     async fn prove_transact(&self, _params: TransactParams) -> Result<PreparedProverTx, Error> {
-        Err(Error::Other(READ_ONLY.into()))
+        Err(Error::Other(anyhow::anyhow!(READ_ONLY)))
     }
 
     async fn prove_disclosure(
         &self,
         _params: DisclosureProveParams,
     ) -> Result<DisclosureReceipt, Error> {
-        Err(Error::Other(READ_ONLY.into()))
+        Err(Error::Other(anyhow::anyhow!(READ_ONLY)))
     }
 
     async fn verify_disclosure_proof(
@@ -34,6 +34,6 @@ impl Prover for NoopProver {
         _receipt: &DisclosureReceipt,
         _expected_vk_hash: &str,
     ) -> Result<bool, Error> {
-        Err(Error::Other(READ_ONLY.into()))
+        Err(Error::Other(anyhow::anyhow!(READ_ONLY)))
     }
 }

--- a/sdk/native/src/signer/local.rs
+++ b/sdk/native/src/signer/local.rs
@@ -1,3 +1,5 @@
+use anyhow::Context;
+
 use crate::chain::{Limits, LocalSigner as StellarSigner, PreparedSorobanTx, WriteXdr};
 
 use super::Signer;
@@ -21,8 +23,7 @@ impl LocalSigner {
         signer_address: SignerAddress,
     ) -> Result<Self, Error> {
         Ok(Self {
-            stellar: StellarSigner::from_secret(secret_key)
-                .map_err(|e| Error::Other(format!("signer: {e:#}")))?,
+            stellar: StellarSigner::from_secret(secret_key).context("signer")?,
             network_passphrase: network_passphrase.into(),
             signer_address,
         })
@@ -57,10 +58,10 @@ impl Signer for LocalSigner {
         let envelope = self
             .stellar
             .sign_prepared_transaction(prepared, &self.network_passphrase, &self.signer_address)
-            .map_err(|e| Error::Other(format!("sign transaction: {e:#}")))?;
+            .context("sign transaction")?;
         let signed_xdr = envelope
             .to_xdr_base64(Limits::none())
-            .map_err(|e| Error::Other(format!("encode signed transaction xdr: {e}")))?;
+            .context("encode signed transaction xdr")?;
         Ok(SignedTransaction { signed_xdr })
     }
 }

--- a/sdk/native/src/signer/mod.rs
+++ b/sdk/native/src/signer/mod.rs
@@ -23,8 +23,8 @@ pub trait Signer {
         prepared: &PreparedSorobanTx,
     ) -> Result<SignedTransaction, Error> {
         let _ = prepared;
-        Err(Error::Other(
-            "signer does not support soroban transactions".into(),
-        ))
+        Err(Error::Other(anyhow::anyhow!(
+            "signer does not support soroban transactions"
+        )))
     }
 }

--- a/sdk/native/src/state/process_local.rs
+++ b/sdk/native/src/state/process_local.rs
@@ -9,7 +9,7 @@ use super::{
 const PROCESS_FETCH_LIMIT: u32 = 50;
 
 pub(crate) fn process_local_state(storage: &mut SqliteStorage) -> Result<(), Error> {
-    while process_local_state_batch(storage).map_err(|e| Error::Other(e.to_string()))? {}
+    while process_local_state_batch(storage)? {}
     Ok(())
 }
 

--- a/sdk/native/src/storage/local.rs
+++ b/sdk/native/src/storage/local.rs
@@ -1,5 +1,7 @@
 use std::{cell::RefCell, collections::HashSet, path::PathBuf};
 
+use anyhow::Context;
+
 use crate::{
     chain::ContractDataStorage,
     planner::SpendableNote,
@@ -33,8 +35,7 @@ pub struct LocalStorage {
 impl LocalStorage {
     pub fn open(storage_path: &str) -> Result<Self, Error> {
         let path = PathBuf::from(storage_path);
-        let db = SqliteStorage::connect_file(&path)
-            .map_err(|e| Error::Other(format!("open storage: {e:#}")))?;
+        let db = SqliteStorage::connect_file(&path).context("open storage")?;
         Ok(Self {
             path,
             db: RefCell::new(db),
@@ -73,8 +74,7 @@ impl ContractDataStorage for LocalStorage {
 #[async_trait::async_trait(?Send)]
 impl Storage for LocalStorage {
     fn fork(&self) -> Result<Self, Error> {
-        let db = SqliteStorage::connect_file(self.path.as_path())
-            .map_err(|e| Error::Other(format!("fork storage: {e:#}")))?;
+        let db = SqliteStorage::connect_file(self.path.as_path()).context("fork storage")?;
         Ok(Self {
             path: self.path.clone(),
             db: RefCell::new(db),
@@ -171,9 +171,9 @@ impl Storage for LocalStorage {
         let entry = self
             .storage()
             .lookup_public_key_by_address(address)
-            .map_err(|e| Error::Other(format!("lookup recipient: {e:#}")))?
+            .context("lookup recipient")?
             .ok_or_else(|| {
-                Error::Other(format!(
+                Error::Other(anyhow::anyhow!(
                     "recipient {address} not found in the public key registry; \
                      they must register keys on-chain"
                 ))
@@ -186,15 +186,13 @@ impl Storage for LocalStorage {
     }
 
     async fn clear_indexing_cursors(&self) -> Result<(), Error> {
-        self.storage_mut()
-            .clear_indexing_cursors()
-            .map_err(|e| Error::Other(e.to_string()))
+        Ok(self.storage_mut().clear_indexing_cursors()?)
     }
 
     async fn clamp_last_fully_indexed_ledger(&self, max_ledger: u32) -> Result<(), Error> {
-        self.storage_mut()
-            .clamp_last_fully_indexed_ledger(max_ledger)
-            .map_err(|e| Error::Other(e.to_string()))
+        Ok(self
+            .storage_mut()
+            .clamp_last_fully_indexed_ledger(max_ledger)?)
     }
 
     async fn list_pool_gvk_events(
@@ -203,9 +201,9 @@ impl Storage for LocalStorage {
         after: Option<(u32, String)>,
         limit: u32,
     ) -> Result<Vec<crate::gvk::GvkEvent>, Error> {
-        self.storage()
-            .list_pool_gvk_events(pool_contract_id, after, limit)
-            .map_err(|e| Error::Other(e.to_string()))
+        Ok(self
+            .storage()
+            .list_pool_gvk_events(pool_contract_id, after, limit)?)
     }
 
     async fn pool_has_commitments(
@@ -213,8 +211,8 @@ impl Storage for LocalStorage {
         pool_contract_id: &str,
         commitments: &[Field],
     ) -> Result<HashSet<Field>, Error> {
-        self.storage()
-            .pool_has_commitments(pool_contract_id, commitments)
-            .map_err(|e| Error::Other(e.to_string()))
+        Ok(self
+            .storage()
+            .pool_has_commitments(pool_contract_id, commitments)?)
     }
 }

--- a/sdk/native/src/storage/mod.rs
+++ b/sdk/native/src/storage/mod.rs
@@ -24,9 +24,9 @@ use std::collections::HashSet;
 pub use local::LocalStorage;
 
 pub(crate) fn map_build_params(
-    result: anyhow::Result<BuildTransactParams>,
+    result: Result<BuildTransactParams, Error>,
 ) -> Result<TransactParams, Error> {
-    match result.map_err(|e| Error::Other(e.to_string()))? {
+    match result? {
         BuildTransactParams::Ready(params) => Ok(*params),
         BuildTransactParams::MembershipSync(status) => Err(Error::MembershipSync(status)),
     }
@@ -37,14 +37,9 @@ pub(crate) fn map_user_keys(
     user_address: &str,
 ) -> Result<StoredUserKeys, Error> {
     storage
-        .get_user_keys(user_address)
-        .map_err(|e| Error::Other(e.to_string()))?
-        .ok_or_else(|| {
-            // Escapes to CLI output and logs.
-            Error::Other(format!(
-                "address {} should generate privacy keys and ASP secret first",
-                crate::types::Sensitive(user_address)
-            ))
+        .get_user_keys(user_address)?
+        .ok_or_else(|| Error::UserKeysNotFound {
+            user_address: user_address.to_string(),
         })
 }
 
@@ -53,18 +48,14 @@ pub(crate) fn spendable_notes_from_storage(
     pool_contract_id: &str,
     user_address: &str,
 ) -> Result<Vec<SpendableNote>, Error> {
-    storage
-        .list_unspent_user_notes(pool_contract_id, user_address)
-        .map_err(|e| Error::Other(e.to_string()))
-        .map(|notes| {
-            notes
-                .into_iter()
-                .map(|n| SpendableNote {
-                    commitment: n.id,
-                    amount: n.amount,
-                })
-                .collect()
+    Ok(storage
+        .list_unspent_user_notes(pool_contract_id, user_address)?
+        .into_iter()
+        .map(|n| SpendableNote {
+            commitment: n.id,
+            amount: n.amount,
         })
+        .collect())
 }
 
 pub(crate) fn pool_notes_from_storage(
@@ -72,9 +63,7 @@ pub(crate) fn pool_notes_from_storage(
     pool_contract_id: &str,
     user_address: &str,
 ) -> Result<Vec<UserNoteSummary>, Error> {
-    storage
-        .list_pool_user_notes(pool_contract_id, user_address)
-        .map_err(|e| Error::Other(e.to_string()))
+    Ok(storage.list_pool_user_notes(pool_contract_id, user_address)?)
 }
 
 pub(crate) fn portfolio_balances_from_storage(
@@ -82,9 +71,7 @@ pub(crate) fn portfolio_balances_from_storage(
     user_address: &str,
     enabled_pools: &[PortfolioPoolEntry],
 ) -> Result<Vec<PortfolioBalance>, Error> {
-    storage
-        .list_portfolio_balances(user_address, enabled_pools)
-        .map_err(|e| Error::Other(e.to_string()))
+    Ok(storage.list_portfolio_balances(user_address, enabled_pools)?)
 }
 
 pub(crate) fn user_notes_from_storage(
@@ -92,9 +79,7 @@ pub(crate) fn user_notes_from_storage(
     user_address: &str,
     limit: u32,
 ) -> Result<Vec<UserNoteSummary>, Error> {
-    storage
-        .list_user_notes(user_address, limit)
-        .map_err(|e| Error::Other(e.to_string()))
+    Ok(storage.list_user_notes(user_address, limit)?)
 }
 
 pub(crate) fn operational_feed_from_storage(
@@ -102,9 +87,7 @@ pub(crate) fn operational_feed_from_storage(
     limit: u32,
     config: &ContractConfig,
 ) -> Result<Vec<OperationalFeedItem>, Error> {
-    storage
-        .get_operational_feed(limit, &config.asp_membership, &config.public_key_registry)
-        .map_err(|e| Error::Other(e.to_string()))
+    Ok(storage.get_operational_feed(limit, &config.asp_membership, &config.public_key_registry)?)
 }
 
 pub(crate) fn recipient_lookup_from_storage(
@@ -112,9 +95,7 @@ pub(crate) fn recipient_lookup_from_storage(
     address: &str,
     config: &ContractConfig,
 ) -> Result<RecipientLookup, Error> {
-    storage
-        .recipient_lookup(address, &config.public_key_registry)
-        .map_err(|e| Error::Other(e.to_string()))
+    Ok(storage.recipient_lookup(address, &config.public_key_registry)?)
 }
 
 /// Wallet reads and sync lifecycle for [`crate::pool::PrivatePool`].

--- a/sdk/native/src/sync.rs
+++ b/sdk/native/src/sync.rs
@@ -11,6 +11,7 @@ use crate::{
     },
     types::{ContractConfig, SyncMetadata},
 };
+use anyhow::Context as _;
 use futures::task::AtomicWaker;
 
 use crate::{Error, Handle, Storage, chain::RpcClient, sleep::sleep, types::TransactionResult};
@@ -277,9 +278,9 @@ impl<S: Storage> BackgroundSync<S> {
                     &self.contract_config,
                 )
                 .await
-                .map_err(|e| Error::Other(format!("indexer: {e:#}")))?
+                .context("indexer")?
             }
-            Err(e) => return Err(Error::Other(format!("indexer: {e:#}"))),
+            Err(e) => return Err(e.context("indexer").into()),
         };
 
         loop {
@@ -336,12 +337,9 @@ async fn apply_bootnode_handoff<S: Storage>(
     storage
         .save_sync_progress(metadata, false)
         .await
-        .map_err(|e| Error::Other(format!("handoff sync progress: {e:#}")))?;
+        .context("handoff sync progress")?;
     storage.clear_indexing_cursors().await?;
-    storage
-        .clamp_last_fully_indexed_ledger(from_ledger)
-        .await
-        .map_err(|e| Error::Other(format!("handoff clamp fully indexed: {e:#}")))?;
+    storage.clamp_last_fully_indexed_ledger(from_ledger).await?;
     tracing::info!(
         from_ledger,
         "bootnode handoff, resuming main RPC from cutoff"
@@ -355,7 +353,9 @@ async fn apply_bootnode_handoff_from_err<S: Storage>(
     err: &RpcError,
 ) -> Result<(), Error> {
     let from_ledger = retention_handoff_from_ledger(err).ok_or_else(|| {
-        Error::Other("bootnode handoff missing fromLedger in error data".to_string())
+        Error::Other(anyhow::anyhow!(
+            "bootnode handoff missing fromLedger in error data"
+        ))
     })?;
     apply_bootnode_handoff(storage, contract_config, from_ledger).await
 }
@@ -379,7 +379,7 @@ pub async fn bootnode_required<S: Storage>(
     match Indexer::init(rpc.clone(), storage.fork()?, contract_config).await {
         Ok(_) => Ok(false),
         Err(e) if is_rpc_sync_gap(&e) => Ok(true),
-        Err(e) => Err(Error::Other(format!("bootnode probe: {e:#}"))),
+        Err(e) => Err(e.context("bootnode probe").into()),
     }
 }
 
@@ -427,18 +427,16 @@ async fn bootnode_catch_up<S: Storage>(
     stop: Option<&AtomicBool>,
 ) -> Result<(), Error> {
     let Some(bootnode) = bootnode_url else {
-        return Err(Error::Other(
+        return Err(Error::Other(anyhow::anyhow!(
             "RPC sync gap: main RPC lacks history; configure a bootnode \
              or use a different RPC / fresher deployment"
-                .to_string(),
-        ));
+        )));
     };
 
     tracing::info!("main RPC sync gap, trying bootnode at {bootnode}");
     storage.clear_indexing_cursors().await?;
 
-    let bootnode_client =
-        RpcClient::new(bootnode).map_err(|e| Error::Other(format!("bootnode rpc: {e:#}")))?;
+    let bootnode_client = RpcClient::new(bootnode).context("bootnode rpc")?;
 
     let bootnode_indexer =
         match Indexer::init(bootnode_client, storage.fork()?, contract_config).await {
@@ -449,7 +447,7 @@ async fn bootnode_catch_up<S: Storage>(
                 }
                 return Ok(());
             }
-            Err(e) => return Err(Error::Other(format!("bootnode indexer: {e:#}"))),
+            Err(e) => return Err(e.context("bootnode indexer").into()),
         };
 
     let mut consecutive_failures = 0u32;
@@ -483,9 +481,11 @@ async fn bootnode_catch_up<S: Storage>(
                     "bootnode sync round failed ({consecutive_failures}/{BOOTNODE_CATCH_UP_MAX_FAILURES}): {e:#}"
                 );
                 if consecutive_failures >= BOOTNODE_CATCH_UP_MAX_FAILURES {
-                    return Err(Error::Other(format!(
-                        "bootnode sync failed after {BOOTNODE_CATCH_UP_MAX_FAILURES} consecutive errors: {e:#}"
-                    )));
+                    return Err(e
+                        .context(format!(
+                            "bootnode sync failed after {BOOTNODE_CATCH_UP_MAX_FAILURES} consecutive errors"
+                        ))
+                        .into());
                 }
                 sleep(BACKGROUND_SYNC_INTERVAL_MS).await;
             }
@@ -509,13 +509,14 @@ pub(crate) async fn catch_up<S: Storage>(
             bootnode_catch_up(storage, contract_config, bootnode_url, None).await?;
             Indexer::init(rpc.clone(), storage.fork()?, contract_config)
                 .await
-                .map_err(|e| Error::Other(format!("indexer: {e:#}")))?
+                .context("indexer")?
         }
-        Err(e) => return Err(Error::Other(format!("indexer: {e:#}"))),
+        Err(e) => return Err(e.context("indexer").into()),
     };
     catch_up_loop(&indexer, storage, None)
         .await
-        .map_err(|e| Error::Other(format!("indexer catch-up: {e:#}")))
+        .context("indexer catch-up")
+        .map_err(Into::into)
 }
 
 /// Poll until a submitted transaction succeeds or fails.
@@ -531,7 +532,7 @@ pub(crate) async fn confirm_tx(
         }
         match rpc_confirm_tx(rpc, hash)
             .await
-            .map_err(|e| Error::Other(format!("confirm transaction: {e:#}")))?
+            .context("confirm transaction")?
         {
             TxConfirmStatus::Success => {
                 return Ok(TransactionResult {
@@ -539,10 +540,10 @@ pub(crate) async fn confirm_tx(
                 });
             }
             TxConfirmStatus::Failed { detail } => {
-                return Err(Error::Other(format!("transaction failed{detail}")));
+                return Err(Error::Other(anyhow::anyhow!("transaction failed{detail}")));
             }
             TxConfirmStatus::Pending if attempt == CONFIRM_POLL_ATTEMPTS => {
-                return Err(Error::Other(format!(
+                return Err(Error::Other(anyhow::anyhow!(
                     "transaction confirmation timed out after 30s (hash: {hash})"
                 )));
             }
@@ -550,7 +551,7 @@ pub(crate) async fn confirm_tx(
         }
     }
 
-    Err(Error::Other(format!(
+    Err(Error::Other(anyhow::anyhow!(
         "transaction confirmation failed (hash: {hash})"
     )))
 }

--- a/sdk/native/src/transact.rs
+++ b/sdk/native/src/transact.rs
@@ -1,6 +1,7 @@
 //! Transact witness input building and prepared-transaction types.
 
 use crate::{
+    Error,
     chain::{OnchainProofPublicInputs, PreparedSorobanTx},
     planner::Transact,
     state::{SqliteStorage, StoredUserKeys},
@@ -123,9 +124,11 @@ pub(crate) fn transact_request_from_step(
 pub fn build_transact_params(
     storage: &SqliteStorage,
     req: &TransactRequest,
-) -> Result<BuildTransactParams> {
+) -> Result<BuildTransactParams, Error> {
     if req.input_commitments.len() > 2 {
-        anyhow::bail!("transact input_commitments must have length 0..=2");
+        return Err(Error::Other(anyhow::anyhow!(
+            "transact input_commitments must have length 0..=2"
+        )));
     }
 
     let (note_privkey, note_pubkey, encryption_pubkey, membership_blinding) =
@@ -170,9 +173,9 @@ pub fn build_transact_params(
         let note_pk = req.out_recipient_note_pubkeys[i].clone();
         let enc_pk = req.out_recipient_encryption_pubkeys[i].clone();
         if note_pk.is_some() != enc_pk.is_some() {
-            anyhow::bail!(
+            return Err(Error::Other(anyhow::anyhow!(
                 "output {i}: recipient_note_pubkey and recipient_encryption_pubkey must both be set or both be null"
-            );
+            )));
         }
         outputs.push(TransactOutput {
             amount: req.output_amounts[i],
@@ -204,7 +207,7 @@ pub fn build_transact_params(
 pub(crate) fn load_user_key_material(
     storage: &SqliteStorage,
     user_address: &str,
-) -> Result<(NotePrivateKey, NotePublicKey, EncryptionPublicKey, Field)> {
+) -> Result<(NotePrivateKey, NotePublicKey, EncryptionPublicKey, Field), Error> {
     let StoredUserKeys {
         note_keypair: NoteKeyPair {
             private,
@@ -214,13 +217,7 @@ pub(crate) fn load_user_key_material(
             public: enc_pub, ..
         },
         membership_blinding,
-    } = storage.get_user_keys(user_address)?.ok_or_else(|| {
-        // Escapes to a UI toast and the telemetry ring buffer.
-        anyhow::anyhow!(
-            "address {} should generate privacy keys and ASP secret first",
-            crate::types::Sensitive(user_address)
-        )
-    })?;
+    } = crate::storage::map_user_keys(storage, user_address)?;
 
     Ok((private, note_pub, enc_pub, membership_blinding))
 }
@@ -233,7 +230,7 @@ fn build_membership_proof(
     aspmem_root: Field,
     aspmem_ledger: u32,
     asp_depth: u32,
-) -> Result<Result<AspMembershipProof, AspMembershipSync>> {
+) -> Result<Result<AspMembershipProof, AspMembershipSync>, Error> {
     let user_leaf = asp_membership_leaf(note_pubkey, &membership_blinding)?;
     let user_leaf_index = match storage.check_asp_membership_precondition(
         aspmem_contract_id,

--- a/sdk/web/src/signer.rs
+++ b/sdk/web/src/signer.rs
@@ -206,7 +206,7 @@ fn wallet_sign_error(error: JsError) -> Error {
             .unwrap_or_else(|| "request rejected".to_string());
         Error::UserRejected(message)
     } else {
-        Error::Other(format!("{error:?}"))
+        Error::Other(anyhow::anyhow!("{error:?}"))
     }
 }
 
@@ -265,7 +265,7 @@ impl Signer for WalletSigner {
 
         let signed_xdr = envelope
             .to_xdr_base64(Limits::none())
-            .map_err(|e| Error::Other(format!("encode signed transaction xdr: {e}")))?;
+            .map_err(|e| Error::Other(anyhow::anyhow!("encode signed transaction xdr: {e}")))?;
 
         Ok(SignedTransaction { signed_xdr })
     }

--- a/sdk/web/src/workers/prover.rs
+++ b/sdk/web/src/workers/prover.rs
@@ -525,10 +525,10 @@ impl Prover for ProverBridge {
             .await
         {
             Ok(ProverWorkerResponse::TransactPrepared(prepared)) => Ok(prepared),
-            Ok(other) => Err(Error::Other(format!(
+            Ok(other) => Err(Error::Other(anyhow::anyhow!(
                 "unexpected prover worker response: {other:?}"
             ))),
-            Err(e) => Err(Error::Other(e.to_string())),
+            Err(e) => Err(Error::Other(e)),
         }
     }
 
@@ -541,10 +541,10 @@ impl Prover for ProverBridge {
             .await
         {
             Ok(ProverWorkerResponse::Disclosure(receipt)) => Ok(receipt),
-            Ok(other) => Err(Error::Other(format!(
+            Ok(other) => Err(Error::Other(anyhow::anyhow!(
                 "unexpected prover worker response: {other:?}"
             ))),
-            Err(e) => Err(Error::Other(e.to_string())),
+            Err(e) => Err(Error::Other(e)),
         }
     }
 
@@ -564,10 +564,10 @@ impl Prover for ProverBridge {
             .await
         {
             Ok(ProverWorkerResponse::DisclosureProofVerified(v)) => Ok(v),
-            Ok(other) => Err(Error::Other(format!(
+            Ok(other) => Err(Error::Other(anyhow::anyhow!(
                 "unexpected prover worker response: {other:?}"
             ))),
-            Err(e) => Err(Error::Other(e.to_string())),
+            Err(e) => Err(Error::Other(e)),
         }
     }
 }

--- a/sdk/web/src/workers/storage.rs
+++ b/sdk/web/src/workers/storage.rs
@@ -712,21 +712,22 @@ impl Storage for StorageBridge {
             .await
         {
             Ok(StorageWorkerResponse::Saved) => Ok(()),
-            Ok(other) => Err(Error::Other(format!(
+            Ok(other) => Err(Error::Other(anyhow::anyhow!(
                 "unexpected process_pending_state response: {other:?}"
             ))),
-            Err(e) => Err(Error::Other(e.to_string())),
+            Err(e) => Err(Error::Other(e)),
         }
     }
 
     async fn clear_indexing_cursors(&self) -> Result<(), Error> {
         match self
             .call(StorageWorkerRequest::ClearIndexingCursors, 2_000)
-            .await
-            .map_err(|e| Error::Other(e.to_string()))?
+            .await?
         {
             StorageWorkerResponse::Saved => Ok(()),
-            other => Err(Error::Other(format!("unexpected response: {other:?}"))),
+            other => Err(Error::Other(anyhow::anyhow!(
+                "unexpected response: {other:?}"
+            ))),
         }
     }
 
@@ -736,16 +737,17 @@ impl Storage for StorageBridge {
                 StorageWorkerRequest::ClampLastFullyIndexedLedger(max_ledger),
                 2_000,
             )
-            .await
-            .map_err(|e| Error::Other(e.to_string()))?
+            .await?
         {
             StorageWorkerResponse::Saved => Ok(()),
-            other => Err(Error::Other(format!("unexpected response: {other:?}"))),
+            other => Err(Error::Other(anyhow::anyhow!(
+                "unexpected response: {other:?}"
+            ))),
         }
     }
 
     async fn ensure_ready(&self) -> Result<(), Error> {
-        self.ping().await.map_err(|e| Error::Other(e.to_string()))
+        Ok(self.ping().await?)
     }
 
     async fn spendable_notes(
@@ -770,10 +772,10 @@ impl Storage for StorageBridge {
                     amount: n.amount,
                 })
                 .collect()),
-            Ok(other) => Err(Error::Other(format!(
+            Ok(other) => Err(Error::Other(anyhow::anyhow!(
                 "unexpected storage response loading spendable notes: {other:?}"
             ))),
-            Err(e) => Err(Error::Other(e.to_string())),
+            Err(e) => Err(Error::Other(e)),
         }
     }
 
@@ -793,10 +795,10 @@ impl Storage for StorageBridge {
             .await
         {
             Ok(StorageWorkerResponse::UserNotes(notes)) => Ok(notes),
-            Ok(other) => Err(Error::Other(format!(
+            Ok(other) => Err(Error::Other(anyhow::anyhow!(
                 "unexpected storage response loading notes: {other:?}"
             ))),
-            Err(e) => Err(Error::Other(e.to_string())),
+            Err(e) => Err(Error::Other(e)),
         }
     }
 
@@ -816,10 +818,10 @@ impl Storage for StorageBridge {
             .await
         {
             Ok(StorageWorkerResponse::PortfolioBalances(balances)) => Ok(balances),
-            Ok(other) => Err(Error::Other(format!(
+            Ok(other) => Err(Error::Other(anyhow::anyhow!(
                 "unexpected storage response loading portfolio balances: {other:?}"
             ))),
-            Err(e) => Err(Error::Other(e.to_string())),
+            Err(e) => Err(Error::Other(e)),
         }
     }
 
@@ -836,10 +838,10 @@ impl Storage for StorageBridge {
             .await
         {
             Ok(StorageWorkerResponse::UserNotes(notes)) => Ok(notes),
-            Ok(other) => Err(Error::Other(format!(
+            Ok(other) => Err(Error::Other(anyhow::anyhow!(
                 "unexpected storage response loading user notes: {other:?}"
             ))),
-            Err(e) => Err(Error::Other(e.to_string())),
+            Err(e) => Err(Error::Other(e)),
         }
     }
 
@@ -860,10 +862,10 @@ impl Storage for StorageBridge {
             .await
         {
             Ok(StorageWorkerResponse::OperationalFeed(list)) => Ok(list),
-            Ok(other) => Err(Error::Other(format!(
+            Ok(other) => Err(Error::Other(anyhow::anyhow!(
                 "unexpected storage response loading operational feed: {other:?}"
             ))),
-            Err(e) => Err(Error::Other(e.to_string())),
+            Err(e) => Err(Error::Other(e)),
         }
     }
 
@@ -883,10 +885,10 @@ impl Storage for StorageBridge {
             .await
         {
             Ok(StorageWorkerResponse::RecipientLookup(lookup)) => Ok(lookup),
-            Ok(other) => Err(Error::Other(format!(
+            Ok(other) => Err(Error::Other(anyhow::anyhow!(
                 "unexpected storage response looking up recipient: {other:?}"
             ))),
-            Err(e) => Err(Error::Other(e.to_string())),
+            Err(e) => Err(Error::Other(e)),
         }
     }
 
@@ -899,10 +901,10 @@ impl Storage for StorageBridge {
             Ok(StorageWorkerResponse::AspMembershipSync(status)) => {
                 Err(Error::MembershipSync(status))
             }
-            Ok(other) => Err(Error::Other(format!(
+            Ok(other) => Err(Error::Other(anyhow::anyhow!(
                 "unexpected storage response building transact params: {other:?}"
             ))),
-            Err(e) => Err(Error::Other(e.to_string())),
+            Err(e) => Err(Error::Other(e)),
         }
     }
 
@@ -918,18 +920,18 @@ impl Storage for StorageBridge {
             Ok(StorageWorkerResponse::AspMembershipSync(status)) => {
                 Err(Error::MembershipSync(status))
             }
-            Ok(other) => Err(Error::Other(format!(
+            Ok(other) => Err(Error::Other(anyhow::anyhow!(
                 "unexpected storage response building disclosure inputs: {other:?}"
             ))),
-            Err(e) => Err(Error::Other(e.to_string())),
+            Err(e) => Err(Error::Other(e)),
         }
     }
 
     async fn user_keys(&self, user_address: &str) -> Result<StoredUserKeys, Error> {
         let _ = user_address;
-        Err(Error::Other(
-            "full stored user keys are not available on the storage bridge; use asp_secret".into(),
-        ))
+        Err(Error::Other(anyhow::anyhow!(
+            "full stored user keys are not available on the storage bridge; use asp_secret"
+        )))
     }
 
     async fn asp_secret(&self, user_address: &str) -> Result<Field, Error> {
@@ -941,12 +943,14 @@ impl Storage for StorageBridge {
             .await
         {
             Ok(StorageWorkerResponse::AspSecret(secret)) => secret
-                .ok_or_else(|| Error::Other("ASP secret not found in worker storage".into()))
+                .ok_or_else(|| {
+                    Error::Other(anyhow::anyhow!("ASP secret not found in worker storage"))
+                })
                 .map(|asp| asp.membership_blinding),
-            Ok(other) => Err(Error::Other(format!(
+            Ok(other) => Err(Error::Other(anyhow::anyhow!(
                 "unexpected storage response loading ASP secret: {other:?}"
             ))),
-            Err(e) => Err(Error::Other(e.to_string())),
+            Err(e) => Err(Error::Other(e)),
         }
     }
 
@@ -962,14 +966,15 @@ impl Storage for StorageBridge {
             .await
         {
             Ok(StorageWorkerResponse::UserKeys(keys)) => {
-                let keys = keys
-                    .ok_or_else(|| Error::Other("user keys not found in worker storage".into()))?;
+                let keys = keys.ok_or_else(|| {
+                    Error::Other(anyhow::anyhow!("user keys not found in worker storage"))
+                })?;
                 Ok((keys.note_keypair.public, keys.encryption_keypair.public))
             }
-            Ok(other) => Err(Error::Other(format!(
+            Ok(other) => Err(Error::Other(anyhow::anyhow!(
                 "unexpected storage response loading user keys: {other:?}"
             ))),
-            Err(e) => Err(Error::Other(e.to_string())),
+            Err(e) => Err(Error::Other(e)),
         }
     }
 
@@ -994,17 +999,17 @@ impl Storage for StorageBridge {
         {
             Ok(StorageWorkerResponse::RecipientLookup(lookup)) => {
                 let entry = lookup.entry.ok_or_else(|| {
-                    Error::Other(format!(
+                    Error::Other(anyhow::anyhow!(
                         "recipient {address} not found in the public key registry; \
                          they must register keys on-chain"
                     ))
                 })?;
                 Ok((entry.note_key, entry.encryption_key))
             }
-            Ok(other) => Err(Error::Other(format!(
+            Ok(other) => Err(Error::Other(anyhow::anyhow!(
                 "unexpected storage response looking up recipient: {other:?}"
             ))),
-            Err(e) => Err(Error::Other(e.to_string())),
+            Err(e) => Err(Error::Other(e)),
         }
     }
 
@@ -1026,10 +1031,10 @@ impl Storage for StorageBridge {
             .await
         {
             Ok(StorageWorkerResponse::PoolGvkEvents(events)) => Ok(events),
-            Ok(other) => Err(Error::Other(format!(
+            Ok(other) => Err(Error::Other(anyhow::anyhow!(
                 "unexpected storage response listing pool gvk events: {other:?}"
             ))),
-            Err(e) => Err(Error::Other(e.to_string())),
+            Err(e) => Err(Error::Other(e)),
         }
     }
 
@@ -1049,10 +1054,10 @@ impl Storage for StorageBridge {
             .await
         {
             Ok(StorageWorkerResponse::PoolHasCommitments(found)) => Ok(found.into_iter().collect()),
-            Ok(other) => Err(Error::Other(format!(
+            Ok(other) => Err(Error::Other(anyhow::anyhow!(
                 "unexpected storage response verifying pool commitments: {other:?}"
             ))),
-            Err(e) => Err(Error::Other(e.to_string())),
+            Err(e) => Err(Error::Other(e)),
         }
     }
 }


### PR DESCRIPTION
Initial efforts to improve SDK error handling (#394).
While the goal is to decrease the use of strings and anyhow use throughout the library, and type most instances, the conversion from `String` to `anyhow::Error` in this PR makes a small incremental improvement: anyhow can at least preserve the full error chain.

Further changes to come in the stack.