### PR TITLE
Extend storage TTL on every contract call

### DIFF
--- a/contracts/asp-membership/src/lib.rs
+++ b/contracts/asp-membership/src/lib.rs
@@ -8,7 +8,7 @@
 use soroban_sdk::{
     Address, Env, U256, Vec, contract, contracterror, contractevent, contractimpl, contracttype,
 };
-use soroban_utils::{get_zeroes, poseidon2_compress};
+use soroban_utils::{bump_entry, bump_instance, get_zeroes, poseidon2_compress};
 
 /// Storage keys for contract persistent data
 #[contracttype]
@@ -120,6 +120,7 @@ impl ASPMembership {
     /// Returns [`Error::NotInitialized`] if the contract has no admin address
     /// stored.
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
+        bump_instance(&env);
         soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin)
             .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
     }
@@ -134,12 +135,15 @@ impl ASPMembership {
     /// # Returns
     /// The current Merkle root as U256
     ///
-    /// # Panics
-    /// Panics if the contract has not been initialized
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if no root is stored.
     pub fn get_root(env: Env) -> Result<U256, Error> {
+        bump_instance(&env);
         env.storage()
             .persistent()
             .get(&DataKey::Root)
+            .inspect(|_| bump_entry(&env, &DataKey::Root))
             .ok_or(Error::NotInitialized)
     }
 
@@ -156,6 +160,7 @@ impl ASPMembership {
     /// # Returns
     /// The Poseidon2 hash result as U256
     pub fn hash_pair(env: &Env, left: U256, right: U256) -> U256 {
+        bump_instance(env);
         poseidon2_compress(env, left, right)
     }
 
@@ -177,14 +182,18 @@ impl ASPMembership {
     /// [`Error::MerkleTreeFull`] if the tree is at capacity, and
     /// [`Error::Overflow`] if the next leaf index would exceed `u64::MAX`.
     pub fn insert_leaf(env: Env, leaf: U256) -> Result<(), Error> {
+        bump_instance(&env);
         let store = env.storage().persistent();
         let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
+        bump_entry(&env, &DataKey::Admin);
         admin.require_auth();
 
         let levels: u32 = store.get(&DataKey::Levels).ok_or(Error::NotInitialized)?;
+        bump_entry(&env, &DataKey::Levels);
         let actual_index: u64 = store
             .get(&DataKey::NextIndex)
             .ok_or(Error::NotInitialized)?;
+        bump_entry(&env, &DataKey::NextIndex);
         let mut current_index = actual_index;
 
         // Check if tree is full (capacity is 2^levels leaves)
@@ -196,18 +205,19 @@ impl ASPMembership {
         // Update tree by recomputing hashes along the path to root
         for lvl in 0..levels {
             let is_right = current_index & 1 == 1;
+            let subtree_key = DataKey::FilledSubtrees(lvl);
             if is_right {
                 // Leaf is right child, get the stored left sibling
-                let left: U256 = store
-                    .get(&DataKey::FilledSubtrees(lvl))
-                    .ok_or(Error::NotInitialized)?;
+                let left: U256 = store.get(&subtree_key).ok_or(Error::NotInitialized)?;
+                bump_entry(&env, &subtree_key);
                 current_hash = poseidon2_compress(&env, left, current_hash);
             } else {
                 // Leaf is left child, store it and pair with zero hash
-                store.set(&DataKey::FilledSubtrees(lvl), &current_hash);
-                let zero_val: U256 = store
-                    .get(&DataKey::Zeroes(lvl))
-                    .ok_or(Error::NotInitialized)?;
+                store.set(&subtree_key, &current_hash);
+                bump_entry(&env, &subtree_key);
+                let zero_key = DataKey::Zeroes(lvl);
+                let zero_val: U256 = store.get(&zero_key).ok_or(Error::NotInitialized)?;
+                bump_entry(&env, &zero_key);
                 current_hash = poseidon2_compress(&env, current_hash, zero_val);
             }
             current_index >>= 1;
@@ -215,6 +225,7 @@ impl ASPMembership {
 
         // Update the root with the computed hash
         store.set(&DataKey::Root, &current_hash);
+        bump_entry(&env, &DataKey::Root);
 
         // Emit event with leaf details
         LeafAddedEvent {

--- a/contracts/asp-membership/src/test.rs
+++ b/contracts/asp-membership/src/test.rs
@@ -6,10 +6,14 @@ use ark_ff::{BigInteger, PrimeField};
 use core::ops::Add;
 use num_bigint::BigUint;
 use soroban_sdk::{
-    Address, Bytes, Env, IntoVal, U256, Vec,
-    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, Bytes, Env, IntoVal, U256, Val, Vec,
+    testutils::{
+        Address as _, Ledger as _, MockAuth, MockAuthInvoke,
+        storage::{Instance as _, Persistent as _},
+    },
     vec,
 };
+use soroban_utils::ttl::{EXTEND_TO, THRESHOLD};
 use taceo_poseidon2::bn254::t2;
 
 /// Create a test environment that disables snapshot writing under Miri.
@@ -665,4 +669,88 @@ fn test_leaf_added_event_exact_shape() {
     }
     .to_xdr(&env, &contract_id);
     assert_eq!(events.events()[0], expected);
+}
+
+fn entry_ttl<K>(env: &Env, contract: &Address, key: &K) -> u32
+where
+    K: IntoVal<Env, Val>,
+{
+    env.as_contract(contract, || env.storage().persistent().get_ttl(key))
+}
+
+fn instance_ttl(env: &Env, contract: &Address) -> u32 {
+    env.as_contract(contract, || env.storage().instance().get_ttl())
+}
+
+/// Advances the ledger far enough that every entry sitting at [`EXTEND_TO`]
+/// drops below [`THRESHOLD`], so a later bump is visible as a jump back up.
+fn decay_below_threshold(env: &Env) {
+    let target = env
+        .ledger()
+        .sequence()
+        .saturating_add(EXTEND_TO.saturating_sub(THRESHOLD).saturating_add(1));
+    env.ledger().set_sequence_number(target);
+}
+
+#[test]
+fn test_insert_leaf_extends_touched_entries() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+
+    client.insert_leaf(&U256::from_u32(&env, 1));
+
+    assert_eq!(instance_ttl(&env, &contract_id), EXTEND_TO);
+    for key in [
+        DataKey::Root,
+        DataKey::NextIndex,
+        DataKey::FilledSubtrees(0),
+        DataKey::Zeroes(1),
+    ] {
+        assert_eq!(
+            entry_ttl(&env, &contract_id, &key),
+            EXTEND_TO,
+            "{key:?} should have been extended"
+        );
+    }
+}
+
+#[test]
+fn test_get_root_extends_root_and_instance() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+
+    client.get_root();
+
+    assert_eq!(instance_ttl(&env, &contract_id), EXTEND_TO);
+    assert_eq!(entry_ttl(&env, &contract_id, &DataKey::Root), EXTEND_TO);
+}
+
+/// A refused insertion rolls back its storage changes, and a TTL extension is
+/// one of them, so a full tree does not keep paying rent on failed calls.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn test_full_tree_insert_fails_without_extending() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 1u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+
+    client.insert_leaf(&U256::from_u32(&env, 1));
+    client.insert_leaf(&U256::from_u32(&env, 2));
+    decay_below_threshold(&env);
+    let before = entry_ttl(&env, &contract_id, &DataKey::NextIndex);
+
+    let err = client
+        .try_insert_leaf(&U256::from_u32(&env, 3))
+        .expect_err("a full tree must refuse a third leaf");
+
+    assert_eq!(err, Ok(Error::MerkleTreeFull));
+    assert_ne!(before, EXTEND_TO);
+    assert_eq!(entry_ttl(&env, &contract_id, &DataKey::NextIndex), before);
 }

--- a/contracts/asp-non-membership/src/lib.rs
+++ b/contracts/asp-non-membership/src/lib.rs
@@ -27,7 +27,7 @@ use soroban_sdk::{
     Address, Env, U256, Vec, contract, contracterror, contractevent, contractimpl, contracttype,
     vec,
 };
-use soroban_utils::{poseidon2_compress, poseidon2_hash2};
+use soroban_utils::{bump_entry, bump_instance, poseidon2_compress, poseidon2_hash2};
 #[contracttype]
 #[derive(Clone, Debug)]
 enum DataKey {
@@ -125,6 +125,7 @@ impl ASPNonMembership {
     /// Returns [`Error::NotInitialized`] if the contract has no admin address
     /// stored.
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
+        bump_instance(&env);
         soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin)
             .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
     }
@@ -242,6 +243,7 @@ impl ASPNonMembership {
         // Get node from storage
         let node_key = DataKey::Node(root.clone());
         let node_data: Vec<U256> = store.get(&node_key).ok_or(Error::KeyNotFound)?;
+        bump_entry(env, &node_key);
 
         // Check if it's a leaf node (3 elements: [1, key, value])
         if node_data.len() == 3
@@ -333,9 +335,11 @@ impl ASPNonMembership {
     /// * `Error::KeyNotFound` - Database operations failed or invalid node
     ///   structure
     pub fn find_key(env: Env, key: U256) -> Result<FindResult, Error> {
+        bump_instance(&env);
         let store = env.storage().persistent();
         let root: U256 = store
             .get(&DataKey::Root)
+            .inspect(|_| bump_entry(&env, &DataKey::Root))
             .unwrap_or(U256::from_u32(&env, 0u32));
         let key_bits = Self::split_bits(&env, &key);
         Self::find_key_internal(&env, &store, &key, &key_bits, &root, 0u32)
@@ -365,12 +369,15 @@ impl ASPNonMembership {
     /// * `Error::KeyNotFound` - Database operations failed
     #[allow(clippy::cast_possible_truncation)]
     pub fn insert_leaf(env: Env, key: U256, value: U256) -> Result<(), Error> {
+        bump_instance(&env);
         let store = env.storage().persistent();
         let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
+        bump_entry(&env, &DataKey::Admin);
         admin.require_auth();
 
         let root: U256 = store
             .get(&DataKey::Root)
+            .inspect(|_| bump_entry(&env, &DataKey::Root))
             .unwrap_or(U256::from_u32(&env, 0u32));
 
         // Compute key bits
@@ -419,7 +426,9 @@ impl ASPNonMembership {
         // Insert the new leaf
         let mut rt = Self::hash_leaf(&env, key.clone(), value.clone());
         let leaf_node = vec![&env, U256::from_u32(&env, 1u32), key.clone(), value.clone()];
-        store.set(&DataKey::Node(rt.clone()), &leaf_node);
+        let leaf_key = DataKey::Node(rt.clone());
+        store.set(&leaf_key, &leaf_node);
+        bump_entry(&env, &leaf_key);
 
         // Build up the tree from leaf to root (process siblings in reverse)
         // Siblings are stored from root level (index 0) to leaf level (last
@@ -468,7 +477,9 @@ impl ASPNonMembership {
 
             // Store internal node
             let internal_node = vec![&env, left_hash, right_hash];
-            store.set(&DataKey::Node(rt.clone()), &internal_node);
+            let node_key = DataKey::Node(rt.clone());
+            store.set(&node_key, &internal_node);
+            bump_entry(&env, &node_key);
         }
 
         // Remove the temporary sibling if we added one for collision
@@ -522,10 +533,13 @@ impl ASPNonMembership {
     /// * `Error::KeyNotFound` - Key does not exist in the tree or database
     ///   operations failed
     pub fn delete_leaf(env: Env, key: U256) -> Result<(), Error> {
+        bump_instance(&env);
         let store = env.storage().persistent();
         let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
+        bump_entry(&env, &DataKey::Admin);
         admin.require_auth();
         let root: U256 = store.get(&DataKey::Root).ok_or(Error::NotInitialized)?;
+        bump_entry(&env, &DataKey::Root);
 
         // Compute key bits once for both find and delete operations
         let key_bits = Self::split_bits(&env, &key);
@@ -608,7 +622,9 @@ impl ASPNonMembership {
                 // Create and store new internal node
                 rt_new = Self::hash_internal(&env, left_hash.clone(), right_hash.clone());
                 let internal_node = vec![&env, left_hash, right_hash];
-                store.set(&DataKey::Node(rt_new.clone()), &internal_node);
+                let node_key = DataKey::Node(rt_new.clone());
+                store.set(&node_key, &internal_node);
+                bump_entry(&env, &node_key);
             }
         }
 
@@ -654,9 +670,11 @@ impl ASPNonMembership {
         not_found_key: U256,
         not_found_value: U256,
     ) -> Result<bool, Error> {
+        bump_instance(&env);
         let store = env.storage().persistent();
         let root: U256 = store
             .get(&DataKey::Root)
+            .inspect(|_| bump_entry(&env, &DataKey::Root))
             .unwrap_or(U256::from_u32(&env, 0u32));
 
         // Compute key bits once
@@ -733,9 +751,11 @@ impl ASPNonMembership {
     ///
     /// Returns the current root hash as a U256 value, or zero if empty
     pub fn get_root(env: Env) -> Result<U256, Error> {
+        bump_instance(&env);
         env.storage()
             .persistent()
             .get(&DataKey::Root)
+            .inspect(|_| bump_entry(&env, &DataKey::Root))
             .ok_or(Error::NotInitialized)
     }
 }

--- a/contracts/asp-non-membership/src/test.rs
+++ b/contracts/asp-non-membership/src/test.rs
@@ -2,9 +2,14 @@
 
 use super::*;
 use soroban_sdk::{
-    Address, Bytes, Env, IntoVal, U256,
-    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, Bytes, Env, IntoVal, U256, Val, Vec,
+    testutils::{
+        Address as _, Ledger as _, MockAuth, MockAuthInvoke,
+        storage::{Instance as _, Persistent as _},
+    },
+    vec,
 };
+use soroban_utils::ttl::{EXTEND_TO, THRESHOLD};
 
 /// Create a test environment that disables snapshot writing under Miri.
 /// Miri's isolation mode blocks filesystem operations, which the Soroban SDK
@@ -1052,4 +1057,155 @@ fn test_old_admin_cannot_insert_after_update() {
         },
     }]);
     client.insert_leaf(&key, &value);
+}
+
+fn entry_ttl<K>(env: &Env, contract: &Address, key: &K) -> u32
+where
+    K: IntoVal<Env, Val>,
+{
+    env.as_contract(contract, || env.storage().persistent().get_ttl(key))
+}
+
+/// Advances the ledger far enough that every entry sitting at [`EXTEND_TO`]
+/// drops below [`THRESHOLD`], so a later bump is visible as a jump back up.
+fn decay_below_threshold(env: &Env) {
+    let target = env
+        .ledger()
+        .sequence()
+        .saturating_add(EXTEND_TO.saturating_sub(THRESHOLD).saturating_add(1));
+    env.ledger().set_sequence_number(target);
+}
+
+/// Returns the hash of every node reachable from the stored root, walking the
+/// tree the way a proof consumer does and failing if a reachable child was
+/// removed.
+fn reachable_nodes(env: &Env, contract: &Address) -> Vec<U256> {
+    env.as_contract(contract, || {
+        let store = env.storage().persistent();
+        let zero = U256::from_u32(env, 0u32);
+        let root: U256 = store.get(&DataKey::Root).expect("Root set in constructor");
+        let mut pending = vec![env, root];
+        let mut seen = Vec::new(env);
+        while let Some(hash) = pending.pop_back() {
+            if hash == zero {
+                continue;
+            }
+            let node: Vec<U256> = store
+                .get(&DataKey::Node(hash.clone()))
+                .expect("a reachable node is still stored");
+            seen.push_back(hash);
+            if node.len() == 2 {
+                pending.push_back(node.get(0).expect("internal node has a left child"));
+                pending.push_back(node.get(1).expect("internal node has a right child"));
+            }
+        }
+        seen
+    })
+}
+
+#[test]
+fn test_insert_leaf_extends_touched_nodes() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+
+    // Keys 1 and 3 share their lowest bit, so the second insertion deepens the
+    // tree rather than replacing a single leaf root.
+    client.insert_leaf(&U256::from_u32(&env, 1u32), &U256::from_u32(&env, 10u32));
+    client.insert_leaf(&U256::from_u32(&env, 3u32), &U256::from_u32(&env, 30u32));
+
+    let nodes = reachable_nodes(&env, &contract_id);
+    assert_eq!(nodes.len(), 4, "a root, one internal node, and two leaves");
+    for hash in nodes.iter() {
+        let key = DataKey::Node(hash);
+        assert_eq!(
+            entry_ttl(&env, &contract_id, &key),
+            EXTEND_TO,
+            "{key:?} should have been extended"
+        );
+    }
+}
+
+#[test]
+fn test_delete_leaf_extends_rebuilt_nodes() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+
+    for key in 1u32..=3 {
+        client.insert_leaf(&U256::from_u32(&env, key), &U256::from_u32(&env, 10u32));
+    }
+
+    client.delete_leaf(&U256::from_u32(&env, 2u32));
+
+    let nodes = reachable_nodes(&env, &contract_id);
+    assert_eq!(nodes.len(), 4, "a root, one internal node, and two leaves");
+    for hash in nodes.iter() {
+        let key = DataKey::Node(hash);
+        assert_eq!(
+            entry_ttl(&env, &contract_id, &key),
+            EXTEND_TO,
+            "{key:?} should have been extended"
+        );
+    }
+}
+
+/// A blocklist pool reads this root cross-contract on every `transact`, so it
+/// must come off the seven-day fuse with the tree it heads.
+#[test]
+fn test_get_root_extends_root_and_instance() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+
+    client.get_root();
+
+    let instance = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
+    assert_eq!(instance, EXTEND_TO);
+    assert_eq!(entry_ttl(&env, &contract_id, &DataKey::Root), EXTEND_TO);
+}
+
+#[test]
+fn test_find_key_extends_the_path_it_reads() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+
+    // Keys 1 and 2 differ in their lowest bit, so the root holds one leaf under
+    // each branch and a lookup for key 1 reads only the right one.
+    client.insert_leaf(&U256::from_u32(&env, 1u32), &U256::from_u32(&env, 10u32));
+    client.insert_leaf(&U256::from_u32(&env, 2u32), &U256::from_u32(&env, 20u32));
+    let (root, children): (U256, Vec<U256>) = env.as_contract(&contract_id, || {
+        let store = env.storage().persistent();
+        let root: U256 = store.get(&DataKey::Root).expect("Root set after inserts");
+        let children = store
+            .get(&DataKey::Node(root.clone()))
+            .expect("the root node is stored");
+        (root, children)
+    });
+    let off_path = children.get(0).expect("the left branch holds key 2");
+    let on_path = children.get(1).expect("the right branch holds key 1");
+    decay_below_threshold(&env);
+
+    client.find_key(&U256::from_u32(&env, 1u32));
+
+    assert_eq!(
+        entry_ttl(&env, &contract_id, &DataKey::Node(root)),
+        EXTEND_TO
+    );
+    assert_eq!(
+        entry_ttl(&env, &contract_id, &DataKey::Node(on_path)),
+        EXTEND_TO
+    );
+    assert_ne!(
+        entry_ttl(&env, &contract_id, &DataKey::Node(off_path)),
+        EXTEND_TO
+    );
 }

--- a/contracts/pool-core/src/merkle_with_history.rs
+++ b/contracts/pool-core/src/merkle_with_history.rs
@@ -12,7 +12,7 @@
 //! these functions.
 
 use soroban_sdk::{Env, U256, Vec, contracttype};
-use soroban_utils::{get_zeroes, poseidon2_compress};
+use soroban_utils::{bump_entry, get_zeroes, poseidon2_compress};
 
 /// Number of roots kept in history for proof verification
 const ROOT_HISTORY_SIZE: u32 = 90;
@@ -125,12 +125,15 @@ impl MerkleTreeWithHistory {
         let levels: u32 = storage
             .get(&MerkleDataKey::Levels)
             .ok_or(Error::NotInitialized)?;
+        bump_entry(env, &MerkleDataKey::Levels);
         let next_index: u64 = storage
             .get(&MerkleDataKey::NextIndex)
             .ok_or(Error::NotInitialized)?;
+        bump_entry(env, &MerkleDataKey::NextIndex);
         let mut root_index: u32 = storage
             .get(&MerkleDataKey::CurrentRootIndex)
             .ok_or(Error::NotInitialized)?;
+        bump_entry(env, &MerkleDataKey::CurrentRootIndex);
         let max_leaves = 1u64.checked_shl(levels).ok_or(Error::WrongLevels)?;
 
         // NextIndex must be even for two-leaf insertion
@@ -154,18 +157,19 @@ impl MerkleTreeWithHistory {
         // leaves
         for lvl in 1..levels {
             let is_right = current_index & 1 == 1;
+            let subtree_key = MerkleDataKey::FilledSubtree(lvl);
             if is_right {
                 // Leaf is right child, get the stored left sibling
-                let left: U256 = storage
-                    .get(&MerkleDataKey::FilledSubtree(lvl))
-                    .ok_or(Error::NotInitialized)?;
+                let left: U256 = storage.get(&subtree_key).ok_or(Error::NotInitialized)?;
+                bump_entry(env, &subtree_key);
                 current_hash = poseidon2_compress(env, left, current_hash);
             } else {
                 // Leaf is left child, store it and pair with zero hash
-                storage.set(&MerkleDataKey::FilledSubtree(lvl), &current_hash);
-                let zero_val: U256 = storage
-                    .get(&MerkleDataKey::Zeroes(lvl))
-                    .ok_or(Error::NotInitialized)?;
+                storage.set(&subtree_key, &current_hash);
+                bump_entry(env, &subtree_key);
+                let zero_key = MerkleDataKey::Zeroes(lvl);
+                let zero_val: U256 = storage.get(&zero_key).ok_or(Error::NotInitialized)?;
+                bump_entry(env, &zero_key);
                 current_hash = poseidon2_compress(env, current_hash, zero_val);
             }
             current_index >>= 1;
@@ -174,7 +178,9 @@ impl MerkleTreeWithHistory {
         // Update the root history index
         root_index = root_index.checked_add(1).ok_or(Error::Overflow)? % ROOT_HISTORY_SIZE;
         // Update the root with the computed hash
-        storage.set(&MerkleDataKey::Root(root_index), &current_hash);
+        let root_key = MerkleDataKey::Root(root_index);
+        storage.set(&root_key, &current_hash);
+        bump_entry(env, &root_key);
         storage.set(&MerkleDataKey::CurrentRootIndex, &root_index);
 
         // Update NextIndex
@@ -217,14 +223,17 @@ impl MerkleTreeWithHistory {
         let current_root_index: u32 = storage
             .get(&MerkleDataKey::CurrentRootIndex)
             .ok_or(Error::NotInitialized)?;
+        bump_entry(env, &MerkleDataKey::CurrentRootIndex);
 
         // Search the ring buffer for the root
         let mut i = current_root_index;
         loop {
             // roots[i]
-            if let Some(r) = storage.get::<MerkleDataKey, U256>(&MerkleDataKey::Root(i))
+            let root_key = MerkleDataKey::Root(i);
+            if let Some(r) = storage.get::<MerkleDataKey, U256>(&root_key)
                 && &r == root
             {
+                bump_entry(env, &root_key);
                 return Ok(true);
             }
             i = i.checked_add(1).ok_or(Error::Overflow)? % ROOT_HISTORY_SIZE;
@@ -252,10 +261,12 @@ impl MerkleTreeWithHistory {
         let current_root_index: u32 = storage
             .get(&MerkleDataKey::CurrentRootIndex)
             .ok_or(Error::NotInitialized)?;
+        bump_entry(env, &MerkleDataKey::CurrentRootIndex);
 
-        storage
-            .get(&MerkleDataKey::Root(current_root_index))
-            .ok_or(Error::NotInitialized)
+        let root_key = MerkleDataKey::Root(current_root_index);
+        let root = storage.get(&root_key).ok_or(Error::NotInitialized)?;
+        bump_entry(env, &root_key);
+        Ok(root)
     }
 
     /// Hash two U256 values using Poseidon2 compression

--- a/contracts/pool-gvk/src/pool_gvk.rs
+++ b/contracts/pool-gvk/src/pool_gvk.rs
@@ -24,7 +24,7 @@ use soroban_sdk::{
     Address, Bytes, BytesN, Env, I256, U256, Vec, contract, contracterror, contractevent,
     contractimpl, contracttype, crypto::bn254::Bn254Fr, token::TokenClient,
 };
-use soroban_utils::constants::bn256_modulus;
+use soroban_utils::{bump_dependency, bump_entry, bump_instance, constants::bn256_modulus};
 
 // Re-exported rather than merely imported so `pool_gvk::ExtData` and
 // `pool_gvk::hash_ext_data` stay part of this crate's surface, mirroring
@@ -284,22 +284,23 @@ impl PoolGvkContract {
     /// input and is published in every proof, so it is not secret. There is
     /// no corresponding setter — see [`DataKey::AdminViewKey`].
     pub fn get_admin_view_key(env: &Env) -> Result<BabyJubJubPoint, Error> {
+        Self::touch(env);
         env.storage()
             .persistent()
             .get(&DataKey::AdminViewKey)
+            .inspect(|_| bump_entry(env, &DataKey::AdminViewKey))
             .ok_or(Error::NotInitialized)
     }
 
     /// Get the Global View Key mode (`gvk::VIEW_ONLY` or `gvk::TRACEABLE`).
     pub fn get_gvk_mode(env: &Env) -> Result<u32, Error> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::GvkMode)
-            .ok_or(Error::NotInitialized)
+        Self::touch(env);
+        Self::load_gvk_mode(env)
     }
 
     /// Get the pool's ASP policy flags.
     pub fn get_policy_flags(env: &Env) -> Result<u32, Error> {
+        Self::touch(env);
         Self::load_policy_flags(env)
     }
 
@@ -307,16 +308,19 @@ impl PoolGvkContract {
         env.storage()
             .persistent()
             .get(&DataKey::PolicyFlags)
+            .inspect(|_| bump_entry(env, &DataKey::PolicyFlags))
             .ok_or(Error::NotInitialized)
     }
 
     /// Get the latest root of the Merkle tree that defines the pool.
     pub fn get_root(env: &Env) -> Result<U256, Error> {
+        Self::touch(env);
         Ok(MerkleTreeWithHistory::get_last_root(env)?)
     }
 
     /// Check whether a pool Merkle root is still in the recent root history.
     pub fn is_known_root(env: &Env, root: &U256) -> Result<bool, Error> {
+        Self::touch(env);
         Ok(MerkleTreeWithHistory::is_known_root(env, root)?)
     }
 
@@ -324,8 +328,13 @@ impl PoolGvkContract {
     ///
     /// Presence of the per-nullifier storage key is the spent flag.
     pub fn is_spent(env: &Env, n: &U256) -> Result<bool, Error> {
+        Self::touch(env);
         let key = DataKey::Nullifier(n.clone());
-        Ok(env.storage().persistent().has(&key))
+        let spent = env.storage().persistent().has(&key);
+        if spent {
+            bump_entry(env, &key);
+        }
+        Ok(spent)
     }
 
     /// Update the contract administrator. Requires authorization from the
@@ -336,6 +345,7 @@ impl PoolGvkContract {
     /// Returns [`Error::NotInitialized`] if the contract has no admin address
     /// stored.
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
+        Self::touch(&env);
         soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin)
             .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
     }
@@ -353,6 +363,7 @@ impl PoolGvkContract {
         env.storage()
             .persistent()
             .get(&DataKey::ASPMembership)
+            .inspect(|_| bump_entry(env, &DataKey::ASPMembership))
             .ok_or(Error::NotInitialized)
     }
 
@@ -361,11 +372,13 @@ impl PoolGvkContract {
         env.storage()
             .persistent()
             .get(&DataKey::ASPNonMembership)
+            .inspect(|_| bump_entry(env, &DataKey::ASPNonMembership))
             .ok_or(Error::NotInitialized)
     }
 
     /// Get the current Merkle root from the ASP Membership contract.
     pub fn get_asp_membership_root(env: &Env) -> Result<U256, Error> {
+        Self::touch(env);
         let asp_address = Self::get_asp_membership(env)?;
         let client = ASPMembershipClient::new(env, &asp_address);
         Ok(client.get_root())
@@ -373,6 +386,7 @@ impl PoolGvkContract {
 
     /// Get the current Merkle root from the ASP Non-Membership contract.
     pub fn get_asp_non_membership_root(env: &Env) -> Result<U256, Error> {
+        Self::touch(env);
         let asp_address = Self::get_asp_non_membership(env)?;
         let client = ASPNonMembershipClient::new(env, &asp_address);
         Ok(client.get_root())
@@ -383,6 +397,7 @@ impl PoolGvkContract {
         env.storage()
             .persistent()
             .get(&DataKey::Token)
+            .inspect(|_| bump_entry(env, &DataKey::Token))
             .ok_or(Error::NotInitialized)
     }
 
@@ -391,6 +406,7 @@ impl PoolGvkContract {
         env.storage()
             .persistent()
             .get(&DataKey::MaximumDepositAmount)
+            .inspect(|_| bump_entry(env, &DataKey::MaximumDepositAmount))
             .ok_or(Error::NotInitialized)
     }
 
@@ -399,7 +415,16 @@ impl PoolGvkContract {
         env.storage()
             .persistent()
             .get(&DataKey::Verifier)
+            .inspect(|_| bump_entry(env, &DataKey::Verifier))
             .ok_or(Error::NotInitialized)
+    }
+
+    /// Extends the TTL of this contract's instance and code entries.
+    ///
+    /// Every public entry point calls this first, so a pool that keeps being
+    /// used never falls behind on rent.
+    fn touch(env: &Env) {
+        bump_instance(env);
     }
 
     /// Convert a non-negative I256 to i128 with bounds checking.
@@ -418,6 +443,7 @@ impl PoolGvkContract {
     fn mark_spent(env: &Env, n: &U256) -> Result<(), Error> {
         let key = DataKey::Nullifier(n.clone());
         env.storage().persistent().set(&key, &());
+        bump_entry(env, &key);
         Ok(())
     }
 
@@ -603,6 +629,7 @@ impl PoolGvkContract {
         env.storage()
             .persistent()
             .get(&DataKey::GvkMode)
+            .inspect(|_| bump_entry(env, &DataKey::GvkMode))
             .ok_or(Error::NotInitialized)
     }
 
@@ -616,7 +643,16 @@ impl PoolGvkContract {
         ext_data: ExtData,
         sender: Address,
     ) -> Result<(), Error> {
+        Self::touch(env);
         sender.require_auth();
+        bump_dependency(env, &Self::get_verifier(env)?);
+        let policy_flags = Self::load_policy_flags(env)?;
+        if policy::requires_membership_proofs(policy_flags) {
+            bump_dependency(env, &Self::get_asp_membership(env)?);
+        }
+        if policy::requires_non_membership_proofs(policy_flags) {
+            bump_dependency(env, &Self::get_asp_non_membership(env)?);
+        }
         let token = Self::get_token(env)?;
         let token_client = TokenClient::new(env, &token);
         let zero = I256::from_i32(env, 0);
@@ -632,13 +668,18 @@ impl PoolGvkContract {
             token_client.transfer(&sender, &this, &amount);
         }
 
-        Self::internal_transact(env, proof, ext_data)
+        Self::internal_transact(env, proof, ext_data, policy_flags)
     }
 
     /// Process a private transaction: validates the proof and all public
     /// inputs, marks nullifiers as spent, processes withdrawals, and inserts
     /// new commitments into the Merkle tree.
-    fn internal_transact(env: &Env, proof: Proof, ext_data: ExtData) -> Result<(), Error> {
+    fn internal_transact(
+        env: &Env,
+        proof: Proof,
+        ext_data: ExtData,
+        policy_flags: u32,
+    ) -> Result<(), Error> {
         // 1. Merkle root check
         if !MerkleTreeWithHistory::is_known_root(env, &proof.root)? {
             return Err(Error::UnknownRoot);
@@ -675,7 +716,6 @@ impl PoolGvkContract {
         }
 
         // ASP root validation
-        let policy_flags = Self::load_policy_flags(env)?;
         if policy::requires_non_membership_proofs(policy_flags) {
             let non_member_root = Self::get_asp_non_membership_root(env)?;
             if non_member_root != proof.asp_non_membership_root {

--- a/contracts/pool-gvk/src/test.rs
+++ b/contracts/pool-gvk/src/test.rs
@@ -20,12 +20,19 @@ use asp_non_membership::{ASPNonMembership, ASPNonMembershipClient};
 use circom_groth16_verifier::{CircomGroth16Verifier, Groth16Proof};
 use contract_types::VerificationKeyBytes;
 use soroban_sdk::{
-    Address, Bytes, BytesN, Env, I256, U256, Vec, contract, contractimpl,
+    Address, Bytes, BytesN, Env, I256, IntoVal, U256, Val, Vec, contract, contractimpl,
     crypto::bn254::{Bn254G1Affine as G1Affine, Bn254G2Affine as G2Affine},
-    testutils::{Address as _, Events},
+    testutils::{
+        Address as _, Events, Ledger as _,
+        storage::{Instance as _, Persistent as _},
+    },
     xdr::ToXdr,
 };
-use soroban_utils::{constants::bn256_modulus, utils::MockToken};
+use soroban_utils::{
+    constants::bn256_modulus,
+    ttl::{EXTEND_TO, THRESHOLD},
+    utils::MockToken,
+};
 
 /// Number of levels for the ASP Membership Merkle tree in tests
 const ASP_MEMBERSHIP_LEVELS: u32 = 8;
@@ -1466,13 +1473,14 @@ fn ark_fr_from_bytesn32(v: &BytesN<32>) -> ArkFr {
 
 /// Independently mirrors `PoolGvkContract::verify_proof`'s public-input
 /// assembly order (ciphertext tail first, then `D, nonce, root,
-/// publicAmount, extDataHash, inputNullifier[], outputCommitment[]` — no ASP
-/// roots, since every test using this helper registers with `policy_flags =
-/// 0`) so the toy-circuit fixture and the real contract call are checked
-/// against the same sequence without one implementation calling the other.
+/// publicAmount, extDataHash, inputNullifier[], outputCommitment[]`, then one
+/// ASP root per input nullifier for each policy bit `policy_flags` sets) so
+/// the toy-circuit fixture and the real contract call are checked against the
+/// same sequence without one implementation calling the other.
 fn expected_ark_public_inputs(
     proof: &Proof,
     admin_view_key: &BabyJubJubPoint,
+    policy_flags: u32,
 ) -> alloc::vec::Vec<ArkFr> {
     let mut ciphertexts: alloc::vec::Vec<GvkCiphertext> = alloc::vec::Vec::new();
     for ct in proof.input_gvk_ciphertexts.iter() {
@@ -1510,6 +1518,17 @@ fn expected_ark_public_inputs(
     result.push(ark_fr_from_u256(&proof.output_commitment0));
     result.push(ark_fr_from_u256(&proof.output_commitment1));
 
+    if policy::requires_membership_proofs(policy_flags) {
+        for _ in 0..proof.input_nullifiers.len() {
+            result.push(ark_fr_from_u256(&proof.asp_membership_root));
+        }
+    }
+    if policy::requires_non_membership_proofs(policy_flags) {
+        for _ in 0..proof.input_nullifiers.len() {
+            result.push(ark_fr_from_u256(&proof.asp_non_membership_root));
+        }
+    }
+
     result
 }
 
@@ -1522,6 +1541,32 @@ fn build_gvk_transact(
     ext_amount: i32,
     maximum_deposit_amount: u32,
 ) -> (Env, PoolGvkContractClient<'static>, Proof, ExtData, Address) {
+    let f =
+        build_gvk_transact_with_policy(gvk_mode, nullifier, ext_amount, maximum_deposit_amount, 0);
+    (f.env, f.pool, f.proof, f.ext, f.sender)
+}
+
+/// A pool, its verifier, and a ready-to-submit transaction for it.
+struct GvkTransactFixture {
+    env: Env,
+    pool: PoolGvkContractClient<'static>,
+    proof: Proof,
+    ext: ExtData,
+    sender: Address,
+    verifier: Address,
+    setup: TestSetup,
+}
+
+/// Same as [`build_gvk_transact`], additionally taking the pool's ASP policy
+/// flags and handing back the verifier address and the shared contract set, so
+/// a caller can assert on the instances the call is expected to extend.
+fn build_gvk_transact_with_policy(
+    gvk_mode: u32,
+    nullifier: u32,
+    ext_amount: i32,
+    maximum_deposit_amount: u32,
+    policy_flags: u32,
+) -> GvkTransactFixture {
     let env = test_env();
     let setup = setup_test_contracts(&env);
     let admin_view_key = mk_point(&env, 1, 2);
@@ -1563,13 +1608,13 @@ fn build_gvk_transact(
         output_commitment1: U256::from_u32(&env, 0x02),
         public_amount,
         ext_data_hash: ext_hash,
-        asp_membership_root: U256::from_u32(&env, 0),
-        asp_non_membership_root: U256::from_u32(&env, 0),
+        asp_membership_root: setup.asp_membership_client.get_root(),
+        asp_non_membership_root: setup.asp_non_membership_client.get_root(),
         output_gvk_ciphertexts: mk_output_ciphertexts(&env),
         input_gvk_ciphertexts,
     };
 
-    let values = expected_ark_public_inputs(&proof, &admin_view_key);
+    let values = expected_ark_public_inputs(&proof, &admin_view_key, policy_flags);
     let (vk_bytes, real_proof) = groth16_fixture_for(&env, &values);
     proof.proof = real_proof;
 
@@ -1580,12 +1625,12 @@ fn build_gvk_transact(
         (
             setup.admin.clone(),
             setup.token.clone(),
-            verifier_id,
+            verifier_id.clone(),
             setup.asp_membership_address.clone(),
             setup.asp_non_membership_address.clone(),
             U256::from_u32(&env, maximum_deposit_amount),
             levels,
-            0u32,
+            policy_flags,
             admin_view_key,
             gvk_mode,
         ),
@@ -1594,7 +1639,15 @@ fn build_gvk_transact(
     env.mock_all_auths();
     let sender = Address::generate(&env);
 
-    (env, pool, proof, ext, sender)
+    GvkTransactFixture {
+        env,
+        pool,
+        proof,
+        ext,
+        sender,
+        verifier: verifier_id,
+        setup,
+    }
 }
 
 /// Runs a full successful `transact` for `gvk_mode`, using a `TestVerifier`
@@ -1780,4 +1833,175 @@ fn transact_rejects_replayed_nullifier() {
         matches!(second, Err(Ok(Error::AlreadySpentNullifier))),
         "expected replaying the same nullifier to be rejected, got {second:?}"
     );
+}
+
+fn entry_ttl<K>(env: &Env, contract: &Address, key: &K) -> u32
+where
+    K: IntoVal<Env, Val>,
+{
+    env.as_contract(contract, || env.storage().persistent().get_ttl(key))
+}
+
+fn instance_ttl(env: &Env, contract: &Address) -> u32 {
+    env.as_contract(contract, || env.storage().instance().get_ttl())
+}
+
+/// Advances the ledger far enough that every entry sitting at [`EXTEND_TO`]
+/// drops below [`THRESHOLD`], so a later bump is visible as a jump back up.
+fn decay_below_threshold(env: &Env) {
+    let target = env
+        .ledger()
+        .sequence()
+        .saturating_add(EXTEND_TO.saturating_sub(THRESHOLD).saturating_add(1));
+    env.ledger().set_sequence_number(target);
+}
+
+#[test]
+fn transact_extends_instance_config_and_nullifier_ttl() {
+    let nullifier = 0xE5;
+    let (env, pool, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, nullifier, 0, 1000);
+    let pool_id = pool.address.clone();
+
+    pool.transact(&proof, &ext, &sender);
+
+    assert_eq!(instance_ttl(&env, &pool_id), EXTEND_TO);
+    for key in [
+        DataKey::Token,
+        DataKey::PolicyFlags,
+        DataKey::Nullifier(U256::from_u32(&env, nullifier)),
+    ] {
+        assert_eq!(
+            entry_ttl(&env, &pool_id, &key),
+            EXTEND_TO,
+            "{key:?} should have been extended"
+        );
+    }
+}
+
+#[test]
+fn transact_extends_admin_view_key_and_gvk_mode() {
+    let (env, pool, proof, ext, sender) = build_gvk_transact(TRACEABLE, 0xE6, 0, 1000);
+    let pool_id = pool.address.clone();
+
+    pool.transact(&proof, &ext, &sender);
+
+    assert_eq!(entry_ttl(&env, &pool_id, &DataKey::AdminViewKey), EXTEND_TO);
+    assert_eq!(entry_ttl(&env, &pool_id, &DataKey::GvkMode), EXTEND_TO);
+}
+
+#[test]
+fn transact_extends_linked_contract_instances() {
+    let f = build_gvk_transact_with_policy(
+        VIEW_ONLY,
+        0xE7,
+        0,
+        1000,
+        policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
+    );
+    let env = &f.env;
+    // Building the fixture read both ASP roots, which extended their
+    // instances. Decay first: without this the assertions below hold before
+    // `transact` even runs.
+    //
+    // Each ASP instance is reachable by two paths here, `bump_dependency` and
+    // the ASP's own `bump_instance` during the root cross-call, so what this
+    // pins is the invariant that every linked instance survives the call, not
+    // which of the two extended it. The verifier has only the one path.
+    decay_below_threshold(env);
+
+    f.pool.transact(&f.proof, &f.ext, &f.sender);
+
+    assert_eq!(instance_ttl(env, &f.verifier), EXTEND_TO);
+    assert_eq!(
+        instance_ttl(env, &f.setup.asp_membership_address),
+        EXTEND_TO
+    );
+    assert_eq!(
+        instance_ttl(env, &f.setup.asp_non_membership_address),
+        EXTEND_TO
+    );
+}
+
+#[test]
+fn transact_on_an_open_pool_leaves_asp_instances_alone() {
+    let f = build_gvk_transact_with_policy(VIEW_ONLY, 0xE8, 0, 1000, 0);
+    let env = &f.env;
+    // Building the fixture read both ASP roots, which extended their
+    // instances. Decay first, or `membership_before` is already EXTEND_TO and
+    // the assertions below cannot fail.
+    decay_below_threshold(env);
+    let membership_before = instance_ttl(env, &f.setup.asp_membership_address);
+    let non_membership_before = instance_ttl(env, &f.setup.asp_non_membership_address);
+    assert_ne!(membership_before, EXTEND_TO);
+
+    f.pool.transact(&f.proof, &f.ext, &f.sender);
+
+    assert_eq!(instance_ttl(env, &f.verifier), EXTEND_TO);
+    assert_eq!(
+        instance_ttl(env, &f.setup.asp_membership_address),
+        membership_before
+    );
+    assert_eq!(
+        instance_ttl(env, &f.setup.asp_non_membership_address),
+        non_membership_before
+    );
+}
+
+/// A failed invocation rolls back its storage changes, and a TTL extension is
+/// one of them, so the pool pays no rent for a call it refused.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn failed_transact_rolls_back_the_ttl_extension() {
+    let (env, pool, mut proof, ext, sender) = build_gvk_transact(VIEW_ONLY, 0xE9, 0, 1000);
+    let pool_id = pool.address.clone();
+    proof.root = U256::from_u32(&env, 0xFF);
+    let before = instance_ttl(&env, &pool_id);
+
+    let err = pool
+        .try_transact(&proof, &ext, &sender)
+        .expect_err("an unknown root must be refused");
+
+    assert_eq!(err, Ok(Error::UnknownRoot));
+    assert_ne!(before, EXTEND_TO);
+    assert_eq!(instance_ttl(&env, &pool_id), before);
+}
+
+/// The spent check must not extend a nullifier entry that does not exist,
+/// because the host rejects an extension of a missing key.
+#[test]
+fn is_spent_on_an_unknown_nullifier_does_not_panic() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool_gvk(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
+        mk_point(&env, 1, 2),
+        VIEW_ONLY,
+    );
+    let pool = PoolGvkContractClient::new(&env, &pool_id);
+
+    assert!(!pool.is_spent(&U256::from_u32(&env, 0xBEEF)));
+}
+
+#[test]
+fn getters_extend_the_instance() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool_gvk(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
+        mk_point(&env, 1, 2),
+        VIEW_ONLY,
+    );
+    let pool = PoolGvkContractClient::new(&env, &pool_id);
+
+    pool.get_root();
+
+    assert_eq!(instance_ttl(&env, &pool_id), EXTEND_TO);
 }

--- a/contracts/pool/src/pool.rs
+++ b/contracts/pool/src/pool.rs
@@ -23,7 +23,7 @@ use soroban_sdk::{
     Address, Bytes, BytesN, Env, I256, U256, Vec, contract, contracterror, contractevent,
     contractimpl, contracttype, crypto::bn254::Bn254Fr, token::TokenClient,
 };
-use soroban_utils::constants::bn256_modulus;
+use soroban_utils::{bump_dependency, bump_entry, bump_instance, constants::bn256_modulus};
 
 // Re-exported rather than merely imported so `pool::ExtData` and
 // `pool::hash_ext_data` keep resolving for existing consumers (`e2e-tests`,
@@ -225,6 +225,14 @@ impl PoolContract {
         Ok(())
     }
 
+    /// Extends the TTL of this contract's instance and code entries.
+    ///
+    /// Every public entry point calls this first, so a pool that keeps being
+    /// used never falls behind on rent.
+    fn touch(env: &Env) {
+        bump_instance(env);
+    }
+
     /// Convert a non-negative I256 to i128 with bounds checking
     ///
     /// # Arguments
@@ -270,6 +278,7 @@ impl PoolContract {
         let key = DataKey::Nullifier(n.clone());
         // Presence of the key is the spent flag; value is unused.
         env.storage().persistent().set(&key, &());
+        bump_entry(env, &key);
         Ok(())
     }
 
@@ -431,7 +440,16 @@ impl PoolContract {
         ext_data: ExtData,
         sender: Address,
     ) -> Result<(), Error> {
+        Self::touch(env);
         sender.require_auth();
+        bump_dependency(env, &Self::get_verifier(env)?);
+        let policy_flags = Self::load_policy_flags(env)?;
+        if policy::requires_membership_proofs(policy_flags) {
+            bump_dependency(env, &Self::get_asp_membership(env)?);
+        }
+        if policy::requires_non_membership_proofs(policy_flags) {
+            bump_dependency(env, &Self::get_asp_non_membership(env)?);
+        }
         let token = Self::get_token(env)?;
         let token_client = TokenClient::new(env, &token);
         let zero = I256::from_i32(env, 0);
@@ -448,7 +466,7 @@ impl PoolContract {
             token_client.transfer(&sender, &this, &amount);
         }
 
-        Self::internal_transact(env, proof, ext_data)
+        Self::internal_transact(env, proof, ext_data, policy_flags)
     }
 
     /// Process a private transaction
@@ -473,7 +491,12 @@ impl PoolContract {
     /// 3. Verify external data hash matches
     /// 4. Verify public amount calculation
     /// 5. Verify zero-knowledge proof
-    fn internal_transact(env: &Env, proof: Proof, ext_data: ExtData) -> Result<(), Error> {
+    fn internal_transact(
+        env: &Env,
+        proof: Proof,
+        ext_data: ExtData,
+        policy_flags: u32,
+    ) -> Result<(), Error> {
         // 1. Merkle root check
         if !MerkleTreeWithHistory::is_known_root(env, &proof.root)? {
             return Err(Error::UnknownRoot);
@@ -498,7 +521,6 @@ impl PoolContract {
         }
 
         // ASP root validation
-        let policy_flags = Self::load_policy_flags(env)?;
         if policy::requires_non_membership_proofs(policy_flags) {
             let non_member_root = Self::get_asp_non_membership_root(env)?;
             if non_member_root != proof.asp_non_membership_root {
@@ -567,6 +589,7 @@ impl PoolContract {
         env.storage()
             .persistent()
             .get(&DataKey::Token)
+            .inspect(|_| bump_entry(env, &DataKey::Token))
             .ok_or(Error::NotInitialized)
     }
 
@@ -575,6 +598,7 @@ impl PoolContract {
         env.storage()
             .persistent()
             .get(&DataKey::MaximumDepositAmount)
+            .inspect(|_| bump_entry(env, &DataKey::MaximumDepositAmount))
             .ok_or(Error::NotInitialized)
     }
 
@@ -583,6 +607,7 @@ impl PoolContract {
         env.storage()
             .persistent()
             .get(&DataKey::Verifier)
+            .inspect(|_| bump_entry(env, &DataKey::Verifier))
             .ok_or(Error::NotInitialized)
     }
 
@@ -591,11 +616,13 @@ impl PoolContract {
         env.storage()
             .persistent()
             .get(&DataKey::Admin)
+            .inspect(|_| bump_entry(env, &DataKey::Admin))
             .ok_or(Error::NotInitialized)
     }
 
     /// Get the pool's ASP policy flags.
     pub fn get_policy_flags(env: &Env) -> Result<u32, Error> {
+        Self::touch(env);
         Self::load_policy_flags(env)
     }
 
@@ -603,11 +630,13 @@ impl PoolContract {
         env.storage()
             .persistent()
             .get(&DataKey::PolicyFlags)
+            .inspect(|_| bump_entry(env, &DataKey::PolicyFlags))
             .ok_or(Error::NotInitialized)
     }
 
     /// Get the latest root of the Merkle tree that defines the pool
     pub fn get_root(env: &Env) -> Result<U256, Error> {
+        Self::touch(env);
         Ok(MerkleTreeWithHistory::get_last_root(env)?)
     }
 
@@ -618,6 +647,7 @@ impl PoolContract {
     /// * `env` - The Soroban environment
     /// * `root` - Pool Merkle root to check
     pub fn is_known_root(env: &Env, root: &U256) -> Result<bool, Error> {
+        Self::touch(env);
         Ok(MerkleTreeWithHistory::is_known_root(env, root)?)
     }
 
@@ -634,8 +664,13 @@ impl PoolContract {
     ///
     /// Returns `true` if the nullifier has been spent, `false` otherwise
     pub fn is_spent(env: &Env, n: &U256) -> Result<bool, Error> {
+        Self::touch(env);
         let key = DataKey::Nullifier(n.clone());
-        Ok(env.storage().persistent().has(&key))
+        let spent = env.storage().persistent().has(&key);
+        if spent {
+            bump_entry(env, &key);
+        }
+        Ok(spent)
     }
 
     /// Update the contract administrator
@@ -653,6 +688,7 @@ impl PoolContract {
     /// Returns [`Error::NotInitialized`] if the contract has no admin address
     /// stored.
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
+        Self::touch(&env);
         soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin)
             .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
     }
@@ -664,6 +700,7 @@ impl PoolContract {
         env.storage()
             .persistent()
             .get(&DataKey::ASPMembership)
+            .inspect(|_| bump_entry(env, &DataKey::ASPMembership))
             .ok_or(Error::NotInitialized)
     }
 
@@ -672,6 +709,7 @@ impl PoolContract {
         env.storage()
             .persistent()
             .get(&DataKey::ASPNonMembership)
+            .inspect(|_| bump_entry(env, &DataKey::ASPNonMembership))
             .ok_or(Error::NotInitialized)
     }
 
@@ -685,11 +723,13 @@ impl PoolContract {
     /// * `env` - The Soroban environment
     /// * `new_asp_membership` - New ASP Membership contract address
     pub fn update_asp_membership(env: &Env, new_asp_membership: Address) -> Result<(), Error> {
+        Self::touch(env);
         let admin = Self::get_admin(env)?;
         admin.require_auth();
         env.storage()
             .persistent()
             .set(&DataKey::ASPMembership, &new_asp_membership);
+        bump_entry(env, &DataKey::ASPMembership);
         Ok(())
     }
 
@@ -706,11 +746,13 @@ impl PoolContract {
         env: &Env,
         new_asp_non_membership: Address,
     ) -> Result<(), Error> {
+        Self::touch(env);
         let admin = Self::get_admin(env)?;
         admin.require_auth();
         env.storage()
             .persistent()
             .set(&DataKey::ASPNonMembership, &new_asp_non_membership);
+        bump_entry(env, &DataKey::ASPNonMembership);
         Ok(())
     }
 
@@ -727,6 +769,7 @@ impl PoolContract {
     ///
     /// The current membership Merkle root as U256
     pub fn get_asp_membership_root(env: &Env) -> Result<U256, Error> {
+        Self::touch(env);
         let asp_address = Self::get_asp_membership(env)?;
         let client = ASPMembershipClient::new(env, &asp_address);
         Ok(client.get_root())
@@ -745,6 +788,7 @@ impl PoolContract {
     ///
     /// The current non-membership Merkle root as U256
     pub fn get_asp_non_membership_root(env: &Env) -> Result<U256, Error> {
+        Self::touch(env);
         let asp_address = Self::get_asp_non_membership(env)?;
         let client = ASPNonMembershipClient::new(env, &asp_address);
         Ok(client.get_root())

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -2,14 +2,18 @@ use crate::{
     Error, ExtData, PoolContract, PoolContractClient, Proof,
     merkle_with_history::{MerkleDataKey, MerkleTreeWithHistory},
     policy,
+    pool::DataKey,
 };
 use asp_membership::{ASPMembership, ASPMembershipClient};
 use asp_non_membership::{ASPNonMembership, ASPNonMembershipClient};
 use circom_groth16_verifier::{CircomGroth16Verifier, Groth16Proof};
 use soroban_sdk::{
-    Address, Bytes, BytesN, Env, I256, U256, Vec,
-    crypto::bn254::{Bn254G1Affine as G1Affine, Bn254G2Affine as G2Affine},
-    testutils::{Address as _, Ledger as _, storage::Persistent as _},
+    Address, Bytes, BytesN, Env, I256, IntoVal, U256, Val, Vec, contract, contractimpl,
+    crypto::bn254::{Bn254Fr, Bn254G1Affine as G1Affine, Bn254G2Affine as G2Affine},
+    testutils::{
+        Address as _, Ledger as _,
+        storage::{Instance as _, Persistent as _},
+    },
     token::{Client as TokenClient, StellarAssetClient},
     xdr::ToXdr,
 };
@@ -352,8 +356,15 @@ fn merkle_init_only_once() {
     });
 }
 
-fn merkle_entry_ttl(env: &Env, pool: &Address, key: &MerkleDataKey) -> u32 {
-    env.as_contract(pool, || env.storage().persistent().get_ttl(key))
+fn entry_ttl<K>(env: &Env, contract: &Address, key: &K) -> u32
+where
+    K: IntoVal<Env, Val>,
+{
+    env.as_contract(contract, || env.storage().persistent().get_ttl(key))
+}
+
+fn instance_ttl(env: &Env, contract: &Address) -> u32 {
+    env.as_contract(contract, || env.storage().instance().get_ttl())
 }
 
 /// Advances the ledger far enough that every entry sitting at [`EXTEND_TO`]
@@ -388,7 +399,7 @@ fn insert_two_leaves_extends_touched_entries() {
         8,
         policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
     );
-    let untouched_before = merkle_entry_ttl(&env, &pool_id, &MerkleDataKey::Root(0));
+    let untouched_before = entry_ttl(&env, &pool_id, &MerkleDataKey::Root(0));
 
     insert_pair(&env, &pool_id, 1, 2);
 
@@ -401,13 +412,13 @@ fn insert_two_leaves_extends_touched_entries() {
         MerkleDataKey::Zeroes(1),
     ] {
         assert_eq!(
-            merkle_entry_ttl(&env, &pool_id, &key),
+            entry_ttl(&env, &pool_id, &key),
             EXTEND_TO,
             "{key:?} should have been extended"
         );
     }
     assert_eq!(
-        merkle_entry_ttl(&env, &pool_id, &MerkleDataKey::Root(0)),
+        entry_ttl(&env, &pool_id, &MerkleDataKey::Root(0)),
         untouched_before
     );
 }
@@ -447,16 +458,16 @@ fn is_known_root_extends_only_the_matching_slot() {
 
     assert!(known);
     assert_eq!(
-        merkle_entry_ttl(&env, &pool_id, &MerkleDataKey::Root(1)),
+        entry_ttl(&env, &pool_id, &MerkleDataKey::Root(1)),
         EXTEND_TO
     );
     let unextended = THRESHOLD.saturating_sub(1);
     assert_eq!(
-        merkle_entry_ttl(&env, &pool_id, &MerkleDataKey::Root(2)),
+        entry_ttl(&env, &pool_id, &MerkleDataKey::Root(2)),
         unextended
     );
     assert_eq!(
-        merkle_entry_ttl(&env, &pool_id, &MerkleDataKey::Root(0)),
+        entry_ttl(&env, &pool_id, &MerkleDataKey::Root(0)),
         unextended
     );
 
@@ -486,13 +497,305 @@ fn get_last_root_extends_the_current_slot() {
     });
 
     assert_eq!(
-        merkle_entry_ttl(&env, &pool_id, &MerkleDataKey::Root(0)),
+        entry_ttl(&env, &pool_id, &MerkleDataKey::Root(0)),
         EXTEND_TO
     );
     assert_eq!(
-        merkle_entry_ttl(&env, &pool_id, &MerkleDataKey::CurrentRootIndex),
+        entry_ttl(&env, &pool_id, &MerkleDataKey::CurrentRootIndex),
         EXTEND_TO
     );
+}
+
+/// A verifier that accepts every proof.
+///
+/// The workspace's shared `CircomGroth16Verifier` embeds a verification key
+/// chosen at compile time, and producing a proof it accepts needs the proving
+/// key and witness machinery that lives in `e2e-tests`. Tests that have to
+/// observe a `transact` run to completion wire the pool to this instead.
+#[contract]
+struct AcceptingVerifier;
+
+#[contractimpl]
+impl AcceptingVerifier {
+    pub fn verify(
+        _env: Env,
+        _proof: Groth16Proof,
+        _public_inputs: Vec<Bn254Fr>,
+    ) -> Result<bool, contract_types::Groth16Error> {
+        Ok(true)
+    }
+}
+
+fn register_pool_with_verifier(
+    env: &Env,
+    setup: &TestSetup,
+    verifier: &Address,
+    levels: u32,
+    policy_flags: u32,
+) -> Address {
+    env.register(
+        PoolContract,
+        (
+            setup.admin.clone(),
+            setup.token.clone(),
+            verifier.clone(),
+            setup.asp_membership_address.clone(),
+            setup.asp_non_membership_address.clone(),
+            U256::from_u32(env, 1000),
+            levels,
+            policy_flags,
+        ),
+    )
+}
+
+#[test]
+fn transact_extends_instance_config_and_nullifier_ttl() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let verifier = env.register(AcceptingVerifier, ());
+    let pool_id = register_pool_with_verifier(
+        &env,
+        &setup,
+        &verifier,
+        3,
+        policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
+    );
+    let pool = PoolContractClient::new(&env, &pool_id);
+    let (member_root, non_member_root) = asp_roots(&setup);
+    env.mock_all_auths();
+
+    let nullifier = 0xA11CE;
+    let (proof, ext) = mk_transact_proof(&env, &pool, member_root, non_member_root, nullifier);
+    pool.transact(&proof, &ext, &Address::generate(&env));
+
+    assert_eq!(instance_ttl(&env, &pool_id), EXTEND_TO);
+    for key in [
+        DataKey::Token,
+        DataKey::PolicyFlags,
+        DataKey::Nullifier(U256::from_u32(&env, nullifier)),
+    ] {
+        assert_eq!(
+            entry_ttl(&env, &pool_id, &key),
+            EXTEND_TO,
+            "{key:?} should have been extended"
+        );
+    }
+}
+
+#[test]
+fn transact_extends_linked_contract_instances() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let verifier = env.register(AcceptingVerifier, ());
+    let pool_id = register_pool_with_verifier(
+        &env,
+        &setup,
+        &verifier,
+        3,
+        policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
+    );
+    let pool = PoolContractClient::new(&env, &pool_id);
+    let (member_root, non_member_root) = asp_roots(&setup);
+    env.mock_all_auths();
+
+    let (proof, ext) = mk_transact_proof(&env, &pool, member_root, non_member_root, 0xA11CF);
+    // `asp_roots` above already extended both ASP instances, so decay first:
+    // without this the assertions below hold before `transact` even runs.
+    //
+    // Each ASP instance is reachable by two paths here, `bump_dependency` and
+    // the ASP's own `bump_instance` during the root cross-call, so what this
+    // pins is the invariant that every linked instance survives the call, not
+    // which of the two extended it. The verifier has only the one path.
+    decay_below_threshold(&env);
+    pool.transact(&proof, &ext, &Address::generate(&env));
+
+    assert_eq!(instance_ttl(&env, &verifier), EXTEND_TO);
+    assert_eq!(instance_ttl(&env, &setup.asp_membership_address), EXTEND_TO);
+    assert_eq!(
+        instance_ttl(&env, &setup.asp_non_membership_address),
+        EXTEND_TO
+    );
+}
+
+#[test]
+fn transact_on_an_open_pool_leaves_asp_instances_alone() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let verifier = env.register(AcceptingVerifier, ());
+    let pool_id = register_pool_with_verifier(&env, &setup, &verifier, 3, 0);
+    let pool = PoolContractClient::new(&env, &pool_id);
+    env.mock_all_auths();
+
+    let zero = U256::from_u32(&env, 0);
+    let membership_before = instance_ttl(&env, &setup.asp_membership_address);
+    let non_membership_before = instance_ttl(&env, &setup.asp_non_membership_address);
+
+    let (proof, ext) = mk_transact_proof(&env, &pool, zero.clone(), zero, 0xA11D0);
+    pool.transact(&proof, &ext, &Address::generate(&env));
+
+    assert_eq!(instance_ttl(&env, &verifier), EXTEND_TO);
+    assert_eq!(
+        instance_ttl(&env, &setup.asp_membership_address),
+        membership_before
+    );
+    assert_eq!(
+        instance_ttl(&env, &setup.asp_non_membership_address),
+        non_membership_before
+    );
+}
+
+/// A failed invocation rolls back its storage changes, and a TTL extension is
+/// one of them, so the pool pays no rent for a call it refused.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn failed_transact_rolls_back_the_ttl_extension() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let verifier = env.register(AcceptingVerifier, ());
+    let pool_id = register_pool_with_verifier(
+        &env,
+        &setup,
+        &verifier,
+        3,
+        policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
+    );
+    let pool = PoolContractClient::new(&env, &pool_id);
+    let (member_root, non_member_root) = asp_roots(&setup);
+    env.mock_all_auths();
+    let before = instance_ttl(&env, &pool_id);
+
+    let ext = mk_ext_data(&env, Address::generate(&env), 0);
+    let proof = Proof {
+        proof: mk_mock_groth16_proof(&env),
+        root: U256::from_u32(&env, 0xFF),
+        input_nullifiers: {
+            let mut v: Vec<U256> = Vec::new(&env);
+            v.push_back(U256::from_u32(&env, 0xAB));
+            v
+        },
+        output_commitment0: U256::from_u32(&env, 0x01),
+        output_commitment1: U256::from_u32(&env, 0x02),
+        public_amount: U256::from_u32(&env, 0),
+        ext_data_hash: compute_ext_hash(&env, &ext),
+        asp_membership_root: member_root,
+        asp_non_membership_root: non_member_root,
+    };
+
+    let err = pool
+        .try_transact(&proof, &ext, &Address::generate(&env))
+        .expect_err("an unknown root must be refused");
+
+    assert_eq!(err, Ok(Error::UnknownRoot));
+    assert_ne!(before, EXTEND_TO);
+    assert_eq!(instance_ttl(&env, &pool_id), before);
+}
+
+/// The spent check must not extend a nullifier entry that does not exist,
+/// because the host rejects an extension of a missing key.
+#[test]
+fn is_spent_on_an_unknown_nullifier_does_not_panic() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
+    );
+    let pool = PoolContractClient::new(&env, &pool_id);
+
+    assert!(!pool.is_spent(&U256::from_u32(&env, 0xBEEF)));
+}
+
+/// The address an admin writes must come off the seven-day fuse with it, or
+/// the pool forgets which ASP it points at.
+#[test]
+fn update_asp_membership_extends_the_written_key() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
+    );
+    let pool = PoolContractClient::new(&env, &pool_id);
+    env.mock_all_auths();
+
+    pool.update_asp_membership(&Address::generate(&env));
+
+    assert_eq!(
+        entry_ttl(&env, &pool_id, &DataKey::ASPMembership),
+        EXTEND_TO
+    );
+}
+
+/// Same for the non-membership address.
+#[test]
+fn update_asp_non_membership_extends_the_written_key() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
+    );
+    let pool = PoolContractClient::new(&env, &pool_id);
+    env.mock_all_auths();
+
+    pool.update_asp_non_membership(&Address::generate(&env));
+
+    assert_eq!(
+        entry_ttl(&env, &pool_id, &DataKey::ASPNonMembership),
+        EXTEND_TO
+    );
+}
+
+/// A nullifier already on file is re-extended by the spent check, so a pool
+/// that keeps being read never lets its double-spend record expire.
+#[test]
+fn is_spent_extends_a_nullifier_already_on_file() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
+    );
+    let pool = PoolContractClient::new(&env, &pool_id);
+    let nullifier = U256::from_u32(&env, 0xC0FFEE);
+    mark_nullifier_spent(&env, &pool_id, &nullifier);
+    decay_below_threshold(&env);
+    let key = DataKey::Nullifier(nullifier.clone());
+    assert_ne!(entry_ttl(&env, &pool_id, &key), EXTEND_TO);
+
+    assert!(pool.is_spent(&nullifier));
+
+    assert_eq!(entry_ttl(&env, &pool_id, &key), EXTEND_TO);
+}
+
+#[test]
+fn getters_extend_the_instance() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
+    );
+    let pool = PoolContractClient::new(&env, &pool_id);
+
+    pool.get_root();
+
+    assert_eq!(instance_ttl(&env, &pool_id), EXTEND_TO);
 }
 
 #[test]

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -9,11 +9,15 @@ use circom_groth16_verifier::{CircomGroth16Verifier, Groth16Proof};
 use soroban_sdk::{
     Address, Bytes, BytesN, Env, I256, U256, Vec,
     crypto::bn254::{Bn254G1Affine as G1Affine, Bn254G2Affine as G2Affine},
-    testutils::Address as _,
+    testutils::{Address as _, Ledger as _, storage::Persistent as _},
     token::{Client as TokenClient, StellarAssetClient},
     xdr::ToXdr,
 };
-use soroban_utils::{constants::bn256_modulus, utils::MockToken};
+use soroban_utils::{
+    constants::bn256_modulus,
+    ttl::{EXTEND_TO, THRESHOLD},
+    utils::MockToken,
+};
 
 /// Number of levels for the ASP Membership Merkle tree in tests
 const ASP_MEMBERSHIP_LEVELS: u32 = 8;
@@ -346,6 +350,149 @@ fn merkle_init_only_once() {
         let result = MerkleTreeWithHistory::init(&env, levels);
         assert!(result.is_err());
     });
+}
+
+fn merkle_entry_ttl(env: &Env, pool: &Address, key: &MerkleDataKey) -> u32 {
+    env.as_contract(pool, || env.storage().persistent().get_ttl(key))
+}
+
+/// Advances the ledger far enough that every entry sitting at [`EXTEND_TO`]
+/// drops below [`THRESHOLD`], so a later bump is visible as a jump back up.
+fn decay_below_threshold(env: &Env) {
+    let target = env
+        .ledger()
+        .sequence()
+        .saturating_add(EXTEND_TO.saturating_sub(THRESHOLD).saturating_add(1));
+    env.ledger().set_sequence_number(target);
+}
+
+fn insert_pair(env: &Env, pool: &Address, left: u32, right: u32) {
+    env.as_contract(pool, || {
+        MerkleTreeWithHistory::insert_two_leaves(
+            env,
+            U256::from_u32(env, left),
+            U256::from_u32(env, right),
+        )
+        .unwrap_or_else(|err| panic!("expected leaf insertion to succeed: {err:?}"));
+    });
+}
+
+#[test]
+fn insert_two_leaves_extends_touched_entries() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(
+        &env,
+        &setup,
+        U256::from_u32(&env, 100),
+        8,
+        policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
+    );
+    let untouched_before = merkle_entry_ttl(&env, &pool_id, &MerkleDataKey::Root(0));
+
+    insert_pair(&env, &pool_id, 1, 2);
+
+    for key in [
+        MerkleDataKey::Levels,
+        MerkleDataKey::NextIndex,
+        MerkleDataKey::CurrentRootIndex,
+        MerkleDataKey::Root(1),
+        MerkleDataKey::FilledSubtree(1),
+        MerkleDataKey::Zeroes(1),
+    ] {
+        assert_eq!(
+            merkle_entry_ttl(&env, &pool_id, &key),
+            EXTEND_TO,
+            "{key:?} should have been extended"
+        );
+    }
+    assert_eq!(
+        merkle_entry_ttl(&env, &pool_id, &MerkleDataKey::Root(0)),
+        untouched_before
+    );
+}
+
+#[test]
+fn is_known_root_extends_only_the_matching_slot() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        8,
+        policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
+    );
+
+    // Reading the root the constructor wrote lifts Root(0) to EXTEND_TO, so all
+    // three occupied slots start the search from the same TTL.
+    env.as_contract(&pool_id, || {
+        MerkleTreeWithHistory::get_last_root(&env)
+            .unwrap_or_else(|err| panic!("expected the initial root to exist: {err:?}"));
+    });
+    insert_pair(&env, &pool_id, 1, 2);
+    insert_pair(&env, &pool_id, 3, 4);
+    let first_root: U256 = env.as_contract(&pool_id, || {
+        env.storage()
+            .persistent()
+            .get(&MerkleDataKey::Root(1))
+            .unwrap_or_else(|| panic!("expected the first inserted root to be stored"))
+    });
+    decay_below_threshold(&env);
+
+    let known = env.as_contract(&pool_id, || {
+        MerkleTreeWithHistory::is_known_root(&env, &first_root)
+            .unwrap_or_else(|err| panic!("expected root lookup to succeed: {err:?}"))
+    });
+
+    assert!(known);
+    assert_eq!(
+        merkle_entry_ttl(&env, &pool_id, &MerkleDataKey::Root(1)),
+        EXTEND_TO
+    );
+    let unextended = THRESHOLD.saturating_sub(1);
+    assert_eq!(
+        merkle_entry_ttl(&env, &pool_id, &MerkleDataKey::Root(2)),
+        unextended
+    );
+    assert_eq!(
+        merkle_entry_ttl(&env, &pool_id, &MerkleDataKey::Root(0)),
+        unextended
+    );
+
+    let unknown = U256::from_u32(&env, 0xdead_beef);
+    let found = env.as_contract(&pool_id, || {
+        MerkleTreeWithHistory::is_known_root(&env, &unknown)
+            .unwrap_or_else(|err| panic!("expected root lookup to succeed: {err:?}"))
+    });
+    assert!(!found);
+}
+
+#[test]
+fn get_last_root_extends_the_current_slot() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        8,
+        policy::ALLOWLIST_BIT | policy::BLOCKLIST_BIT,
+    );
+
+    env.as_contract(&pool_id, || {
+        MerkleTreeWithHistory::get_last_root(&env)
+            .unwrap_or_else(|err| panic!("expected last root to exist: {err:?}"));
+    });
+
+    assert_eq!(
+        merkle_entry_ttl(&env, &pool_id, &MerkleDataKey::Root(0)),
+        EXTEND_TO
+    );
+    assert_eq!(
+        merkle_entry_ttl(&env, &pool_id, &MerkleDataKey::CurrentRootIndex),
+        EXTEND_TO
+    );
 }
 
 #[test]

--- a/contracts/soroban-utils/Cargo.toml
+++ b/contracts/soroban-utils/Cargo.toml
@@ -23,5 +23,9 @@ ark-ff = { workspace = true }
 ark-groth16 = { workspace = true }
 soroban-sdk = { workspace = true }
 
+[dev-dependencies]
+# external
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
 [lints]
 workspace = true

--- a/contracts/soroban-utils/src/lib.rs
+++ b/contracts/soroban-utils/src/lib.rs
@@ -6,8 +6,10 @@
 
 pub mod constants;
 pub mod poseidon2;
+pub mod ttl;
 pub mod utils;
 
 pub use constants::*;
 pub use poseidon2::*;
+pub use ttl::*;
 pub use utils::*;

--- a/contracts/soroban-utils/src/ttl.rs
+++ b/contracts/soroban-utils/src/ttl.rs
@@ -1,0 +1,199 @@
+//! Ledger entry lifetime extensions.
+//!
+//! Every ledger entry carries a time to live (TTL) measured in ledgers, and the
+//! network archives an entry whose TTL reaches zero. Writing an entry does not
+//! refresh its TTL, so a persistent entry created with the network minimum is
+//! archived seven days later unless something extends it. Each helper below
+//! extends an entry to [`EXTEND_TO`] once fewer than [`THRESHOLD`] ledgers
+//! remain, which keeps the state a contract touches alive for as long
+//! as the contract keeps being called.
+//!
+//! Call [`bump_entry`] only on a key that already holds a value. Extending a
+//! missing persistent entry is a host error that traps the invocation.
+
+use soroban_sdk::{Address, Env, IntoVal, Val};
+
+/// Ledgers per day at the five-second close time.
+pub const DAY_IN_LEDGERS: u32 = 17_280;
+
+/// Remaining lifetime below which an extension takes effect.
+pub const THRESHOLD: u32 = 30 * DAY_IN_LEDGERS;
+
+/// Lifetime that an extension targets, equal to the network maximum entry TTL.
+///
+/// The host clamps an extension to the network maximum, so this value is safe
+/// on a network whose maximum is lower.
+pub const EXTEND_TO: u32 = 180 * DAY_IN_LEDGERS;
+
+/// Extends the TTL of the calling contract's instance and code entries.
+pub fn bump_instance(env: &Env) {
+    env.storage().instance().extend_ttl(THRESHOLD, EXTEND_TO);
+}
+
+/// Extends the TTL of the persistent entry stored under `key`.
+///
+/// # Panics
+///
+/// Panics if no persistent entry is stored under `key`, because the host
+/// rejects an extension of an entry that does not exist.
+pub fn bump_entry<K>(env: &Env, key: &K)
+where
+    K: IntoVal<Env, Val>,
+{
+    env.storage()
+        .persistent()
+        .extend_ttl(key, THRESHOLD, EXTEND_TO);
+}
+
+/// Extends the TTL of the instance and code entries of `contract`.
+///
+/// Use this to keep a contract that this one calls out to reachable, such as a
+/// proof verifier or a policy registry.
+///
+/// # Panics
+///
+/// Panics if `contract` does not name a deployed contract, because the host
+/// rejects an extension of an instance or code entry that does not exist.
+pub fn bump_dependency(env: &Env, contract: &Address) {
+    env.deployer()
+        .extend_ttl(contract.clone(), THRESHOLD, EXTEND_TO);
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::{
+        contract, contractimpl,
+        testutils::{
+            Ledger as _,
+            storage::{Instance as _, Persistent as _},
+        },
+    };
+
+    const KEY: u32 = 7;
+
+    #[contract]
+    struct TtlProbe;
+
+    #[contractimpl]
+    impl TtlProbe {
+        pub fn write(env: Env) {
+            env.storage().persistent().set(&KEY, &1u32);
+        }
+
+        pub fn bump_key(env: Env) {
+            bump_entry(&env, &KEY);
+        }
+
+        pub fn bump_self(env: Env) {
+            bump_instance(&env);
+        }
+
+        pub fn bump_other(env: Env, contract: Address) {
+            bump_dependency(&env, &contract);
+        }
+    }
+
+    fn entry_ttl(env: &Env, id: &Address) -> u32 {
+        env.as_contract(id, || env.storage().persistent().get_ttl(&KEY))
+    }
+
+    fn instance_ttl(env: &Env, id: &Address) -> u32 {
+        env.as_contract(id, || env.storage().instance().get_ttl())
+    }
+
+    fn advance(env: &Env, ledgers: u32) {
+        let next = env.ledger().sequence().saturating_add(ledgers);
+        env.ledger().set_sequence_number(next);
+    }
+
+    #[test]
+    fn bump_entry_extends_a_fresh_entry_to_the_target() {
+        let env = Env::default();
+        let id = env.register(TtlProbe, ());
+        let client = TtlProbeClient::new(&env, &id);
+
+        client.write();
+        client.bump_key();
+
+        assert_eq!(entry_ttl(&env, &id), EXTEND_TO);
+    }
+
+    #[test]
+    fn bump_entry_is_a_no_op_above_the_threshold() {
+        let env = Env::default();
+        let id = env.register(TtlProbe, ());
+        let client = TtlProbeClient::new(&env, &id);
+
+        client.write();
+        client.bump_key();
+        advance(&env, 1);
+        client.bump_key();
+
+        assert_eq!(entry_ttl(&env, &id), EXTEND_TO.saturating_sub(1));
+    }
+
+    #[test]
+    fn bump_entry_extends_again_once_below_the_threshold() {
+        let env = Env::default();
+        let id = env.register(TtlProbe, ());
+        let client = TtlProbeClient::new(&env, &id);
+
+        client.write();
+        client.bump_key();
+        advance(&env, EXTEND_TO.saturating_sub(THRESHOLD).saturating_add(1));
+        client.bump_key();
+
+        assert_eq!(entry_ttl(&env, &id), EXTEND_TO);
+    }
+
+    #[test]
+    fn bump_entry_is_clamped_to_the_network_maximum() {
+        let env = Env::default();
+        // Above the environment's minimum persistent entry TTL, so a fresh
+        // entry starts below the maximum and the clamp is observable.
+        env.ledger().set_max_entry_ttl(100_000);
+        let id = env.register(TtlProbe, ());
+        let client = TtlProbeClient::new(&env, &id);
+
+        client.write();
+        client.bump_key();
+
+        assert_eq!(entry_ttl(&env, &id), 100_000);
+    }
+
+    #[test]
+    fn bump_instance_extends_the_instance() {
+        let env = Env::default();
+        let id = env.register(TtlProbe, ());
+        let client = TtlProbeClient::new(&env, &id);
+
+        client.bump_self();
+
+        assert_eq!(instance_ttl(&env, &id), EXTEND_TO);
+    }
+
+    #[test]
+    fn bump_dependency_extends_another_contract() {
+        let env = Env::default();
+        let caller = env.register(TtlProbe, ());
+        let dependency = env.register(TtlProbe, ());
+
+        TtlProbeClient::new(&env, &caller).bump_other(&dependency);
+
+        assert_eq!(instance_ttl(&env, &dependency), EXTEND_TO);
+    }
+
+    /// This test is skipped under Miri because the panic formatting path
+    /// triggers undefined behavior in the `ethnum` crate's unsafe
+    /// formatting code. See: https://github.com/nlordell/ethnum-rs/issues/34
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    #[should_panic(expected = "MissingValue")]
+    fn bump_entry_on_a_missing_key_panics() {
+        let env = Env::default();
+        let id = env.register(TtlProbe, ());
+
+        TtlProbeClient::new(&env, &id).bump_key();
+    }
+}


### PR DESCRIPTION
Soroban charges rent on ledger entries. An entry that goes unrenewed past its expiry is
archived: the host can no longer read it, and any call whose footprint touches it fails until
somebody restores it. Nothing in this tree renewed anything, so every contract was running
down a clock nobody was watching.

The practical shape of the bug: a pool with no traffic for long enough had its Merkle state
archived. The next `transact` then failed reading entries that still existed on chain but
were no longer live, and no amount of retrying fixed it.

## The `ttl` module in `soroban-utils`

Two constants and three helpers, so every contract renews on the same schedule instead of
each one inventing its own.

- `THRESHOLD` is 30 days of ledgers, `EXTEND_TO` is 180. A renewal is skipped entirely while
  an entry still has more than `THRESHOLD` left, so the cost lands only on calls that would
  otherwise let something lapse. A busy pool pays almost nothing; a pool waking up after
  months pays once.
- `bump_instance` renews the calling contract's own instance entry and its code.
- `bump_entry` renews one persistent key.
- `bump_dependency` renews a linked contract's instance and code together, through
  `deployer().extend_ttl`. Pools use it on the verifier and the two ASP contracts they call,
  because a live pool with an archived verifier is just as stuck.

## Applied across the contracts

Every entry point in `pool`, `pool-gvk`, `asp-membership`, `asp-non-membership`, and
`pool-core` renews its own instance plus the entries it reads or writes on that call.

The deliberate limit is that a call renews **only what it touches**. Renewing everything a
pool owns would mean a `transact` bumping all ninety root-history slots and every level's zero
hash, adding over a hundred entries to its footprint and charging every user for entries their
transaction never read.

The consequence is worth being explicit about: entries that no call touches are not covered
here and stay on their existing expiry. That includes an idle pool's untouched ring slots, old
nullifiers, and the sparse tree's long tail. Reaching those needs something that runs without
a user transaction, which is not in this change.

## Compatibility

No signature changes, no new error variants, no storage layout changes. Deployed contracts
keep working and begin renewing themselves on their next call, with no migration and no
redeploy.

## Tests

Most of the diff. Each contract has a test that advances the ledger until its entries fall
below `THRESHOLD`, calls an entry point, and asserts the entries jump back to `EXTEND_TO`.
One asserts that a call which fails renews nothing, so a reverted transaction cannot be used
to extend state for free.
