### PR TITLE
Add the pausable module and an admin-change event

### DIFF
--- a/contracts/asp-membership/src/test.rs
+++ b/contracts/asp-membership/src/test.rs
@@ -13,7 +13,10 @@ use soroban_sdk::{
     },
     vec,
 };
-use soroban_utils::ttl::{EXTEND_TO, THRESHOLD};
+use soroban_utils::{
+    AdminUpdated,
+    ttl::{EXTEND_TO, THRESHOLD},
+};
 use taceo_poseidon2::bn254::t2;
 
 /// Create a test environment that disables snapshot writing under Miri.
@@ -265,6 +268,51 @@ fn test_update_admin() {
             .expect("Admin updated")
     });
     assert_eq!(stored_admin_after, new_admin);
+}
+
+#[test]
+fn test_update_admin_emits_admin_updated() {
+    use soroban_sdk::{events::Event, testutils::Events};
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin.clone(), 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    client.update_admin(&new_admin);
+
+    let events = env.events().all();
+    assert_eq!(events.events().len(), 1);
+    let expected = AdminUpdated {
+        old_admin: admin,
+        new_admin,
+    }
+    .to_xdr(&env, &contract_id);
+    assert_eq!(events.events()[0], expected);
+}
+
+/// Rotating to the address already stored is a permitted no-op rotation, and it
+/// is recorded so an operator reading the log sees the attempt.
+#[test]
+fn test_update_admin_to_self_emits_with_equal_fields() {
+    use soroban_sdk::{events::Event, testutils::Events};
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin.clone(), 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    client.update_admin(&admin);
+
+    let events = env.events().all();
+    assert_eq!(events.events().len(), 1);
+    let expected = AdminUpdated {
+        old_admin: admin.clone(),
+        new_admin: admin,
+    }
+    .to_xdr(&env, &contract_id);
+    assert_eq!(events.events()[0], expected);
 }
 
 #[test]

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -1287,6 +1287,27 @@ fn update_admin_errors_when_admin_unset() {
     ));
 }
 
+/// The refusal is driven from inside a host frame that goes on to succeed,
+/// because a frame that fails discards its events whatever the contract did.
+#[test]
+fn update_admin_errors_when_admin_unset_emits_nothing() {
+    use soroban_sdk::testutils::Events;
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 3, 0u32);
+    let new_admin = Address::generate(&env);
+
+    env.as_contract(&pool_id, || {
+        env.storage().persistent().remove(&DataKey::Admin);
+        assert_eq!(
+            soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin),
+            Err(soroban_utils::AdminError::NotInitialized)
+        );
+    });
+
+    assert!(env.events().all().events().is_empty());
+}
+
 /// This test is skipped under Miri because the panic formatting path triggers
 /// undefined behavior in the `ethnum` crate's unsafe formatting code.
 /// See: https://github.com/nlordell/ethnum-rs/issues/34

--- a/contracts/soroban-utils/src/lib.rs
+++ b/contracts/soroban-utils/src/lib.rs
@@ -5,6 +5,7 @@
 //! across multiple Soroban contracts
 
 pub mod constants;
+pub mod pausable;
 pub mod poseidon2;
 pub mod ttl;
 pub mod utils;

--- a/contracts/soroban-utils/src/pausable.rs
+++ b/contracts/soroban-utils/src/pausable.rs
@@ -1,0 +1,503 @@
+//! Pause bits that stop a contract from accepting some of its calls.
+//!
+//! A contract keeps one persistent entry holding a bit set, so a gated call
+//! reads a single entry to learn whether it may proceed. The bits belong to the
+//! contract: pools recognize [`DEPOSITS`], [`TRANSFERS`], and [`WITHDRAWALS`],
+//! and the ASP contracts recognize [`MUTATIONS`]. Every caller passes the mask
+//! of bits it honors, so a mistyped flag is refused rather than setting a bit
+//! nothing ever reads.
+//!
+//! Only [`WITHDRAWALS`] expires. A timed pause names the ledger from which
+//! withdrawals resume, so an operator can hold deposits and transfers shut for
+//! as long as an incident lasts while withdrawals reopen on their own. The
+//! module enforces less than that promise suggests: a second timed pause is
+//! refused while one is armed, so the recorded ledger cannot be pushed back.
+//! An [`unpause`] drops it along with the bits it names, and an untimed
+//! [`pause`] drops it too, which leaves a set [`WITHDRAWALS`] bit paused with
+//! no deadline at all.
+//!
+//! None of these functions authorizes anyone. A contract that exposes a pause
+//! or an unpause is responsible for requiring its administrator's
+//! authorization first.
+
+use soroban_sdk::{Env, I256, contractevent, contracttype};
+
+use crate::ttl::bump_entry;
+
+/// Pool bit gating deposits.
+pub const DEPOSITS: u32 = 1;
+
+/// Pool bit gating transfers.
+pub const TRANSFERS: u32 = 2;
+
+/// Pool bit gating withdrawals, and the only bit a timed pause releases.
+pub const WITHDRAWALS: u32 = 4;
+
+/// The one bit for ASP contracts, gating inserts and deletes.
+pub const MUTATIONS: u32 = 1;
+
+/// Every bit a pool honors.
+pub const POOL_MASK: u32 = DEPOSITS | TRANSFERS | WITHDRAWALS;
+
+/// The pause bits a contract has set.
+#[contracttype]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct PauseState {
+    /// Bits set by the last pause or unpause. [`WITHDRAWALS`] is honored only
+    /// until the ledger in `until`, so read the answer from [`is_paused`]
+    /// rather than testing this field.
+    pub flags: u32,
+    /// Ledger from which the [`WITHDRAWALS`] bit is no longer honored.
+    pub until: Option<u32>,
+    /// Set by a timed pause; cleared only by an untimed pause or an unpause.
+    pub armed: bool,
+}
+
+#[contracttype]
+#[derive(Clone)]
+enum PausableKey {
+    Pause,
+}
+
+/// Emitted whenever the pause bits change.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PauseChanged {
+    /// Bits set after the change.
+    pub flags: u32,
+    /// Expiry ledger for [`WITHDRAWALS`] after the change.
+    pub until: Option<u32>,
+}
+
+/// Reason a pause or an unpause was refused.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum PauseError {
+    /// The flags were zero, or held a bit outside the caller's mask.
+    InvalidFlags,
+    /// A timed pause is already in force, and a second one would move the
+    /// ledger that users were promised.
+    TimedPauseArmed,
+}
+
+/// Returns the stored pause state, or an all-clear state when none is stored.
+///
+/// Extends the entry's lifetime when it exists, so a contract that is called
+/// keeps its own pause state alive.
+pub fn get_state(env: &Env) -> PauseState {
+    env.storage()
+        .persistent()
+        .get(&PausableKey::Pause)
+        .inspect(|_| bump_entry(env, &PausableKey::Pause))
+        .unwrap_or_default()
+}
+
+/// Sets `flags` in the stored pause state, timed by `until`.
+///
+/// `mask` is the set of bits the calling contract honors. Passing `Some(until)`
+/// promises that [`WITHDRAWALS`] reopens at that ledger, and that promise
+/// cannot be extended: a second timed pause is refused until an untimed pause
+/// or an unpause clears the arm.
+///
+/// # Errors
+///
+/// Returns [`PauseError::InvalidFlags`] if `flags` is zero or holds a bit
+/// outside `mask`, and [`PauseError::TimedPauseArmed`] if `until` is `Some`
+/// while a timed pause is already armed.
+///
+/// # Events
+///
+/// Publishes [`PauseChanged`] from the calling contract on success.
+pub fn pause(env: &Env, flags: u32, until: Option<u32>, mask: u32) -> Result<(), PauseError> {
+    check_flags(flags, mask)?;
+    let mut state = get_state(env);
+    if until.is_some() && state.armed {
+        return Err(PauseError::TimedPauseArmed);
+    }
+
+    state.flags |= flags;
+    state.until = until;
+    state.armed = until.is_some();
+    store(env, &state);
+    Ok(())
+}
+
+/// Clears `flags` from the stored pause state.
+///
+/// `mask` is the set of bits the calling contract honors. Clearing bits that
+/// are not set is accepted, and any call clears the timed pause along with the
+/// named bits.
+///
+/// # Errors
+///
+/// Returns [`PauseError::InvalidFlags`] if `flags` is zero or holds a bit
+/// outside `mask`.
+///
+/// # Events
+///
+/// Publishes [`PauseChanged`] from the calling contract on success.
+pub fn unpause(env: &Env, flags: u32, mask: u32) -> Result<(), PauseError> {
+    check_flags(flags, mask)?;
+    let mut state = get_state(env);
+
+    state.flags &= !flags;
+    state.until = None;
+    state.armed = false;
+    store(env, &state);
+    Ok(())
+}
+
+/// Reports whether `bit` is paused at the current ledger.
+///
+/// [`WITHDRAWALS`] stops being honored from the timed pause's ledger onwards.
+/// No other bit expires.
+pub fn is_paused(env: &Env, bit: u32) -> bool {
+    let state = get_state(env);
+    let expired = bit == WITHDRAWALS
+        && state
+            .until
+            .is_some_and(|until| env.ledger().sequence() >= until);
+
+    state.flags & bit != 0 && !expired
+}
+
+/// Returns the pool bit that governs a transaction moving `ext_amount`.
+///
+/// A positive amount is a deposit, a negative one a withdrawal, and zero a
+/// transfer between notes already inside the pool.
+pub fn shape_bit(env: &Env, ext_amount: &I256) -> u32 {
+    let zero = I256::from_i32(env, 0);
+    if *ext_amount > zero {
+        DEPOSITS
+    } else if *ext_amount < zero {
+        WITHDRAWALS
+    } else {
+        TRANSFERS
+    }
+}
+
+fn check_flags(flags: u32, mask: u32) -> Result<(), PauseError> {
+    if flags == 0 || flags & !mask != 0 {
+        Err(PauseError::InvalidFlags)
+    } else {
+        Ok(())
+    }
+}
+
+fn store(env: &Env, state: &PauseState) {
+    env.storage().persistent().set(&PausableKey::Pause, state);
+    bump_entry(env, &PausableKey::Pause);
+    PauseChanged {
+        flags: state.flags,
+        until: state.until,
+    }
+    .publish(env);
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ttl::{EXTEND_TO, THRESHOLD};
+    use soroban_sdk::{
+        Address, contract, contracterror, contractimpl,
+        events::Event,
+        testutils::{Events, Ledger as _, storage::Persistent as _},
+    };
+
+    /// Contract-facing form of [`PauseError`], so the probe's failures cross
+    /// the host boundary the way a real target's do.
+    #[contracterror]
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+    #[repr(u32)]
+    enum ProbeError {
+        InvalidFlags = 1,
+        TimedPauseArmed = 2,
+    }
+
+    impl From<PauseError> for ProbeError {
+        fn from(error: PauseError) -> Self {
+            match error {
+                PauseError::InvalidFlags => Self::InvalidFlags,
+                PauseError::TimedPauseArmed => Self::TimedPauseArmed,
+            }
+        }
+    }
+
+    #[contract]
+    struct PauseProbe;
+
+    #[contractimpl]
+    impl PauseProbe {
+        pub fn pause(
+            env: Env,
+            flags: u32,
+            until: Option<u32>,
+            mask: u32,
+        ) -> Result<(), ProbeError> {
+            super::pause(&env, flags, until, mask).map_err(ProbeError::from)
+        }
+
+        pub fn unpause(env: Env, flags: u32, mask: u32) -> Result<(), ProbeError> {
+            super::unpause(&env, flags, mask).map_err(ProbeError::from)
+        }
+
+        pub fn state(env: Env) -> PauseState {
+            get_state(&env)
+        }
+
+        pub fn paused(env: Env, bit: u32) -> bool {
+            is_paused(&env, bit)
+        }
+    }
+
+    fn probe(env: &Env) -> (Address, PauseProbeClient<'_>) {
+        let id = env.register(PauseProbe, ());
+        let client = PauseProbeClient::new(env, &id);
+        (id, client)
+    }
+
+    #[test]
+    fn shape_bit_reads_the_sign_of_the_external_amount() {
+        let env = Env::default();
+
+        assert_eq!(shape_bit(&env, &I256::from_i32(&env, 500)), DEPOSITS);
+        assert_eq!(shape_bit(&env, &I256::from_i32(&env, 0)), TRANSFERS);
+        assert_eq!(shape_bit(&env, &I256::from_i32(&env, -300)), WITHDRAWALS);
+    }
+
+    #[test]
+    fn pause_rejects_flags_outside_the_mask() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+
+        assert_eq!(
+            client.try_pause(&8u32, &None, &POOL_MASK),
+            Err(Ok(ProbeError::InvalidFlags))
+        );
+    }
+
+    #[test]
+    fn pause_rejects_zero_flags() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+
+        assert_eq!(
+            client.try_pause(&0u32, &None, &POOL_MASK),
+            Err(Ok(ProbeError::InvalidFlags))
+        );
+        assert_eq!(
+            client.try_unpause(&0u32, &POOL_MASK),
+            Err(Ok(ProbeError::InvalidFlags))
+        );
+    }
+
+    #[test]
+    fn the_mutations_mask_accepts_only_its_own_bit() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+
+        client.pause(&MUTATIONS, &None, &MUTATIONS);
+
+        assert_eq!(client.state().flags, MUTATIONS);
+        assert_eq!(
+            client.try_pause(&TRANSFERS, &None, &MUTATIONS),
+            Err(Ok(ProbeError::InvalidFlags))
+        );
+    }
+
+    #[test]
+    fn a_fresh_state_pauses_nothing() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+
+        assert_eq!(
+            client.state(),
+            PauseState {
+                flags: 0,
+                until: None,
+                armed: false,
+            }
+        );
+        for bit in [DEPOSITS, TRANSFERS, WITHDRAWALS] {
+            assert!(!client.paused(&bit));
+        }
+    }
+
+    #[test]
+    fn a_timed_pause_records_the_ledger_and_arms() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+
+        client.pause(&WITHDRAWALS, &Some(500), &POOL_MASK);
+
+        assert_eq!(
+            client.state(),
+            PauseState {
+                flags: WITHDRAWALS,
+                until: Some(500),
+                armed: true,
+            }
+        );
+        assert!(client.paused(&WITHDRAWALS));
+    }
+
+    #[test]
+    fn a_second_timed_pause_is_refused_while_armed() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+        client.pause(&WITHDRAWALS, &Some(500), &POOL_MASK);
+
+        assert_eq!(
+            client.try_pause(&DEPOSITS, &Some(900), &POOL_MASK),
+            Err(Ok(ProbeError::TimedPauseArmed))
+        );
+        assert_eq!(client.state().until, Some(500));
+        assert_eq!(client.state().flags, WITHDRAWALS);
+    }
+
+    #[test]
+    fn an_untimed_pause_keeps_the_flags_and_clears_the_arm() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+        client.pause(&WITHDRAWALS, &Some(500), &POOL_MASK);
+
+        client.pause(&DEPOSITS, &None, &POOL_MASK);
+
+        assert_eq!(
+            client.state(),
+            PauseState {
+                flags: DEPOSITS | WITHDRAWALS,
+                until: None,
+                armed: false,
+            }
+        );
+    }
+
+    #[test]
+    fn unpause_clears_only_the_named_bits() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+        client.pause(&POOL_MASK, &None, &POOL_MASK);
+
+        client.unpause(&DEPOSITS, &POOL_MASK);
+
+        assert_eq!(client.state().flags, TRANSFERS | WITHDRAWALS);
+    }
+
+    #[test]
+    fn unpause_of_unset_bits_still_clears_the_timed_pause() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+        client.pause(&WITHDRAWALS, &Some(500), &POOL_MASK);
+
+        client.unpause(&DEPOSITS, &POOL_MASK);
+
+        assert_eq!(
+            client.state(),
+            PauseState {
+                flags: WITHDRAWALS,
+                until: None,
+                armed: false,
+            }
+        );
+    }
+
+    #[test]
+    fn withdrawals_stop_being_honored_at_the_recorded_ledger() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+        let until = env.ledger().sequence().saturating_add(10);
+        client.pause(&POOL_MASK, &Some(until), &POOL_MASK);
+
+        env.ledger().set_sequence_number(until.saturating_sub(1));
+        assert!(client.paused(&WITHDRAWALS));
+
+        env.ledger().set_sequence_number(until);
+        assert!(!client.paused(&WITHDRAWALS));
+        assert!(client.paused(&DEPOSITS));
+        assert!(client.paused(&TRANSFERS));
+    }
+
+    /// The one sequence in which a user who watched withdrawals reopen finds
+    /// them shut again, and with no deadline the second time.
+    #[test]
+    fn an_untimed_pause_reshuts_withdrawals_that_the_timer_released() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+        let until = env.ledger().sequence().saturating_add(10);
+        client.pause(&WITHDRAWALS, &Some(until), &POOL_MASK);
+        env.ledger().set_sequence_number(until);
+        assert!(!client.paused(&WITHDRAWALS));
+
+        client.pause(&DEPOSITS, &None, &POOL_MASK);
+
+        assert!(client.paused(&WITHDRAWALS));
+        assert_eq!(client.state().until, None);
+    }
+
+    #[test]
+    fn a_ledger_already_past_never_honors_withdrawals_but_still_arms() {
+        let env = Env::default();
+        env.ledger().set_sequence_number(1_000);
+        let (_, client) = probe(&env);
+
+        client.pause(&POOL_MASK, &Some(500), &POOL_MASK);
+
+        assert!(!client.paused(&WITHDRAWALS));
+        assert!(client.paused(&DEPOSITS));
+        assert!(client.state().armed);
+    }
+
+    #[test]
+    fn pause_emits_pause_changed() {
+        let env = Env::default();
+        let (id, client) = probe(&env);
+
+        client.pause(&DEPOSITS, &Some(500), &POOL_MASK);
+
+        let events = env.events().all();
+        assert_eq!(events.events().len(), 1);
+        let expected = PauseChanged {
+            flags: DEPOSITS,
+            until: Some(500),
+        }
+        .to_xdr(&env, &id);
+        assert_eq!(events.events()[0], expected);
+    }
+
+    #[test]
+    fn unpause_emits_pause_changed() {
+        let env = Env::default();
+        let (id, client) = probe(&env);
+        client.pause(&(DEPOSITS | TRANSFERS), &None, &POOL_MASK);
+
+        client.unpause(&DEPOSITS, &POOL_MASK);
+
+        let events = env.events().all();
+        assert_eq!(events.events().len(), 1);
+        let expected = PauseChanged {
+            flags: TRANSFERS,
+            until: None,
+        }
+        .to_xdr(&env, &id);
+        assert_eq!(events.events()[0], expected);
+    }
+
+    #[test]
+    fn get_state_extends_the_entry() {
+        let env = Env::default();
+        let (id, client) = probe(&env);
+        client.pause(&DEPOSITS, &None, &POOL_MASK);
+        let decayed = env
+            .ledger()
+            .sequence()
+            .saturating_add(EXTEND_TO.saturating_sub(THRESHOLD).saturating_add(1));
+        env.ledger().set_sequence_number(decayed);
+
+        client.state();
+
+        let ttl = env.as_contract(&id, || {
+            env.storage().persistent().get_ttl(&PausableKey::Pause)
+        });
+        assert_eq!(ttl, EXTEND_TO);
+    }
+}

--- a/contracts/soroban-utils/src/utils.rs
+++ b/contracts/soroban-utils/src/utils.rs
@@ -1,9 +1,11 @@
 use ark_bn254::{G1Affine as ArkG1Affine, G2Affine as ArkG2Affine};
 use ark_ff::{BigInteger, fields::PrimeField};
 use contract_types::VerificationKeyBytes;
-use soroban_sdk::{Address, BytesN, Env, IntoVal, TryFromVal, Val, Vec};
+use soroban_sdk::{Address, BytesN, Env, IntoVal, TryFromVal, Val, Vec, contractevent};
 #[cfg(any(test, feature = "testutils"))]
 use soroban_sdk::{contract, contractimpl};
+
+use crate::ttl::bump_entry;
 
 /// Error returned by the shared admin helpers.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -12,11 +14,22 @@ pub enum AdminError {
     NotInitialized,
 }
 
+/// Emitted when a contract's administrator changes.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminUpdated {
+    /// Address that held the role before the call.
+    pub old_admin: Address,
+    /// Address that holds it afterwards.
+    pub new_admin: Address,
+}
+
 /// Replaces the administrator stored under `admin_key` with `new_admin`.
 ///
 /// The address already stored under `admin_key` must authorize the call. Each
 /// contract passes its own storage key, so contracts sharing this helper keep
-/// separate admin entries.
+/// separate admin entries. Rotating to the address already stored is allowed
+/// and is recorded like any other rotation.
 ///
 /// # Errors
 ///
@@ -27,15 +40,26 @@ pub enum AdminError {
 ///
 /// Panics if the address stored under `admin_key` does not authorize the call,
 /// because `require_auth` raises a host error rather than returning.
+///
+/// # Events
+///
+/// Publishes [`AdminUpdated`] from the calling contract once the new address is
+/// stored. A call that fails publishes nothing.
 pub fn update_admin<K>(env: &Env, admin_key: &K, new_admin: &Address) -> Result<(), AdminError>
 where
     K: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
 {
     let store = env.storage().persistent();
     let admin: Address = store.get(admin_key).ok_or(AdminError::NotInitialized)?;
+    bump_entry(env, admin_key);
     admin.require_auth();
 
     store.set(admin_key, new_admin);
+    AdminUpdated {
+        old_admin: admin,
+        new_admin: new_admin.clone(),
+    }
+    .publish(env);
     Ok(())
 }
 


### PR DESCRIPTION
Library groundwork for pausing contracts during an incident. Nothing in this pull request
changes how any contract behaves, which is deliberate: the semantics below are easier to argue
about before four contracts depend on them.

## Storage shape

`pausable` keeps one persistent entry per contract, a struct under the key `Pause` holding
`flags`, `until`, and `armed`.

One entry rather than a key per bit. A gated call reads a single entry, so the cost of the
check is one storage read regardless of how many bits a contract recognizes, and a client
reads pause state the same way it reads any other contract key.

## Masks

Every caller passes the set of bits it recognizes. Pools will pass
`DEPOSITS | TRANSFERS | WITHDRAWALS`, the ASP contracts `MUTATIONS`.

Flags of zero, or any flag outside the caller's mask, are refused. Without that check a
mistyped constant would set a bit no code ever reads, and the operator would believe something
was paused when it was not. Failing the call is the safer answer.

## Timed pauses, and why only withdrawals expire

A timed pause names the ledger from which `WITHDRAWALS` resumes. That lets an operator hold
deposits and transfers shut for as long as an incident lasts while promising users their funds
become withdrawable again at a specific ledger, without needing anyone to be awake to lift it.

The promise is enforced rather than advisory:

- A second timed pause is refused while one is armed, so the ledger users were told cannot be
  quietly pushed back.
- An unpause clears the arm, as does an untimed pause. An untimed pause therefore leaves the
  bits set with no deadline at all, which is the honest reading of "we do not know yet".
- No other bit expires. On a contract that only recognizes `MUTATIONS`, a timed pause records
  a deadline that never arrives. That is surprising enough to be worth a test rather than a
  discovery, and there is one.

## Authorization

The module authorizes nobody. Every function assumes the caller has already established the
right to change pause state. A contract exposing a pause entry point is responsible for
requiring its administrator first.

## The admin event

`update_admin` now publishes `AdminUpdated` carrying the old and the new address. It
previously rotated the administrator silently, which left an operator with no way to see a
rotation without diffing state. Rotating to the address already stored is still permitted and
is recorded like any other rotation, so an attempted no-op rotation is visible too.

The two contract test files in this diff cover the new event and change nothing else.

Part of #372.
