### PR TITLE
Gate contract calls on pause bits

### DIFF
--- a/contracts/asp-membership/src/lib.rs
+++ b/contracts/asp-membership/src/lib.rs
@@ -8,7 +8,11 @@
 use soroban_sdk::{
     Address, Env, U256, Vec, contract, contracterror, contractevent, contractimpl, contracttype,
 };
-use soroban_utils::{bump_entry, bump_instance, get_zeroes, poseidon2_compress};
+use soroban_utils::{
+    bump_entry, bump_instance, get_zeroes,
+    pausable::{self, PauseError, PauseState},
+    poseidon2_compress,
+};
 
 /// Storage keys for contract persistent data
 #[contracttype]
@@ -43,6 +47,21 @@ pub enum Error {
     NotInitialized = 4,
     /// Arithmetic overflow occurred
     Overflow = 5,
+    /// Tree mutations are paused.
+    Paused = 6,
+    /// Pause flags were zero, or held a bit the contract does not recognize.
+    InvalidPauseFlags = 7,
+    /// A timed pause is in force, and a second one would move its deadline.
+    TimedPauseArmed = 8,
+}
+
+impl From<PauseError> for Error {
+    fn from(e: PauseError) -> Self {
+        match e {
+            PauseError::InvalidFlags => Error::InvalidPauseFlags,
+            PauseError::TimedPauseArmed => Error::TimedPauseArmed,
+        }
+    }
 }
 
 /// Event emitted when a new leaf is added to the Merkle tree
@@ -125,6 +144,68 @@ impl ASPMembership {
             .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
     }
 
+    /// Reads the stored administrator and extends the entry's lifetime.
+    fn get_admin(env: &Env) -> Result<Address, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .inspect(|_| bump_entry(env, &DataKey::Admin))
+            .ok_or(Error::NotInitialized)
+    }
+
+    /// Pauses tree mutations.
+    ///
+    /// The only bit the contract honors is `MUTATIONS` from
+    /// [`soroban_utils::pausable`], and it does not expire, so `until` only
+    /// arms the timed pause the module refuses to move. Requires admin
+    /// authorization.
+    ///
+    /// A pause stops `insert_leaf` and nothing else. `update_admin`,
+    /// `unpause`, `get_root`, and `hash_pair` answer while the contract is
+    /// paused, so an operator can hand over a paused contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the contract has no admin address
+    /// stored, [`Error::InvalidPauseFlags`] if `flags` is zero or holds a bit
+    /// other than `MUTATIONS`, and [`Error::TimedPauseArmed`] if `until` is
+    /// `Some` while a timed pause is already in force.
+    ///
+    /// # Events
+    ///
+    /// Publishes [`soroban_utils::pausable::PauseChanged`] from the contract.
+    pub fn pause(env: Env, flags: u32, until: Option<u32>) -> Result<(), Error> {
+        bump_instance(&env);
+        Self::get_admin(&env)?.require_auth();
+        Ok(pausable::pause(&env, flags, until, pausable::MUTATIONS)?)
+    }
+
+    /// Clears the pause bits named by `flags`.
+    ///
+    /// Clearing bits that are not set is accepted, and any unpause also clears
+    /// a timed pause. Requires admin authorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the contract has no admin address
+    /// stored, and [`Error::InvalidPauseFlags`] if `flags` is zero or holds a
+    /// bit other than `MUTATIONS`.
+    ///
+    /// # Events
+    ///
+    /// Publishes [`soroban_utils::pausable::PauseChanged`] from the contract.
+    pub fn unpause(env: Env, flags: u32) -> Result<(), Error> {
+        bump_instance(&env);
+        Self::get_admin(&env)?.require_auth();
+        Ok(pausable::unpause(&env, flags, pausable::MUTATIONS)?)
+    }
+
+    /// Returns the contract's pause bits.
+    pub fn get_pause_state(env: Env) -> PauseState {
+        bump_instance(&env);
+        pausable::get_state(&env)
+    }
+
     /// Get the current Merkle root
     ///
     /// Returns the current root hash of the Merkle tree.
@@ -178,16 +259,18 @@ impl ASPMembership {
     /// # Errors
     ///
     /// Returns [`Error::NotInitialized`] if the contract is missing the admin
-    /// address or any tree state the insertion reads,
-    /// [`Error::MerkleTreeFull`] if the tree is at capacity, and
-    /// [`Error::Overflow`] if the next leaf index would exceed `u64::MAX`.
+    /// address or any tree state the insertion reads, [`Error::Paused`] if
+    /// mutations are paused, [`Error::MerkleTreeFull`] if the tree is at
+    /// capacity, and [`Error::Overflow`] if the next leaf index would exceed
+    /// `u64::MAX`.
     pub fn insert_leaf(env: Env, leaf: U256) -> Result<(), Error> {
         bump_instance(&env);
-        let store = env.storage().persistent();
-        let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
-        bump_entry(&env, &DataKey::Admin);
-        admin.require_auth();
+        Self::get_admin(&env)?.require_auth();
+        if pausable::is_paused(&env, pausable::MUTATIONS) {
+            return Err(Error::Paused);
+        }
 
+        let store = env.storage().persistent();
         let levels: u32 = store.get(&DataKey::Levels).ok_or(Error::NotInitialized)?;
         bump_entry(&env, &DataKey::Levels);
         let actual_index: u64 = store

--- a/contracts/asp-membership/src/test.rs
+++ b/contracts/asp-membership/src/test.rs
@@ -802,3 +802,201 @@ fn test_full_tree_insert_fails_without_extending() {
     assert_ne!(before, EXTEND_TO);
     assert_eq!(entry_ttl(&env, &contract_id, &DataKey::NextIndex), before);
 }
+
+fn next_index(env: &Env, contract: &Address) -> u64 {
+    env.as_contract(contract, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::NextIndex)
+            .expect("NextIndex set in constructor")
+    })
+}
+
+/// Registers a paused contract and returns its address and client.
+fn paused_contract(env: &Env) -> (Address, ASPMembershipClient<'_>) {
+    let admin = Address::generate(env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(env, &contract_id);
+
+    env.mock_all_auths();
+    client.pause(&pausable::MUTATIONS, &None);
+    (contract_id, client)
+}
+
+#[test]
+fn test_insert_leaf_rejected_while_paused() {
+    use soroban_sdk::testutils::Events;
+    let env = test_env();
+    let (contract_id, client) = paused_contract(&env);
+    let root_before = client.get_root();
+    let events_before = env.events().all().events().len();
+
+    let err = client
+        .try_insert_leaf(&U256::from_u32(&env, 100))
+        .expect_err("an insert must be refused while mutations are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+    assert_eq!(client.get_root(), root_before);
+    assert_eq!(next_index(&env, &contract_id), 0);
+    assert_eq!(env.events().all().events().len(), events_before);
+}
+
+#[test]
+fn test_insert_leaf_allowed_after_unpause() {
+    let env = test_env();
+    let (contract_id, client) = paused_contract(&env);
+
+    client.unpause(&pausable::MUTATIONS);
+    client.insert_leaf(&U256::from_u32(&env, 100));
+
+    assert_eq!(next_index(&env, &contract_id), 1);
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_pause_requires_admin() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+
+    ASPMembershipClient::new(&env, &contract_id).pause(&pausable::MUTATIONS, &None);
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_unpause_requires_admin() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+
+    ASPMembershipClient::new(&env, &contract_id).unpause(&pausable::MUTATIONS);
+}
+
+#[test]
+fn test_pause_rejects_bits_outside_mutations() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+
+    let err = client
+        .try_pause(&2u32, &None)
+        .expect_err("a pause naming a bit the contract does not honor must be refused");
+
+    assert_eq!(err, Ok(Error::InvalidPauseFlags));
+}
+
+#[test]
+fn test_timed_pause_arms_and_second_is_refused() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+    client.pause(&pausable::MUTATIONS, &Some(500));
+
+    let err = client
+        .try_pause(&pausable::MUTATIONS, &Some(900))
+        .expect_err("a second timed pause must not move the promised ledger");
+
+    assert_eq!(err, Ok(Error::TimedPauseArmed));
+    assert_eq!(client.get_pause_state().until, Some(500));
+}
+
+#[test]
+fn test_update_admin_and_get_root_work_while_paused() {
+    let env = test_env();
+    let (contract_id, client) = paused_contract(&env);
+    let new_admin = Address::generate(&env);
+    let root = client.get_root();
+
+    client.update_admin(&new_admin);
+
+    let stored_admin: Address = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Admin set in constructor")
+    });
+    assert_eq!(stored_admin, new_admin);
+    assert_eq!(client.get_root(), root);
+}
+
+#[test]
+fn test_new_admin_can_unpause_after_rotation() {
+    let env = test_env();
+    let (contract_id, client) = paused_contract(&env);
+    let new_admin = Address::generate(&env);
+    client.update_admin(&new_admin);
+
+    env.mock_auths(&[MockAuth {
+        address: &new_admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "unpause",
+            args: (pausable::MUTATIONS,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.unpause(&pausable::MUTATIONS);
+
+    assert_eq!(client.get_pause_state().flags, 0);
+}
+
+/// `mock_all_auths` approves any signer, so the tests above cannot tell an
+/// admin signature from anyone else's. This one pins the address.
+///
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_pause_from_a_non_admin_is_refused() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+    let stranger = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &stranger,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "pause",
+            args: (pausable::MUTATIONS, None::<u32>).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.pause(&pausable::MUTATIONS, &None);
+}
+
+/// Only `WITHDRAWALS` expires, so a timed pause on `MUTATIONS` records a
+/// deadline that never arrives.
+#[test]
+fn test_a_timed_pause_still_blocks_insert_after_the_ledger_passes() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+    let until = env.ledger().sequence().saturating_add(10);
+    client.pause(&pausable::MUTATIONS, &Some(until));
+
+    env.ledger().set_sequence_number(until);
+
+    let err = client
+        .try_insert_leaf(&U256::from_u32(&env, 100))
+        .expect_err("a timed pause on mutations never reopens");
+    assert_eq!(err, Ok(Error::Paused));
+    assert!(client.get_pause_state().armed);
+}

--- a/contracts/asp-non-membership/src/lib.rs
+++ b/contracts/asp-non-membership/src/lib.rs
@@ -27,7 +27,11 @@ use soroban_sdk::{
     Address, Env, U256, Vec, contract, contracterror, contractevent, contractimpl, contracttype,
     vec,
 };
-use soroban_utils::{bump_entry, bump_instance, poseidon2_compress, poseidon2_hash2};
+use soroban_utils::{
+    bump_entry, bump_instance,
+    pausable::{self, PauseError, PauseState},
+    poseidon2_compress, poseidon2_hash2,
+};
 #[contracttype]
 #[derive(Clone, Debug)]
 enum DataKey {
@@ -66,6 +70,21 @@ pub enum Error {
     InvalidProof = 4,
     NotInitialized = 5,
     Overflow = 6,
+    /// Tree mutations are paused.
+    Paused = 7,
+    /// Pause flags were zero, or held a bit the contract does not recognize.
+    InvalidPauseFlags = 8,
+    /// A timed pause is in force, and a second one would move its deadline.
+    TimedPauseArmed = 9,
+}
+
+impl From<PauseError> for Error {
+    fn from(e: PauseError) -> Self {
+        match e {
+            PauseError::InvalidFlags => Error::InvalidPauseFlags,
+            PauseError::TimedPauseArmed => Error::TimedPauseArmed,
+        }
+    }
 }
 
 // Events
@@ -128,6 +147,69 @@ impl ASPNonMembership {
         bump_instance(&env);
         soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin)
             .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
+    }
+
+    /// Reads the stored administrator and extends the entry's lifetime.
+    fn get_admin(env: &Env) -> Result<Address, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .inspect(|_| bump_entry(env, &DataKey::Admin))
+            .ok_or(Error::NotInitialized)
+    }
+
+    /// Pauses tree mutations.
+    ///
+    /// The only bit the contract honors is `MUTATIONS` from
+    /// [`soroban_utils::pausable`], and it does not expire, so `until` only
+    /// arms the timed pause the module refuses to move. Requires admin
+    /// authorization.
+    ///
+    /// A pause stops `insert_leaf` and `delete_leaf`, and nothing else.
+    /// `update_admin`, `unpause`, `find_key`, `verify_non_membership`, and
+    /// `get_root` answer while the contract is paused, so pools keep proving
+    /// non-membership against a frozen tree.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the contract has no admin address
+    /// stored, [`Error::InvalidPauseFlags`] if `flags` is zero or holds a bit
+    /// other than `MUTATIONS`, and [`Error::TimedPauseArmed`] if `until` is
+    /// `Some` while a timed pause is already in force.
+    ///
+    /// # Events
+    ///
+    /// Publishes [`soroban_utils::pausable::PauseChanged`] from the contract.
+    pub fn pause(env: Env, flags: u32, until: Option<u32>) -> Result<(), Error> {
+        bump_instance(&env);
+        Self::get_admin(&env)?.require_auth();
+        Ok(pausable::pause(&env, flags, until, pausable::MUTATIONS)?)
+    }
+
+    /// Clears the pause bits named by `flags`.
+    ///
+    /// Clearing bits that are not set is accepted, and any unpause also clears
+    /// a timed pause. Requires admin authorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the contract has no admin address
+    /// stored, and [`Error::InvalidPauseFlags`] if `flags` is zero or holds a
+    /// bit other than `MUTATIONS`.
+    ///
+    /// # Events
+    ///
+    /// Publishes [`soroban_utils::pausable::PauseChanged`] from the contract.
+    pub fn unpause(env: Env, flags: u32) -> Result<(), Error> {
+        bump_instance(&env);
+        Self::get_admin(&env)?.require_auth();
+        Ok(pausable::unpause(&env, flags, pausable::MUTATIONS)?)
+    }
+
+    /// Returns the contract's pause bits.
+    pub fn get_pause_state(env: Env) -> PauseState {
+        bump_instance(&env);
+        pausable::get_state(&env)
     }
 
     /// Hash a leaf node using Poseidon2
@@ -365,16 +447,18 @@ impl ASPNonMembership {
     ///
     /// # Errors
     ///
+    /// * `Error::Paused` - Tree mutations are paused
     /// * `Error::KeyAlreadyExists` - Key already exists in the tree
     /// * `Error::KeyNotFound` - Database operations failed
     #[allow(clippy::cast_possible_truncation)]
     pub fn insert_leaf(env: Env, key: U256, value: U256) -> Result<(), Error> {
         bump_instance(&env);
-        let store = env.storage().persistent();
-        let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
-        bump_entry(&env, &DataKey::Admin);
-        admin.require_auth();
+        Self::get_admin(&env)?.require_auth();
+        if pausable::is_paused(&env, pausable::MUTATIONS) {
+            return Err(Error::Paused);
+        }
 
+        let store = env.storage().persistent();
         let root: U256 = store
             .get(&DataKey::Root)
             .inspect(|_| bump_entry(&env, &DataKey::Root))
@@ -530,14 +614,17 @@ impl ASPNonMembership {
     ///
     /// # Errors
     ///
+    /// * `Error::Paused` - Tree mutations are paused
     /// * `Error::KeyNotFound` - Key does not exist in the tree or database
     ///   operations failed
     pub fn delete_leaf(env: Env, key: U256) -> Result<(), Error> {
         bump_instance(&env);
+        Self::get_admin(&env)?.require_auth();
+        if pausable::is_paused(&env, pausable::MUTATIONS) {
+            return Err(Error::Paused);
+        }
+
         let store = env.storage().persistent();
-        let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
-        bump_entry(&env, &DataKey::Admin);
-        admin.require_auth();
         let root: U256 = store.get(&DataKey::Root).ok_or(Error::NotInitialized)?;
         bump_entry(&env, &DataKey::Root);
 

--- a/contracts/asp-non-membership/src/test.rs
+++ b/contracts/asp-non-membership/src/test.rs
@@ -1209,3 +1209,174 @@ fn test_find_key_extends_the_path_it_reads() {
         EXTEND_TO
     );
 }
+
+/// Registers a contract holding one leaf, then pauses mutations. Returns the
+/// client, the key it holds, and that key's value.
+fn paused_with_one_leaf(env: &Env) -> (ASPNonMembershipClient<'_>, U256, U256) {
+    let admin = Address::generate(env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(env, &contract_id);
+    let key = U256::from_u32(env, 1u32);
+    let value = U256::from_u32(env, 42u32);
+
+    env.mock_all_auths();
+    client.insert_leaf(&key, &value);
+    client.pause(&pausable::MUTATIONS, &None);
+    (client, key, value)
+}
+
+#[test]
+fn test_insert_leaf_rejected_while_paused() {
+    let env = test_env();
+    let (client, ..) = paused_with_one_leaf(&env);
+    let root_before = client.get_root();
+
+    let err = client
+        .try_insert_leaf(&U256::from_u32(&env, 7u32), &U256::from_u32(&env, 99u32))
+        .expect_err("an insert must be refused while mutations are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+    assert_eq!(client.get_root(), root_before);
+}
+
+#[test]
+fn test_delete_leaf_rejected_while_paused() {
+    let env = test_env();
+    let (client, key, value) = paused_with_one_leaf(&env);
+    let root_before = client.get_root();
+
+    let err = client
+        .try_delete_leaf(&key)
+        .expect_err("a delete must be refused while mutations are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+    assert_eq!(client.get_root(), root_before);
+    let find_result = client.find_key(&key);
+    assert!(find_result.found);
+    assert_eq!(find_result.found_value, value);
+}
+
+#[test]
+fn test_find_key_and_verify_work_while_paused() {
+    let env = test_env();
+    let (client, key, value) = paused_with_one_leaf(&env);
+    let absent_key = U256::from_u32(&env, 99u32);
+
+    let find_result = client.find_key(&absent_key);
+
+    assert!(!find_result.found);
+    assert_eq!(find_result.not_found_key, key);
+    assert_eq!(find_result.not_found_value, value);
+    assert!(client.verify_non_membership(
+        &absent_key,
+        &find_result.siblings,
+        &find_result.not_found_key,
+        &find_result.not_found_value,
+    ));
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_pause_requires_admin() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+
+    ASPNonMembershipClient::new(&env, &contract_id).pause(&pausable::MUTATIONS, &None);
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_unpause_requires_admin() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+
+    ASPNonMembershipClient::new(&env, &contract_id).unpause(&pausable::MUTATIONS);
+}
+
+#[test]
+fn test_writes_resume_after_unpause() {
+    let env = test_env();
+    let (client, key, _) = paused_with_one_leaf(&env);
+
+    client.unpause(&pausable::MUTATIONS);
+    client.insert_leaf(&U256::from_u32(&env, 7u32), &U256::from_u32(&env, 99u32));
+    client.delete_leaf(&key);
+
+    assert!(!client.find_key(&key).found);
+}
+
+#[test]
+fn test_timed_pause_arms_and_second_is_refused() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+    client.pause(&pausable::MUTATIONS, &Some(500));
+
+    let err = client
+        .try_pause(&pausable::MUTATIONS, &Some(900))
+        .expect_err("a second timed pause must not move the promised ledger");
+
+    assert_eq!(err, Ok(Error::TimedPauseArmed));
+    assert_eq!(client.get_pause_state().until, Some(500));
+}
+
+/// `mock_all_auths` approves any signer, so the tests above cannot tell an
+/// admin signature from anyone else's. This one pins the address.
+///
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_pause_from_a_non_admin_is_refused() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+    let stranger = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &stranger,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "pause",
+            args: (pausable::MUTATIONS, None::<u32>).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.pause(&pausable::MUTATIONS, &None);
+}
+
+/// Only `WITHDRAWALS` expires, so a timed pause on `MUTATIONS` records a
+/// deadline that never arrives.
+#[test]
+fn test_a_timed_pause_still_blocks_insert_after_the_ledger_passes() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+    let until = env.ledger().sequence().saturating_add(10);
+    client.pause(&pausable::MUTATIONS, &Some(until));
+
+    env.ledger().set_sequence_number(until);
+
+    let err = client
+        .try_insert_leaf(&U256::from_u32(&env, 1u32), &U256::from_u32(&env, 42u32))
+        .expect_err("a timed pause on mutations never reopens");
+    assert_eq!(err, Ok(Error::Paused));
+    assert!(client.get_pause_state().armed);
+}

--- a/contracts/pool-gvk/src/pool_gvk.rs
+++ b/contracts/pool-gvk/src/pool_gvk.rs
@@ -24,7 +24,11 @@ use soroban_sdk::{
     Address, Bytes, BytesN, Env, I256, U256, Vec, contract, contracterror, contractevent,
     contractimpl, contracttype, crypto::bn254::Bn254Fr, token::TokenClient,
 };
-use soroban_utils::{bump_dependency, bump_entry, bump_instance, constants::bn256_modulus};
+use soroban_utils::{
+    bump_dependency, bump_entry, bump_instance,
+    constants::bn256_modulus,
+    pausable::{self, PauseError, PauseState},
+};
 
 // Re-exported rather than merely imported so `pool_gvk::ExtData` and
 // `pool_gvk::hash_ext_data` stay part of this crate's surface, mirroring
@@ -72,6 +76,21 @@ pub enum Error {
     WrongGvkCiphertextCount = 16,
     /// Admin view key `D` is unusable as a circuit public input.
     InvalidAdminViewKey = 17,
+    /// Transactions of this shape are paused.
+    Paused = 18,
+    /// Pause flags were zero, or held a bit the pool does not recognize.
+    InvalidPauseFlags = 19,
+    /// A timed pause is in force, and a second one would move its deadline.
+    TimedPauseArmed = 20,
+}
+
+impl From<PauseError> for Error {
+    fn from(e: PauseError) -> Self {
+        match e {
+            PauseError::InvalidFlags => Error::InvalidPauseFlags,
+            PauseError::TimedPauseArmed => Error::TimedPauseArmed,
+        }
+    }
 }
 
 impl From<MerkleError> for Error {
@@ -337,6 +356,15 @@ impl PoolGvkContract {
         Ok(spent)
     }
 
+    /// Get the admin address.
+    fn get_admin(env: &Env) -> Result<Address, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .inspect(|_| bump_entry(env, &DataKey::Admin))
+            .ok_or(Error::NotInitialized)
+    }
+
     /// Update the contract administrator. Requires authorization from the
     /// current admin.
     ///
@@ -348,6 +376,59 @@ impl PoolGvkContract {
         Self::touch(&env);
         soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin)
             .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
+    }
+
+    /// Pause the transaction shapes named by `flags`.
+    ///
+    /// The bits are `DEPOSITS`, `TRANSFERS`, and `WITHDRAWALS` from
+    /// [`soroban_utils::pausable`]. Passing `Some(until)` promises that
+    /// withdrawals reopen at that ledger, and no second timed pause may move
+    /// that ledger. Requires admin authorization.
+    ///
+    /// A pause stops `transact` and nothing else. `update_admin`, `unpause`,
+    /// and every getter answer while the pool is fully paused, so an operator
+    /// can hand over a paused pool.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the pool has no admin address
+    /// stored, [`Error::InvalidPauseFlags`] if `flags` is zero or holds a bit
+    /// outside the three above, and [`Error::TimedPauseArmed`] if `until` is
+    /// `Some` while a timed pause is already in force.
+    ///
+    /// # Events
+    ///
+    /// Publishes [`soroban_utils::pausable::PauseChanged`] from the pool.
+    pub fn pause(env: &Env, flags: u32, until: Option<u32>) -> Result<(), Error> {
+        Self::touch(env);
+        Self::get_admin(env)?.require_auth();
+        Ok(pausable::pause(env, flags, until, pausable::POOL_MASK)?)
+    }
+
+    /// Clear the pause bits named by `flags`.
+    ///
+    /// Clearing bits that are not set is accepted, and any unpause also clears
+    /// a timed pause. Requires admin authorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the pool has no admin address
+    /// stored, and [`Error::InvalidPauseFlags`] if `flags` is zero or holds a
+    /// bit the pool does not recognize.
+    ///
+    /// # Events
+    ///
+    /// Publishes [`soroban_utils::pausable::PauseChanged`] from the pool.
+    pub fn unpause(env: &Env, flags: u32) -> Result<(), Error> {
+        Self::touch(env);
+        Self::get_admin(env)?.require_auth();
+        Ok(pausable::unpause(env, flags, pausable::POOL_MASK)?)
+    }
+
+    /// Get the pool's pause bits and the ledger at which withdrawals reopen.
+    pub fn get_pause_state(env: &Env) -> PauseState {
+        Self::touch(env);
+        pausable::get_state(env)
     }
 
     // ========== ASP Contract Functions ==========
@@ -645,6 +726,11 @@ impl PoolGvkContract {
     ) -> Result<(), Error> {
         Self::touch(env);
         sender.require_auth();
+
+        if pausable::is_paused(env, pausable::shape_bit(env, &ext_data.ext_amount)) {
+            return Err(Error::Paused);
+        }
+
         bump_dependency(env, &Self::get_verifier(env)?);
         let policy_flags = Self::load_policy_flags(env)?;
         if policy::requires_membership_proofs(policy_flags) {

--- a/contracts/pool-gvk/src/test.rs
+++ b/contracts/pool-gvk/src/test.rs
@@ -30,6 +30,7 @@ use soroban_sdk::{
 };
 use soroban_utils::{
     constants::bn256_modulus,
+    pausable::{self, PauseChanged},
     ttl::{EXTEND_TO, THRESHOLD},
     utils::MockToken,
 };
@@ -2004,4 +2005,293 @@ fn getters_extend_the_instance() {
     pool.get_root();
 
     assert_eq!(instance_ttl(&env, &pool_id), EXTEND_TO);
+}
+
+/// A GVK pool with mocked authorizations and no ASP policy, for the pause
+/// paths that never reach a proof.
+fn pausable_pool_gvk(env: &Env) -> PoolGvkContractClient<'static> {
+    env.mock_all_auths();
+    let setup = setup_test_contracts(env);
+    let pool_id = register_pool_gvk(
+        env,
+        &setup,
+        U256::from_u32(env, 1000),
+        3,
+        0,
+        mk_point(env, 1, 2),
+        VIEW_ONLY,
+    );
+    PoolGvkContractClient::new(env, &pool_id)
+}
+
+#[test]
+fn transact_rejects_deposit_while_deposits_paused() {
+    let nullifier = 0xF1;
+    let (env, pool, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, nullifier, 500, 1000);
+    pool.pause(&pausable::DEPOSITS, &None);
+
+    let err = pool
+        .try_transact(&proof, &ext, &sender)
+        .expect_err("a deposit must be refused while deposits are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+    assert!(!pool.is_spent(&U256::from_u32(&env, nullifier)));
+}
+
+#[test]
+fn transact_allows_withdrawal_and_transfer_while_only_deposits_paused() {
+    let (_, withdrawing, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, 0xF2, -300, 1000);
+    withdrawing.pause(&pausable::DEPOSITS, &None);
+    withdrawing.transact(&proof, &ext, &sender);
+
+    let (_, transferring, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, 0xF3, 0, 1000);
+    transferring.pause(&pausable::DEPOSITS, &None);
+    transferring.transact(&proof, &ext, &sender);
+}
+
+#[test]
+fn transact_rejects_transfer_while_transfers_paused() {
+    let (_, pool, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, 0xF4, 0, 1000);
+    pool.pause(&pausable::TRANSFERS, &None);
+
+    let err = pool
+        .try_transact(&proof, &ext, &sender)
+        .expect_err("a transfer must be refused while transfers are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+}
+
+#[test]
+fn transact_rejects_withdrawal_while_withdrawals_paused() {
+    let (_, pool, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, 0xF5, -300, 1000);
+    pool.pause(&pausable::WITHDRAWALS, &None);
+
+    let err = pool
+        .try_transact(&proof, &ext, &sender)
+        .expect_err("a withdrawal must be refused while withdrawals are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+}
+
+#[test]
+fn full_pause_blocks_all_three_shapes() {
+    for ext_amount in [500i32, 0, -300] {
+        let (_, pool, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, 0xF6, ext_amount, 1000);
+        pool.pause(&pausable::POOL_MASK, &None);
+
+        let err = pool
+            .try_transact(&proof, &ext, &sender)
+            .expect_err("a fully paused pool must refuse every shape");
+
+        assert_eq!(
+            err,
+            Ok(Error::Paused),
+            "ext_amount {ext_amount} was allowed"
+        );
+    }
+}
+
+#[test]
+fn withdrawals_reopen_when_the_timed_pause_expires_but_deposits_stay_paused() {
+    let (env, pool, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, 0xF7, -300, 1000);
+    let until = env.ledger().sequence().saturating_add(10);
+    pool.pause(&(pausable::DEPOSITS | pausable::WITHDRAWALS), &Some(until));
+
+    env.ledger().set_sequence_number(until);
+    pool.transact(&proof, &ext, &sender);
+
+    // The pause check reads only the sign of `ext_amount`, and it runs before
+    // the proof is looked at, so a deposit-shaped call needs no proof of its
+    // own to prove that deposits are still shut.
+    let deposit = mk_ext_data(&env, Address::generate(&env), 500);
+    let err = pool
+        .try_transact(&proof, &deposit, &sender)
+        .expect_err("only withdrawals reopen when a timed pause expires");
+    assert_eq!(err, Ok(Error::Paused));
+
+    let state = pool.get_pause_state();
+    assert_eq!(state.flags, pausable::DEPOSITS | pausable::WITHDRAWALS);
+    assert!(state.armed);
+}
+
+#[test]
+fn transact_succeeds_again_after_unpause() {
+    let (_, pool, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, 0xF8, 0, 1000);
+    pool.pause(&pausable::TRANSFERS, &None);
+    assert!(pool.try_transact(&proof, &ext, &sender).is_err());
+
+    pool.unpause(&pausable::TRANSFERS);
+
+    pool.transact(&proof, &ext, &sender);
+}
+
+#[test]
+fn update_admin_works_while_fully_paused() {
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+    pool.pause(&pausable::POOL_MASK, &None);
+    let new_admin = Address::generate(&env);
+
+    pool.update_admin(&new_admin);
+
+    let stored: Address = env.as_contract(&pool.address, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Admin updated")
+    });
+    assert_eq!(stored, new_admin);
+}
+
+#[test]
+fn getters_work_while_fully_paused() {
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+    pool.pause(&pausable::POOL_MASK, &None);
+
+    let root = pool.get_root();
+
+    assert!(pool.is_known_root(&root));
+    assert_eq!(pool.get_gvk_mode(), VIEW_ONLY);
+}
+
+#[test]
+fn get_admin_view_key_works_while_fully_paused() {
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+    pool.pause(&pausable::POOL_MASK, &None);
+
+    assert_eq!(pool.get_admin_view_key(), mk_point(&env, 1, 2));
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn pause_requires_admin() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool_gvk(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        0,
+        mk_point(&env, 1, 2),
+        VIEW_ONLY,
+    );
+
+    PoolGvkContractClient::new(&env, &pool_id).pause(&pausable::DEPOSITS, &None);
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn unpause_requires_admin() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool_gvk(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        0,
+        mk_point(&env, 1, 2),
+        VIEW_ONLY,
+    );
+
+    PoolGvkContractClient::new(&env, &pool_id).unpause(&pausable::DEPOSITS);
+}
+
+#[test]
+fn pause_errors_when_admin_unset() {
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+    env.as_contract(&pool.address, || {
+        env.storage().persistent().remove(&DataKey::Admin);
+    });
+
+    assert_eq!(
+        pool.try_pause(&pausable::DEPOSITS, &None)
+            .expect_err("a pool with no admin cannot be paused"),
+        Ok(Error::NotInitialized)
+    );
+    assert_eq!(
+        pool.try_unpause(&pausable::DEPOSITS)
+            .expect_err("a pool with no admin cannot be unpaused"),
+        Ok(Error::NotInitialized)
+    );
+}
+
+#[test]
+fn pause_rejects_zero_flags() {
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+
+    let err = pool
+        .try_pause(&0u32, &None)
+        .expect_err("a pause that names no bit must be refused");
+
+    assert_eq!(err, Ok(Error::InvalidPauseFlags));
+}
+
+#[test]
+fn pause_rejects_unknown_bits() {
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+
+    let err = pool
+        .try_pause(&8u32, &None)
+        .expect_err("a pause naming a bit the pool does not honor must be refused");
+
+    assert_eq!(err, Ok(Error::InvalidPauseFlags));
+}
+
+#[test]
+fn second_timed_pause_is_refused_while_armed() {
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+    pool.pause(&pausable::WITHDRAWALS, &Some(500));
+
+    let err = pool
+        .try_pause(&pausable::DEPOSITS, &Some(900))
+        .expect_err("a second timed pause must not move the promised ledger");
+
+    assert_eq!(err, Ok(Error::TimedPauseArmed));
+    assert_eq!(pool.get_pause_state().until, Some(500));
+}
+
+#[test]
+fn untimed_pause_clears_the_arm_so_a_timed_pause_is_accepted_again() {
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+    pool.pause(&pausable::WITHDRAWALS, &Some(500));
+
+    pool.pause(&pausable::DEPOSITS, &None);
+    pool.pause(&pausable::TRANSFERS, &Some(900));
+
+    assert_eq!(pool.get_pause_state().until, Some(900));
+}
+
+#[test]
+fn pause_emits_pause_changed_from_the_pool_address() {
+    use soroban_sdk::events::Event;
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+
+    pool.pause(&pausable::DEPOSITS, &Some(500));
+
+    let events = env.events().all();
+    assert_eq!(events.events().len(), 1);
+    let expected = PauseChanged {
+        flags: pausable::DEPOSITS,
+        until: Some(500),
+    }
+    .to_xdr(&env, &pool.address);
+    assert_eq!(events.events()[0], expected);
 }

--- a/contracts/pool/src/pool.rs
+++ b/contracts/pool/src/pool.rs
@@ -23,7 +23,11 @@ use soroban_sdk::{
     Address, Bytes, BytesN, Env, I256, U256, Vec, contract, contracterror, contractevent,
     contractimpl, contracttype, crypto::bn254::Bn254Fr, token::TokenClient,
 };
-use soroban_utils::{bump_dependency, bump_entry, bump_instance, constants::bn256_modulus};
+use soroban_utils::{
+    bump_dependency, bump_entry, bump_instance,
+    constants::bn256_modulus,
+    pausable::{self, PauseError, PauseState},
+};
 
 // Re-exported rather than merely imported so `pool::ExtData` and
 // `pool::hash_ext_data` keep resolving for existing consumers (`e2e-tests`,
@@ -63,6 +67,21 @@ pub enum Error {
     NonCanonicalPublicInput = 13,
     /// Unsupported policy flag bits.
     InvalidPolicyFlags = 14,
+    /// Transactions of this shape are paused.
+    Paused = 15,
+    /// Pause flags were zero, or held a bit the pool does not recognize.
+    InvalidPauseFlags = 16,
+    /// A timed pause is in force, and a second one would move its deadline.
+    TimedPauseArmed = 17,
+}
+
+impl From<PauseError> for Error {
+    fn from(e: PauseError) -> Self {
+        match e {
+            PauseError::InvalidFlags => Error::InvalidPauseFlags,
+            PauseError::TimedPauseArmed => Error::TimedPauseArmed,
+        }
+    }
 }
 
 /// Conversion from MerkleTreeWithHistory errors to pool contract errors
@@ -431,6 +450,9 @@ impl PoolContract {
     /// * `sender` - Address of the transaction sender (must authorize funding
     ///   transaction)
     ///
+    /// The shape of the transaction, read from the sign of
+    /// `ext_data.ext_amount`, must not be paused.
+    ///
     /// # Returns
     ///
     /// Returns `Ok(())` on success, or an error if validation fails
@@ -442,6 +464,11 @@ impl PoolContract {
     ) -> Result<(), Error> {
         Self::touch(env);
         sender.require_auth();
+
+        if pausable::is_paused(env, pausable::shape_bit(env, &ext_data.ext_amount)) {
+            return Err(Error::Paused);
+        }
+
         bump_dependency(env, &Self::get_verifier(env)?);
         let policy_flags = Self::load_policy_flags(env)?;
         if policy::requires_membership_proofs(policy_flags) {
@@ -691,6 +718,61 @@ impl PoolContract {
         Self::touch(&env);
         soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin)
             .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
+    }
+
+    /// Pause the transaction shapes named by `flags`.
+    ///
+    /// The bits are `DEPOSITS`, `TRANSFERS`, and `WITHDRAWALS` from
+    /// [`soroban_utils::pausable`]. Passing `Some(until)` promises that
+    /// withdrawals reopen at that ledger, and no second timed pause may move
+    /// that ledger. Requires admin authorization.
+    ///
+    /// A pause stops `transact` and nothing else. Administration keeps working
+    /// throughout: `update_admin`, `update_asp_membership`,
+    /// `update_asp_non_membership`, `unpause`, and every getter answer while
+    /// the pool is fully paused, so an operator can repoint or hand over a
+    /// paused pool.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the pool has no admin address
+    /// stored, [`Error::InvalidPauseFlags`] if `flags` is zero or holds a bit
+    /// outside the three above, and [`Error::TimedPauseArmed`] if `until` is
+    /// `Some` while a timed pause is already in force.
+    ///
+    /// # Events
+    ///
+    /// Publishes [`soroban_utils::pausable::PauseChanged`] from the pool.
+    pub fn pause(env: &Env, flags: u32, until: Option<u32>) -> Result<(), Error> {
+        Self::touch(env);
+        Self::get_admin(env)?.require_auth();
+        Ok(pausable::pause(env, flags, until, pausable::POOL_MASK)?)
+    }
+
+    /// Clear the pause bits named by `flags`.
+    ///
+    /// Clearing bits that are not set is accepted, and any unpause also clears
+    /// a timed pause. Requires admin authorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the pool has no admin address
+    /// stored, and [`Error::InvalidPauseFlags`] if `flags` is zero or holds a
+    /// bit the pool does not recognize.
+    ///
+    /// # Events
+    ///
+    /// Publishes [`soroban_utils::pausable::PauseChanged`] from the pool.
+    pub fn unpause(env: &Env, flags: u32) -> Result<(), Error> {
+        Self::touch(env);
+        Self::get_admin(env)?.require_auth();
+        Ok(pausable::unpause(env, flags, pausable::POOL_MASK)?)
+    }
+
+    /// Get the pool's pause bits and the ledger at which withdrawals reopen.
+    pub fn get_pause_state(env: &Env) -> PauseState {
+        Self::touch(env);
+        pausable::get_state(env)
     }
 
     // ========== ASP Contract Functions ==========

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -19,6 +19,7 @@ use soroban_sdk::{
 };
 use soroban_utils::{
     constants::bn256_modulus,
+    pausable::{self, PauseChanged},
     ttl::{EXTEND_TO, THRESHOLD},
     utils::MockToken,
 };
@@ -1984,4 +1985,342 @@ fn transact_rejects_deposit_with_invalid_proof_without_moving_funds() {
         0,
         "a refused deposit must not credit the pool"
     );
+}
+
+/// Tokens minted to the sender and to the pool by [`pausable_pool`], enough for
+/// any single deposit or withdrawal the pause tests make.
+const PAUSE_FIXTURE_FUNDS: i128 = 10_000;
+
+/// A pool on a verifier that accepts every proof, holding a real asset so that
+/// a deposit or a withdrawal shows up in balances. Authorizations are mocked,
+/// and the pool carries no ASP policy, so only the pause check stands between a
+/// well-formed transaction and success.
+fn pausable_pool(env: &Env, sender: &Address) -> (TestSetup, Address, PoolContractClient<'static>) {
+    env.mock_all_auths();
+    let mut setup = setup_test_contracts(env);
+    setup.token = register_funded_token(env, sender, PAUSE_FIXTURE_FUNDS);
+    let verifier = env.register(AcceptingVerifier, ());
+    let pool_id = register_pool_with_verifier(env, &setup, &verifier, 3, 0);
+    StellarAssetClient::new(env, &setup.token).mint(&pool_id, &PAUSE_FIXTURE_FUNDS);
+    let pool = PoolContractClient::new(env, &pool_id);
+    (setup, pool_id, pool)
+}
+
+/// The public amount a proof must carry for `ext_amount`: the value itself for
+/// a deposit or a transfer, and the field's complement for a withdrawal.
+fn expected_public_amount(env: &Env, ext_amount: i32) -> U256 {
+    let magnitude = U256::from_u32(env, ext_amount.unsigned_abs());
+    if ext_amount < 0 {
+        bn256_modulus(env).sub(&magnitude)
+    } else {
+        magnitude
+    }
+}
+
+/// A proof and external data moving `ext_amount`, consistent enough that only
+/// the pause check can refuse it.
+fn mk_transact_of(
+    env: &Env,
+    setup: &TestSetup,
+    pool: &PoolContractClient,
+    ext_amount: i32,
+    nullifier: u32,
+) -> (Proof, ExtData) {
+    let (member_root, non_member_root) = asp_roots(setup);
+    let (mut proof, _) = mk_transact_proof(env, pool, member_root, non_member_root, nullifier);
+    let ext = mk_ext_data(env, Address::generate(env), ext_amount);
+    proof.ext_data_hash = compute_ext_hash(env, &ext);
+    proof.public_amount = expected_public_amount(env, ext_amount);
+    (proof, ext)
+}
+
+#[test]
+fn transact_rejects_deposit_while_deposits_paused() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (setup, pool_id, pool) = pausable_pool(&env, &sender);
+    let token = TokenClient::new(&env, &setup.token);
+    pool.pause(&pausable::DEPOSITS, &None);
+
+    let nullifier = 0xD1;
+    let (proof, ext) = mk_transact_of(&env, &setup, &pool, 500, nullifier);
+    let err = pool
+        .try_transact(&proof, &ext, &sender)
+        .expect_err("a deposit must be refused while deposits are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+    assert_eq!(token.balance(&sender), PAUSE_FIXTURE_FUNDS);
+    assert_eq!(token.balance(&pool_id), PAUSE_FIXTURE_FUNDS);
+    assert!(!pool.is_spent(&U256::from_u32(&env, nullifier)));
+}
+
+#[test]
+fn transact_allows_withdrawal_and_transfer_while_only_deposits_paused() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (setup, pool_id, pool) = pausable_pool(&env, &sender);
+    let token = TokenClient::new(&env, &setup.token);
+    pool.pause(&pausable::DEPOSITS, &None);
+
+    let (withdrawal, withdrawal_ext) = mk_transact_of(&env, &setup, &pool, -300, 0xD2);
+    pool.transact(&withdrawal, &withdrawal_ext, &sender);
+    let (transfer, transfer_ext) = mk_transact_of(&env, &setup, &pool, 0, 0xD3);
+    pool.transact(&transfer, &transfer_ext, &sender);
+
+    assert_eq!(
+        token.balance(&pool_id),
+        PAUSE_FIXTURE_FUNDS.saturating_sub(300)
+    );
+}
+
+#[test]
+fn transact_rejects_transfer_while_transfers_paused() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (setup, _, pool) = pausable_pool(&env, &sender);
+    pool.pause(&pausable::TRANSFERS, &None);
+
+    let (proof, ext) = mk_transact_of(&env, &setup, &pool, 0, 0xD4);
+    let err = pool
+        .try_transact(&proof, &ext, &sender)
+        .expect_err("a transfer must be refused while transfers are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+}
+
+#[test]
+fn transact_rejects_withdrawal_while_withdrawals_paused() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (setup, pool_id, pool) = pausable_pool(&env, &sender);
+    let token = TokenClient::new(&env, &setup.token);
+    pool.pause(&pausable::WITHDRAWALS, &None);
+
+    let (proof, ext) = mk_transact_of(&env, &setup, &pool, -300, 0xD5);
+    let err = pool
+        .try_transact(&proof, &ext, &sender)
+        .expect_err("a withdrawal must be refused while withdrawals are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+    assert_eq!(token.balance(&pool_id), PAUSE_FIXTURE_FUNDS);
+}
+
+#[test]
+fn full_pause_blocks_all_three_shapes() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (setup, _, pool) = pausable_pool(&env, &sender);
+    pool.pause(&pausable::POOL_MASK, &None);
+
+    for ext_amount in [500i32, 0, -300] {
+        let (proof, ext) = mk_transact_of(&env, &setup, &pool, ext_amount, 0xD6);
+        let err = pool
+            .try_transact(&proof, &ext, &sender)
+            .expect_err("a fully paused pool must refuse every shape");
+        assert_eq!(
+            err,
+            Ok(Error::Paused),
+            "ext_amount {ext_amount} was allowed"
+        );
+    }
+}
+
+#[test]
+fn withdrawals_reopen_when_the_timed_pause_expires_but_deposits_stay_paused() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (setup, pool_id, pool) = pausable_pool(&env, &sender);
+    let token = TokenClient::new(&env, &setup.token);
+    let until = env.ledger().sequence().saturating_add(10);
+    pool.pause(&(pausable::DEPOSITS | pausable::WITHDRAWALS), &Some(until));
+
+    env.ledger().set_sequence_number(until);
+
+    let (withdrawal, withdrawal_ext) = mk_transact_of(&env, &setup, &pool, -300, 0xD7);
+    pool.transact(&withdrawal, &withdrawal_ext, &sender);
+    assert_eq!(
+        token.balance(&pool_id),
+        PAUSE_FIXTURE_FUNDS.saturating_sub(300)
+    );
+
+    let (deposit, deposit_ext) = mk_transact_of(&env, &setup, &pool, 500, 0xD8);
+    let err = pool
+        .try_transact(&deposit, &deposit_ext, &sender)
+        .expect_err("only withdrawals reopen when a timed pause expires");
+    assert_eq!(err, Ok(Error::Paused));
+
+    let state = pool.get_pause_state();
+    assert_eq!(state.flags, pausable::DEPOSITS | pausable::WITHDRAWALS);
+    assert!(state.armed);
+}
+
+#[test]
+fn transact_succeeds_again_after_unpause() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (setup, _, pool) = pausable_pool(&env, &sender);
+    pool.pause(&pausable::TRANSFERS, &None);
+    let (proof, ext) = mk_transact_of(&env, &setup, &pool, 0, 0xD9);
+    assert!(pool.try_transact(&proof, &ext, &sender).is_err());
+
+    pool.unpause(&pausable::TRANSFERS);
+
+    pool.transact(&proof, &ext, &sender);
+}
+
+#[test]
+fn update_admin_works_while_fully_paused() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (_, pool_id, pool) = pausable_pool(&env, &sender);
+    pool.pause(&pausable::POOL_MASK, &None);
+    let new_admin = Address::generate(&env);
+
+    pool.update_admin(&new_admin);
+
+    let stored: Address = env.as_contract(&pool_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Admin updated")
+    });
+    assert_eq!(stored, new_admin);
+}
+
+#[test]
+fn getters_work_while_fully_paused() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (setup, _, pool) = pausable_pool(&env, &sender);
+    pool.pause(&pausable::POOL_MASK, &None);
+
+    let root = pool.get_root();
+
+    assert!(pool.is_known_root(&root));
+    assert_eq!(
+        pool.get_asp_membership_root(),
+        setup.asp_membership_client.get_root()
+    );
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn pause_requires_admin() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 3, 0u32);
+
+    PoolContractClient::new(&env, &pool_id).pause(&pausable::DEPOSITS, &None);
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn unpause_requires_admin() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 3, 0u32);
+
+    PoolContractClient::new(&env, &pool_id).unpause(&pausable::DEPOSITS);
+}
+
+#[test]
+fn pause_errors_when_admin_unset() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (_, pool_id, pool) = pausable_pool(&env, &sender);
+    env.as_contract(&pool_id, || {
+        env.storage().persistent().remove(&DataKey::Admin);
+    });
+
+    assert_eq!(
+        pool.try_pause(&pausable::DEPOSITS, &None)
+            .expect_err("a pool with no admin cannot be paused"),
+        Ok(Error::NotInitialized)
+    );
+    assert_eq!(
+        pool.try_unpause(&pausable::DEPOSITS)
+            .expect_err("a pool with no admin cannot be unpaused"),
+        Ok(Error::NotInitialized)
+    );
+}
+
+#[test]
+fn pause_rejects_zero_flags() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (_, _, pool) = pausable_pool(&env, &sender);
+
+    let err = pool
+        .try_pause(&0u32, &None)
+        .expect_err("a pause that names no bit must be refused");
+
+    assert_eq!(err, Ok(Error::InvalidPauseFlags));
+}
+
+#[test]
+fn pause_rejects_unknown_bits() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (_, _, pool) = pausable_pool(&env, &sender);
+
+    let err = pool
+        .try_pause(&8u32, &None)
+        .expect_err("a pause naming a bit the pool does not honor must be refused");
+
+    assert_eq!(err, Ok(Error::InvalidPauseFlags));
+}
+
+#[test]
+fn second_timed_pause_is_refused_while_armed() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (_, _, pool) = pausable_pool(&env, &sender);
+    pool.pause(&pausable::WITHDRAWALS, &Some(500));
+
+    let err = pool
+        .try_pause(&pausable::DEPOSITS, &Some(900))
+        .expect_err("a second timed pause must not move the promised ledger");
+
+    assert_eq!(err, Ok(Error::TimedPauseArmed));
+    assert_eq!(pool.get_pause_state().until, Some(500));
+}
+
+#[test]
+fn untimed_pause_clears_the_arm_so_a_timed_pause_is_accepted_again() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (_, _, pool) = pausable_pool(&env, &sender);
+    pool.pause(&pausable::WITHDRAWALS, &Some(500));
+
+    pool.pause(&pausable::DEPOSITS, &None);
+    pool.pause(&pausable::TRANSFERS, &Some(900));
+
+    assert_eq!(pool.get_pause_state().until, Some(900));
+}
+
+#[test]
+fn pause_emits_pause_changed_from_the_pool_address() {
+    use soroban_sdk::{events::Event, testutils::Events};
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (_, pool_id, pool) = pausable_pool(&env, &sender);
+
+    pool.pause(&pausable::DEPOSITS, &Some(500));
+
+    let events = env.events().all();
+    assert_eq!(events.events().len(), 1);
+    let expected = PauseChanged {
+        flags: pausable::DEPOSITS,
+        until: Some(500),
+    }
+    .to_xdr(&env, &pool_id);
+    assert_eq!(events.events()[0], expected);
 }


### PR DESCRIPTION
Wires the `pausable` module into the four contracts that hold funds or trees: `pool`,
`pool-gvk`, `asp-membership`, and `asp-non-membership`.

## Where the check sits, and why there

`transact` picks its bit from the sign of `ext_data.ext_amount`. Positive is a deposit, zero a
transfer between notes already in the pool, negative a withdrawal. An operator can therefore
stop deposits while letting users withdraw, which is usually what an incident calls for.

The check runs immediately after `require_auth` and before the token read, so a paused
transaction touches no balances and moves no funds. Placing it later would risk a refusal
after a partial effect.

`insert_leaf` and `delete_leaf` check `MUTATIONS` immediately after the admin authorizes,
before any tree state is read or written, so a refused write leaves the root and the index
exactly as they were.

## Administration is never gated

`update_admin`, `unpause`, and every getter answer while a contract is fully paused. A pause
is meant to stop user traffic, not to lock the operator out of the contract they need to fix
or hand over. Each of these is covered by a test that pauses everything and then exercises it.

## Who can pause

The three new entry points require the contract's existing `admin` key. No new key, role, or
approval mechanism is introduced here.

## Breaking changes

New error variants, appended with the next free number in each contract, nothing renumbered:

| Contract | Paused | InvalidPauseFlags | TimedPauseArmed |
| --- | --- | --- | --- |
| `pool` | 15 | 16 | 17 |
| `pool-gvk` | 18 | 19 | 20 |
| `asp-membership` | 6 | 7 | 8 |
| `asp-non-membership` | 7 | 8 | 9 |

All four contracts gain `pause`, `unpause`, and `get_pause_state`. `transact`, `insert_leaf`,
and `delete_leaf` gain a failure mode that callers did not previously have to handle, which is
what earns the breaking marker: a client that treats any error as fatal will now surface a
pause as a hard failure rather than a retryable state.

## Reviewing the repetition

`pool` and `pool-gvk` take the same change as each other, as do the two ASP contracts. Reading
`pool` and `asp-membership` closely and then diffing their counterparts covers the substance.

Part of #372.
