### PR TITLE
Index governance events and read pause state in the SDK

### DIFF
--- a/sdk/native/src/chain/contract_state.rs
+++ b/sdk/native/src/chain/contract_state.rs
@@ -1,7 +1,7 @@
 use super::{
     conversions::{
         field_to_scval_u256, scval_to_address_string, scval_to_baby_jub_jub_point, scval_to_bool,
-        scval_to_policy_flags, scval_to_u32, scval_to_u64, scval_to_u256,
+        scval_to_pause_state, scval_to_policy_flags, scval_to_u32, scval_to_u64, scval_to_u256,
     },
     rpc::{Client, ContractDataBulkRequest},
     soroban_encode::BASE_FEE,
@@ -15,7 +15,7 @@ use stellar_xdr::{self as xdr, ReadXdr};
 use crate::types::{
     AspMembership, AspNonMembership, AspNonMembershipProof, BabyJubJubPoint, ContractConfig,
     ContractsStateData, ExtAmount, Field, GlobalViewKeyCiphertext, GvkMode, NotePublicKey,
-    PoolInfo, SMT_DEPTH, TransactChainContext, U256, transact_chain_context_from_state,
+    PauseState, PoolInfo, SMT_DEPTH, TransactChainContext, U256, transact_chain_context_from_state,
 };
 
 macro_rules! get_state {
@@ -99,6 +99,12 @@ impl StateFetcher {
             .transpose()?;
         let gvk_mode = pool_state.get("GvkMode").map(scval_to_u32).transpose()?;
         Ok((admin_view_key, gvk_mode))
+    }
+
+    /// Reads a contract's pause bits, absent on a contract deployed before the
+    /// key existed.
+    fn pause_from_state(state: &HashMap<String, xdr::ScVal>) -> Result<Option<PauseState>> {
+        Ok(state.get("Pause").map(scval_to_pause_state).transpose()?)
     }
 
     /// Cross-checks a pool's configured GVK settings against what the chain
@@ -223,10 +229,12 @@ impl StateFetcher {
                     "MaximumDepositAmount",
                     "PolicyFlags",
                 ],
-                // Only written by `contracts/pool-gvk`, never by
-                // `contracts/pool`, so a missing entry is expected rather
-                // than an error. Read below with `.get(...)`, not `get_state!`.
-                optional_enum_keys: vec!["AdminViewKey", "GvkMode"],
+                // `AdminViewKey` and `GvkMode` are written only by
+                // `contracts/pool-gvk`; `Pause` is absent until the first
+                // pause on either pool. A missing entry is expected rather
+                // than an error for all three, so read them below with
+                // `.get(...)`, not `get_state!`.
+                optional_enum_keys: vec!["AdminViewKey", "GvkMode", "Pause"],
                 valued_keys: vec![],
             });
         }
@@ -234,14 +242,14 @@ impl StateFetcher {
         requests.push(ContractDataBulkRequest {
             contract_id: self.config.asp_membership.as_str(),
             enum_keys: vec!["Root", "Levels", "NextIndex", "Admin"],
-            optional_enum_keys: vec![],
+            optional_enum_keys: vec!["Pause"],
             valued_keys: vec![],
         });
 
         requests.push(ContractDataBulkRequest {
             contract_id: self.config.asp_non_membership.as_str(),
             enum_keys: vec!["Root", "Admin"],
-            optional_enum_keys: vec![],
+            optional_enum_keys: vec!["Pause"],
             valued_keys: vec![],
         });
 
@@ -402,6 +410,7 @@ impl StateFetcher {
                     )?)?,
                     admin_view_key: gvk_admin_view_key,
                     gvk_mode,
+                    pause: Self::pause_from_state(pool_state)?,
                 };
 
                 out.push(pool_info);
@@ -438,6 +447,7 @@ impl StateFetcher {
                 )?)?,
                 capacity: asp_mem_capacity,
                 used_slots: asp_mem_next_index.to_string(),
+                pause: Self::pause_from_state(asp_membership_state)?,
             };
 
             let asp_non_membership_id = &self.config.asp_non_membership;
@@ -462,6 +472,7 @@ impl StateFetcher {
                     "Admin",
                     asp_non_membership_id
                 )?)?,
+                pause: Self::pause_from_state(asp_non_membership_state)?,
             };
 
             return Ok(ContractsStateData {
@@ -918,6 +929,126 @@ mod tests {
 
         assert!(admin_view_key.is_none());
         assert!(gvk_mode.is_none());
+    }
+
+    fn pause_scval(entries: Vec<(&str, xdr::ScVal)>) -> xdr::ScVal {
+        let mut entries: Vec<xdr::ScMapEntry> = entries
+            .into_iter()
+            .map(|(name, val)| xdr::ScMapEntry {
+                key: xdr::ScVal::Symbol(xdr::ScSymbol(name.try_into().expect("symbol"))),
+                val,
+            })
+            .collect();
+        entries.sort_by(|a, b| a.key.cmp(&b.key));
+        xdr::ScVal::Map(Some(xdr::ScMap(entries.try_into().expect("pause map"))))
+    }
+
+    fn pause_state_with(key: &str, val: xdr::ScVal) -> HashMap<String, xdr::ScVal> {
+        HashMap::from([(key.to_string(), val)])
+    }
+
+    #[test]
+    fn pause_is_none_for_a_contract_deployed_before_the_key_existed() {
+        let state: HashMap<String, xdr::ScVal> = HashMap::new();
+
+        let pause = StateFetcher::pause_from_state(&state).expect("no Pause key present");
+
+        assert!(pause.is_none());
+    }
+
+    #[test]
+    fn pause_is_read_from_a_contract_that_stores_it() {
+        let state = pause_state_with(
+            "Pause",
+            pause_scval(vec![
+                ("flags", xdr::ScVal::U32(5)),
+                ("until", xdr::ScVal::U32(900)),
+                ("armed", xdr::ScVal::Bool(true)),
+            ]),
+        );
+
+        let pause = StateFetcher::pause_from_state(&state).expect("Pause key present");
+
+        assert_eq!(
+            pause,
+            Some(PauseState {
+                flags: 5,
+                until: Some(900),
+                armed: true,
+            })
+        );
+    }
+
+    /// An untimed pause stores `until` as `Void`, which is a present field
+    /// holding `None`, not a missing one.
+    #[test]
+    fn an_untimed_pause_reads_until_as_none() {
+        let state = pause_state_with(
+            "Pause",
+            pause_scval(vec![
+                ("flags", xdr::ScVal::U32(1)),
+                ("until", xdr::ScVal::Void),
+                ("armed", xdr::ScVal::Bool(false)),
+            ]),
+        );
+
+        let pause = StateFetcher::pause_from_state(&state).expect("Pause key present");
+
+        assert_eq!(
+            pause,
+            Some(PauseState {
+                flags: 1,
+                until: None,
+                armed: false,
+            })
+        );
+    }
+
+    #[test]
+    fn a_pause_entry_missing_a_field_names_it() {
+        let full = [
+            ("flags", xdr::ScVal::U32(5)),
+            ("until", xdr::ScVal::Void),
+            ("armed", xdr::ScVal::Bool(false)),
+        ];
+        for missing in ["flags", "until", "armed"] {
+            let entries = full
+                .iter()
+                .filter(|(name, _)| *name != missing)
+                .map(|(name, val)| (*name, val.clone()))
+                .collect();
+            let state = pause_state_with("Pause", pause_scval(entries));
+
+            let err = StateFetcher::pause_from_state(&state)
+                .expect_err("every PauseState field is required");
+
+            assert!(err.to_string().contains(missing), "{err}");
+        }
+    }
+
+    #[test]
+    fn a_pause_entry_with_a_non_u32_flags_is_rejected() {
+        let state = pause_state_with(
+            "Pause",
+            pause_scval(vec![
+                ("flags", xdr::ScVal::Bool(true)),
+                ("until", xdr::ScVal::Void),
+                ("armed", xdr::ScVal::Bool(false)),
+            ]),
+        );
+
+        let err = StateFetcher::pause_from_state(&state).expect_err("flags must be a u32");
+
+        assert!(err.to_string().contains("flags"), "{err}");
+    }
+
+    #[test]
+    fn a_pause_entry_that_is_not_a_map_is_rejected() {
+        let state = pause_state_with("Pause", xdr::ScVal::U32(1));
+
+        let err = StateFetcher::pause_from_state(&state).expect_err("PauseState must be a map");
+
+        assert!(err.to_string().contains("expected ScVal::Map"), "{err}");
     }
 
     #[test]

--- a/sdk/native/src/chain/conversions.rs
+++ b/sdk/native/src/chain/conversions.rs
@@ -1,6 +1,6 @@
 use crate::{
     chain::rpc::Error,
-    types::{BabyJubJubPoint, ContractEvent, Field, GlobalViewKeyCiphertext, U256},
+    types::{BabyJubJubPoint, ContractEvent, Field, GlobalViewKeyCiphertext, PauseState, U256},
 };
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use core::ops::Shl;
@@ -219,6 +219,50 @@ pub(crate) fn scval_to_baby_jub_jub_point(val: &xdr::ScVal) -> Result<BabyJubJub
             .map_err(|e| Error::UnexpectedScVal(format!("BabyJubJubPoint.x: {e}")))?,
         y: Field::try_from_u256(y)
             .map_err(|e| Error::UnexpectedScVal(format!("BabyJubJubPoint.y: {e}")))?,
+    })
+}
+
+/// Prefixes a decode failure with the `PauseState` field that produced it.
+fn field<T>(decoded: Result<T, Error>, name: &str) -> Result<T, Error> {
+    decoded.map_err(|e| Error::UnexpectedScVal(format!("PauseState.{name}: {e}")))
+}
+
+/// Decode a `soroban_utils::pausable::PauseState`
+/// (`{ flags: u32, until: Option<u32>, armed: bool }`) from contract storage.
+pub(crate) fn scval_to_pause_state(val: &xdr::ScVal) -> Result<PauseState, Error> {
+    let xdr::ScVal::Map(Some(map)) = val else {
+        return Err(Error::UnexpectedScVal(format!(
+            "PauseState: expected ScVal::Map, found: {val:?}"
+        )));
+    };
+
+    let mut flags = None;
+    let mut until = None;
+    let mut armed = None;
+    for xdr::ScMapEntry { key, val } in map.iter() {
+        let xdr::ScVal::Symbol(name) = key else {
+            continue;
+        };
+        match name.to_utf8_string_lossy().as_str() {
+            "flags" => flags = Some(field(scval_to_u32(val), "flags")?),
+            "until" => {
+                until = Some(match val {
+                    xdr::ScVal::Void => None,
+                    other => Some(field(scval_to_u32(other), "until")?),
+                });
+            }
+            "armed" => armed = Some(field(scval_to_bool(val), "armed")?),
+            _ => {}
+        }
+    }
+
+    Ok(PauseState {
+        flags: flags
+            .ok_or_else(|| Error::UnexpectedScVal("PauseState missing field: flags".into()))?,
+        until: until
+            .ok_or_else(|| Error::UnexpectedScVal("PauseState missing field: until".into()))?,
+        armed: armed
+            .ok_or_else(|| Error::UnexpectedScVal("PauseState missing field: armed".into()))?,
     })
 }
 

--- a/sdk/native/src/state/events_parsers.rs
+++ b/sdk/native/src/state/events_parsers.rs
@@ -5,11 +5,13 @@ use crate::{
         scval_to_u32, scval_to_u64, scval_to_u256,
     },
     types::{
-        ContractEvent, Field, LeafAddedEvent, LeafDeletedEvent, LeafInsertedEvent,
-        LeafUpdatedEvent, NewCommitmentEvent, NewNullifierEvent, ProcessedEvent, PublicKeyEvent,
+        AdminUpdatedEvent, ContractEvent, Field, LeafAddedEvent, LeafDeletedEvent,
+        LeafInsertedEvent, LeafUpdatedEvent, NewCommitmentEvent, NewNullifierEvent,
+        PauseChangedEvent, ProcessedEvent, PublicKeyEvent,
     },
 };
 use anyhow::{Result, anyhow};
+use stellar_xdr as xdr;
 
 /// Field name emitted by `contracts/pool-gvk`'s pool events, carrying the
 /// admin-decryptable ciphertext of the note.
@@ -41,6 +43,14 @@ pub fn parse_event(event: ContractEvent) -> Result<ProcessedEvent> {
         }
         "leaf_updated" | "LeafUpdated" => ProcessedEvent::LeafUpdated(parse_leaf_updated(parsed)?),
         "leaf_deleted" | "LeafDeleted" => ProcessedEvent::LeafDeleted(parse_leaf_deleted(parsed)?),
+        // Governance events contracts/soroban-utils/src/{utils,pausable}.rs, emitted by
+        // every contract that exposes an admin rotation or a pause
+        "admin_updated" | "AdminUpdated" => {
+            ProcessedEvent::AdminUpdated(parse_admin_updated(parsed)?)
+        }
+        "pause_changed" | "PauseChanged" => {
+            ProcessedEvent::PauseChanged(parse_pause_changed(parsed)?)
+        }
         _ => return Err(anyhow!("unhandled event {}", parsed.name)),
     };
     Ok(ev)
@@ -289,18 +299,72 @@ fn parse_leaf_deleted(parsed: ParsedContractEvent) -> Result<LeafDeletedEvent> {
     Ok(LeafDeletedEvent { id, key, root })
 }
 
+// #[contractevent]
+// #[derive(Clone, Debug, Eq, PartialEq)]
+// pub struct AdminUpdated {
+//     pub old_admin: Address,
+//     pub new_admin: Address,
+// }
+fn parse_admin_updated(parsed: ParsedContractEvent) -> Result<AdminUpdatedEvent> {
+    let ParsedContractEvent {
+        id, name, values, ..
+    } = parsed;
+    let old_admin_scval = values
+        .get("old_admin")
+        .ok_or_else(|| anyhow!("event `{name}` id {id} should have an old_admin value"))?;
+    let old_admin = scval_to_address_string(old_admin_scval)?;
+    let new_admin_scval = values
+        .get("new_admin")
+        .ok_or_else(|| anyhow!("event `{name}` id {id} should have an new_admin value"))?;
+    let new_admin = scval_to_address_string(new_admin_scval)?;
+    Ok(AdminUpdatedEvent {
+        id,
+        old_admin,
+        new_admin,
+    })
+}
+
+// #[contractevent]
+// #[derive(Clone, Debug, Eq, PartialEq)]
+// pub struct PauseChanged {
+//     pub flags: u32,
+//     pub until: Option<u32>,
+// }
+fn parse_pause_changed(parsed: ParsedContractEvent) -> Result<PauseChangedEvent> {
+    let ParsedContractEvent {
+        id, name, values, ..
+    } = parsed;
+    let flags_scval = values
+        .get("flags")
+        .ok_or_else(|| anyhow!("event `{name}` id {id} should have an flags value"))?;
+    let flags = scval_to_u32(flags_scval)?;
+    let until_scval = values
+        .get("until")
+        .ok_or_else(|| anyhow!("event `{name}` id {id} should have an until value"))?;
+    let until = match until_scval {
+        xdr::ScVal::Void => None,
+        xdr::ScVal::U32(ledger) => Some(*ledger),
+        other => {
+            return Err(anyhow!(
+                "event `{name}` id {id} has an until value that is neither void nor u32: {other:?}"
+            ));
+        }
+    };
+    Ok(PauseChangedEvent { id, flags, until })
+}
+
 #[cfg(test)]
 mod gvk_passthrough_tests {
     use super::*;
     use crate::types::{Field, U256};
     use stellar_xdr::{self as xdr, WriteXdr};
 
-    fn b64(val: &xdr::ScVal) -> String {
+    pub(super) fn b64(val: &xdr::ScVal) -> String {
         val.to_xdr_base64(xdr::Limits::none())
             .expect("encode scval")
     }
 
-    fn symbol(s: &str) -> xdr::ScVal {
+    pub(super) fn symbol(s: &str) -> xdr::ScVal {
         xdr::ScVal::Symbol(xdr::ScSymbol(s.try_into().expect("symbol")))
     }
 
@@ -469,5 +533,129 @@ mod gvk_passthrough_tests {
         assert!(without.gvk_ciphertext.is_none());
         let ct = with.gvk_ciphertext.expect("gvk ciphertext");
         assert_eq!(ct.c2, Field(U256::from(2)));
+    }
+}
+
+#[cfg(test)]
+mod governance_event_tests {
+    use super::{
+        gvk_passthrough_tests::{b64, symbol},
+        *,
+    };
+    use stellar_xdr as xdr;
+
+    fn address(byte: u8) -> xdr::ScVal {
+        xdr::ScVal::Address(xdr::ScAddress::Contract(xdr::ContractId(xdr::Hash(
+            [byte; 32],
+        ))))
+    }
+
+    fn event(name: &str, entries: Vec<xdr::ScMapEntry>) -> ContractEvent {
+        let mut entries = entries;
+        // Soroban emits map entries in key order.
+        entries.sort_by(|a, b| a.key.cmp(&b.key));
+        ContractEvent {
+            id: "0000000000000000003-0000000000".to_string(),
+            ledger: 1,
+            contract_id: "CPOOL".to_string(),
+            topics: vec![b64(&symbol(name))],
+            value: b64(&xdr::ScVal::Map(Some(xdr::ScMap(
+                entries.try_into().expect("data map"),
+            )))),
+        }
+    }
+
+    fn admin_updated_event(with_new_admin: bool) -> ContractEvent {
+        let mut entries = vec![xdr::ScMapEntry {
+            key: symbol("old_admin"),
+            val: address(1),
+        }];
+        if with_new_admin {
+            entries.push(xdr::ScMapEntry {
+                key: symbol("new_admin"),
+                val: address(2),
+            });
+        }
+        event("admin_updated", entries)
+    }
+
+    fn pause_changed_event(until: xdr::ScVal) -> ContractEvent {
+        event(
+            "pause_changed",
+            vec![
+                xdr::ScMapEntry {
+                    key: symbol("flags"),
+                    val: xdr::ScVal::U32(5),
+                },
+                xdr::ScMapEntry {
+                    key: symbol("until"),
+                    val: until,
+                },
+            ],
+        )
+    }
+
+    #[test]
+    fn admin_updated_parses_both_addresses() {
+        let ProcessedEvent::AdminUpdated(ev) =
+            parse_event(admin_updated_event(true)).expect("parse admin_updated")
+        else {
+            panic!("expected an admin updated event");
+        };
+
+        assert_eq!(ev.id, "0000000000000000003-0000000000");
+        assert_eq!(
+            ev.old_admin,
+            "CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC526"
+        );
+        assert_eq!(
+            ev.new_admin,
+            "CABAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAFNSZ"
+        );
+    }
+
+    #[test]
+    fn admin_updated_without_new_admin_fails() {
+        let err = parse_event(admin_updated_event(false))
+            .expect_err("an admin_updated event without new_admin must not parse");
+
+        assert!(err.to_string().contains("new_admin"), "{err}");
+    }
+
+    #[test]
+    fn pause_changed_reads_an_untimed_pause_as_none() {
+        let ProcessedEvent::PauseChanged(ev) =
+            parse_event(pause_changed_event(xdr::ScVal::Void)).expect("parse pause_changed")
+        else {
+            panic!("expected a pause changed event");
+        };
+
+        assert_eq!(ev.flags, 5);
+        assert_eq!(ev.until, None);
+    }
+
+    #[test]
+    fn pause_changed_reads_a_timed_pause_as_some() {
+        let ProcessedEvent::PauseChanged(ev) =
+            parse_event(pause_changed_event(xdr::ScVal::U32(42))).expect("parse pause_changed")
+        else {
+            panic!("expected a pause changed event");
+        };
+
+        assert_eq!(ev.flags, 5);
+        assert_eq!(ev.until, Some(42));
+    }
+
+    #[test]
+    fn pause_changed_with_a_non_ledger_until_names_the_event_id() {
+        let err = parse_event(pause_changed_event(xdr::ScVal::Bool(true)))
+            .expect_err("an until that is neither void nor u32 must not parse");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("0000000000000000003-0000000000"),
+            "{message}"
+        );
+        assert!(message.contains("until"), "{message}");
     }
 }

--- a/sdk/native/src/state/processor.rs
+++ b/sdk/native/src/state/processor.rs
@@ -11,6 +11,7 @@ pub(crate) fn process_events(storage: &mut SqliteStorage, limit: u32) -> Result<
     let mut commitments = vec![];
     let mut pubkeys = vec![];
     let mut leaves = vec![];
+    let mut processed_ids = vec![];
     while let Some(event) = unprocessed.pop() {
         let parsed = match parse_event(event) {
             Ok(parsed) => parsed,
@@ -27,6 +28,8 @@ pub(crate) fn process_events(storage: &mut SqliteStorage, limit: u32) -> Result<
             ProcessedEvent::Commitment(ev) => commitments.push(ev),
             ProcessedEvent::PublicKey(ev) => pubkeys.push(ev),
             ProcessedEvent::LeafAdded(ev) => leaves.push(ev),
+            ProcessedEvent::AdminUpdated(ev) => processed_ids.push(ev.id),
+            ProcessedEvent::PauseChanged(ev) => processed_ids.push(ev.id),
             _ => tracing::warn!("event won't be saved to the storage: {parsed:?}"),
         }
     }
@@ -34,6 +37,7 @@ pub(crate) fn process_events(storage: &mut SqliteStorage, limit: u32) -> Result<
     storage.save_commitment_events_batch(&commitments)?;
     storage.save_public_key_events_batch(&pubkeys)?;
     storage.save_leaf_added_events_batch(&leaves)?;
+    storage.save_processed_event_ids(&processed_ids)?;
     Ok(true)
 }
 
@@ -51,4 +55,60 @@ pub(crate) fn process_notes(
     did_work |= storage.scan_commitments_for_user_notes(limit, derive)?;
     did_work |= storage.reconcile_nullifiers(limit)?;
     Ok(did_work)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ContractEvent, ContractsEventData};
+    use stellar_xdr::{self as xdr, WriteXdr};
+
+    fn b64(val: &xdr::ScVal) -> String {
+        val.to_xdr_base64(xdr::Limits::none())
+            .expect("encode scval")
+    }
+
+    fn symbol(s: &str) -> xdr::ScVal {
+        xdr::ScVal::Symbol(xdr::ScSymbol(s.try_into().expect("symbol")))
+    }
+
+    fn pause_changed_event() -> ContractEvent {
+        let entries = vec![
+            xdr::ScMapEntry {
+                key: symbol("flags"),
+                val: xdr::ScVal::U32(1),
+            },
+            xdr::ScMapEntry {
+                key: symbol("until"),
+                val: xdr::ScVal::Void,
+            },
+        ];
+        ContractEvent {
+            id: "0000000000000000004-0000000000".to_string(),
+            ledger: 1,
+            contract_id: "CPOOL".to_string(),
+            topics: vec![b64(&symbol("pause_changed"))],
+            value: b64(&xdr::ScVal::Map(Some(xdr::ScMap(
+                entries.try_into().expect("data map"),
+            )))),
+        }
+    }
+
+    /// A pause event saves no row of its own, so only the `processed_events`
+    /// table stops it from being read again on the next pass.
+    #[test]
+    fn a_pause_changed_event_is_read_once() -> Result<()> {
+        let mut storage = SqliteStorage::connect_in_memory()?;
+        storage.save_events_batch(&ContractsEventData {
+            events: vec![pause_changed_event()],
+            cursor: "cur".to_string(),
+            latest_ledger: 1,
+        })?;
+        assert_eq!(storage.get_unprocessed_events(10)?.len(), 1);
+
+        assert!(process_events(&mut storage, 10)?);
+
+        assert!(storage.get_unprocessed_events(10)?.is_empty());
+        Ok(())
+    }
 }

--- a/sdk/native/src/state/schema_v3_processed_events.sql
+++ b/sdk/native/src/state/schema_v3_processed_events.sql
@@ -1,0 +1,3 @@
+-- Events that parse but leave no row in a saved-event table. Without this,
+-- get_unprocessed_events re-reads them on every pass forever.
+CREATE TABLE processed_events (event_id TEXT PRIMARY KEY);

--- a/sdk/native/src/state/storage.rs
+++ b/sdk/native/src/state/storage.rs
@@ -21,6 +21,7 @@ pub const DEFAULT_BOOTNODE_URL: &str = "https://bootnode.dev-nethermind.xyz";
 const MIGRATION_ARRAY: &[M] = &[
     M::up(include_str!("schema.sql")),
     M::up(include_str!("schema_v2_gvk_ciphertext.sql")),
+    M::up(include_str!("schema_v3_processed_events.sql")),
 ];
 const MIGRATIONS: Migrations = Migrations::from_slice(MIGRATION_ARRAY);
 
@@ -1256,6 +1257,30 @@ impl Storage {
         Ok(leaves)
     }
 
+    /// Records event ids that parsed but produced no row of their own, so
+    /// [`Self::get_unprocessed_events`] stops returning them.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the transaction cannot be opened or an insert
+    /// fails.
+    pub fn save_processed_event_ids(&mut self, ids: &[String]) -> Result<()> {
+        let tx = self.conn.transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO processed_events (event_id)
+                    VALUES (?1)
+                    ON CONFLICT(event_id) DO NOTHING",
+            )?;
+
+            for id in ids {
+                stmt.execute(params![id])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
     /// Unprocessed raw events fetch
     pub fn get_unprocessed_events(&self, limit: u32) -> Result<Vec<ContractEvent>> {
         let mut stmt = self.conn.prepare(
@@ -1266,10 +1291,12 @@ impl Storage {
                 LEFT JOIN public_keys p ON r.id = p.event_id
                 LEFT JOIN asp_membership_leaves l ON r.id = l.event_id
                 LEFT JOIN pool_nullifiers n ON r.id = n.event_id
+                LEFT JOIN processed_events pe ON r.id = pe.event_id
                 WHERE pc.event_id IS NULL
                 AND p.event_id IS NULL
                 AND n.event_id IS NULL
                 AND l.event_id IS NULL
+                AND pe.event_id IS NULL
                 ORDER BY r.ledger ASC, r.id ASC
                 LIMIT ?1",
         )?;
@@ -2953,5 +2980,49 @@ mod tests {
 
         let _ = std::fs::remove_file(path);
         Ok(())
+    }
+
+    #[test]
+    fn processed_event_ids_are_not_returned_as_unprocessed() -> Result<()> {
+        let mut storage = Storage::connect_in_memory()?;
+        storage.save_events_batch(&ContractsEventData {
+            events: vec![dummy_event("evt-pause"), dummy_event("evt-other")],
+            cursor: "cur".to_string(),
+            latest_ledger: 1,
+        })?;
+
+        storage.save_processed_event_ids(&["evt-pause".to_string()])?;
+
+        let ids: Vec<String> = storage
+            .get_unprocessed_events(10)?
+            .into_iter()
+            .map(|e| e.id)
+            .collect();
+        assert_eq!(ids, vec!["evt-other".to_string()]);
+        Ok(())
+    }
+
+    #[test]
+    fn opening_a_v2_database_applies_the_processed_events_migration() -> Result<()> {
+        let mut conn = Connection::open_in_memory()?;
+        MIGRATIONS.to_version(&mut conn, 2)?;
+        assert!(
+            !table_exists(&conn, "processed_events")?,
+            "v2 must predate the table"
+        );
+
+        let storage = Storage::connect_with_connection(conn)?;
+
+        assert!(table_exists(&storage.conn, "processed_events")?);
+        Ok(())
+    }
+
+    fn table_exists(conn: &Connection, name: &str) -> Result<bool> {
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            params![name],
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
     }
 }

--- a/sdk/native/src/types/chain_data.rs
+++ b/sdk/native/src/types/chain_data.rs
@@ -335,6 +335,35 @@ pub struct LeafDeletedEvent {
     pub root: Field,
 }
 
+/// Event emitted when a contract's administrator is replaced
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminUpdatedEvent {
+    // Unique identifier for this event, based on the TOID format.
+    // It combines a 19-character TOID and a 10-character, zero-padded event index, separated by a
+    // hyphen.
+    pub id: String,
+    /// Address that held the administrator role before the call.
+    pub old_admin: String,
+    /// Address that holds it afterwards.
+    pub new_admin: String,
+}
+
+/// Event emitted when a contract's pause bits change
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PauseChangedEvent {
+    // Unique identifier for this event, based on the TOID format.
+    // It combines a 19-character TOID and a 10-character, zero-padded event index, separated by a
+    // hyphen.
+    pub id: String,
+    /// Bits set after the change.
+    pub flags: u32,
+    /// Ledger from which the withdrawals bit is no longer honored, absent when
+    /// the pause is untimed.
+    pub until: Option<u32>,
+}
+
 /// A contract event after full parsing
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -346,6 +375,8 @@ pub enum ProcessedEvent {
     LeafInserted(LeafInsertedEvent),
     LeafUpdated(LeafUpdatedEvent),
     LeafDeleted(LeafDeletedEvent),
+    AdminUpdated(AdminUpdatedEvent),
+    PauseChanged(PauseChangedEvent),
 }
 
 #[cfg(test)]

--- a/sdk/native/src/types/chain_data.rs
+++ b/sdk/native/src/types/chain_data.rs
@@ -37,6 +37,22 @@ pub struct ContractsStateData {
     pub asp_non_membership: AspNonMembership,
 }
 
+/// The pause bits a contract has set, as `soroban_utils::pausable` stores
+/// them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PauseState {
+    /// Bits set by the last pause or unpause. Which bits mean what depends on
+    /// the contract: pools recognize deposits, transfers, and withdrawals, and
+    /// the ASP contracts recognize mutations.
+    pub flags: u32,
+    /// Ledger from which the withdrawals bit is no longer honored, absent when
+    /// the pause is untimed.
+    pub until: Option<u32>,
+    /// Set by a timed pause, cleared by an untimed pause or an unpause.
+    pub armed: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PoolInfo {
@@ -70,6 +86,13 @@ pub struct PoolInfo {
     /// Omitted from serialized output when absent, as for `admin_view_key`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gvk_mode: Option<u32>,
+    /// Pause bits read from the contract. `None` when the contract has never
+    /// been paused or unpaused, which includes contracts deployed before the
+    /// pause entry existed. Treat it as all bits clear.
+    ///
+    /// Omitted from serialized output when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pause: Option<PauseState>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -86,6 +109,13 @@ pub struct AspMembership {
     pub admin: String,
     pub capacity: u64,
     pub used_slots: String, //num_bigint::BigUint,
+    /// Pause bits read from the contract. `None` when the contract has never
+    /// been paused or unpaused, which includes contracts deployed before the
+    /// pause entry existed. Treat it as all bits clear.
+    ///
+    /// Omitted from serialized output when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pause: Option<PauseState>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -99,6 +129,13 @@ pub struct AspNonMembership {
     pub root: Field,
     pub is_empty: bool,
     pub admin: String,
+    /// Pause bits read from the contract. `None` when the contract has never
+    /// been paused or unpaused, which includes contracts deployed before the
+    /// pause entry existed. Treat it as all bits clear.
+    ///
+    /// Omitted from serialized output when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pause: Option<PauseState>,
 }
 
 /// ASP non-membership (blocklist) proof data needed by the circuit.
@@ -407,6 +444,7 @@ mod pool_info_gvk_tests {
                 y: Field(U256::from(2)),
             }),
             gvk_mode: Some(2),
+            pause: None,
         }
     }
 
@@ -450,6 +488,7 @@ mod pool_info_gvk_tests {
         let pool = PoolInfo {
             admin_view_key: None,
             gvk_mode: None,
+            pause: None,
             ..pool_info_with_gvk()
         };
 
@@ -458,6 +497,7 @@ mod pool_info_gvk_tests {
 
         assert!(!object.contains_key("adminViewKey"));
         assert!(!object.contains_key("gvkMode"));
+        assert!(!object.contains_key("pause"));
         // Unrelated optional fields keep their existing null-emitting shape.
         assert!(object.contains_key("merkleRoot"));
         assert!(object.contains_key("merkleCurrentRootIndex"));
@@ -465,5 +505,82 @@ mod pool_info_gvk_tests {
         let decoded: PoolInfo = serde_json::from_value(value).expect("decode non-GVK PoolInfo");
         assert!(decoded.admin_view_key.is_none());
         assert!(decoded.gvk_mode.is_none());
+    }
+
+    fn pause_state() -> PauseState {
+        PauseState {
+            flags: 5,
+            until: Some(900),
+            armed: true,
+        }
+    }
+
+    /// State serialized before the pause key existed must still decode, for
+    /// every contract that gained the field.
+    #[test]
+    fn contract_state_without_pause_still_decodes() {
+        let pool = PoolInfo {
+            pause: Some(pause_state()),
+            ..pool_info_with_gvk()
+        };
+        assert!(decode_without_pause::<PoolInfo>(&pool).pause.is_none());
+
+        let membership = AspMembership {
+            ledger: 1,
+            contract_id: "CASPM".to_string(),
+            contract_type: "ASP Membership".to_string(),
+            root: Field(U256::from(7)),
+            levels: 20,
+            next_index: "0".to_string(),
+            admin: "GADMIN".to_string(),
+            capacity: 1_048_576,
+            used_slots: "0".to_string(),
+            pause: Some(pause_state()),
+        };
+        assert!(
+            decode_without_pause::<AspMembership>(&membership)
+                .pause
+                .is_none()
+        );
+
+        let non_membership = AspNonMembership {
+            ledger: 1,
+            contract_id: "CASPN".to_string(),
+            contract_type: "ASP Non-Membership".to_string(),
+            root: Field(U256::from(0)),
+            is_empty: true,
+            admin: "GADMIN".to_string(),
+            pause: Some(pause_state()),
+        };
+        assert!(
+            decode_without_pause::<AspNonMembership>(&non_membership)
+                .pause
+                .is_none()
+        );
+    }
+
+    /// Serializes `value`, drops the `pause` key, and decodes what an older
+    /// deployment would have produced.
+    fn decode_without_pause<T>(value: &impl Serialize) -> T
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let mut encoded = serde_json::to_value(value).expect("serialize to value");
+        let object = encoded.as_object_mut().expect("serializes as object");
+        assert!(object.remove("pause").is_some(), "field was present");
+        serde_json::from_value(encoded).expect("decode state written without pause")
+    }
+
+    #[test]
+    fn pool_info_round_trips_with_pause_set() {
+        let pool = PoolInfo {
+            pause: Some(pause_state()),
+            ..pool_info_with_gvk()
+        };
+
+        let encoded = serde_json::to_string(&pool).expect("serialize PoolInfo");
+        let decoded: PoolInfo = serde_json::from_str(&encoded).expect("decode PoolInfo");
+
+        assert_eq!(decoded.pause, Some(pause_state()));
     }
 }


### PR DESCRIPTION
Client-side support for observing pause state and administrator changes. Includes a schema
migration.

## Event parsing

`AdminUpdated` and `PauseChanged` now parse into typed events. `PauseChanged` carries an
optional expiry: an absent value decodes as `None`, a ledger number as `Some`. Anything else
is an error naming the event id, so a malformed event is traceable rather than silently
dropped.

## The `processed_events` table, migration v3

`get_unprocessed_events` finds work by selecting every raw event that has no row in one of the
saved-event tables. That works because every event the indexer handles produces a row
somewhere.

These two events produce no row of their own. They are read, parsed, and acted on, but they
leave nothing behind for that query to find, so without a record of having handled them they
would be selected again on every pass, forever. The new table stores their ids and the query
excludes anything listed in it.

A test opens a database at the v2 schema, applies v3, and confirms the table exists, so an
existing local database upgrades rather than needing to be rebuilt.

## Pause state on contract state types

`PoolInfo`, `AspMembership`, and `AspNonMembership` gain a `pause` field, an
`Option<PauseState>` read from the contract's `Pause` key.

`None` means the contract has never been paused or unpaused. That covers a contract deployed
before the entry existed and a contract that has simply never been touched, and consumers
should treat both as all bits clear rather than as an unknown state.

The field carries `#[serde(default, skip_serializing_if = "Option::is_none")]`, so state
written before it existed still decodes, and a contract that was never paused serializes no new
key. Existing consumers see no change.

Part of #372.
