### PR TITLE
Restore archived ledger entries before invoking

### DIFF
--- a/sdk/native/src/account.rs
+++ b/sdk/native/src/account.rs
@@ -8,6 +8,7 @@ use crate::chain::{Limits, ReadXdr, StateFetcher, TransactionEnvelope, submit_tx
 use crate::{
     Error, Handle, PrivatePool, Prover, Signer, Storage,
     chain::RpcClient,
+    pool::restore_archived_entries,
     sync::{SyncHandle, catch_up, confirm_tx},
     types::{PrivatePoolConfig, TransactionResult},
 };
@@ -163,13 +164,28 @@ impl<S: Storage> Account<S> {
 
         let fetcher = StateFetcher::new(self.rpc.clone(), self.contract_config.clone())
             .map_err(|e| Error::Other(format!("state fetcher: {e:#}")))?;
-        let prepared = fetcher
+        let mut prepared = fetcher
             // Registration uses the note-owner address, which is both the
             // registry key and the transaction source. Which it should be when
             // the two identities differ is unsettled.
             .prepare_register(self.user_address.as_str(), note_pk.0, enc_pk.0)
             .await
             .map_err(|e| Error::Other(format!("prepare register: {e:#}")))?;
+
+        if let Some(restore_tx_xdr) = prepared.restore_tx_xdr.take() {
+            restore_archived_entries(&self.rpc, &self.signer, restore_tx_xdr).await?;
+            prepared = fetcher
+                .prepare_register(self.user_address.as_str(), note_pk.0, enc_pk.0)
+                .await
+                .map_err(|e| Error::Other(format!("prepare register after restore: {e:#}")))?;
+            if prepared.restore_tx_xdr.is_some() {
+                return Err(Error::Other(
+                    "registration still asks for a footprint restore after one was submitted"
+                        .into(),
+                ));
+            }
+        }
+
         let signed = self.signer.sign_soroban_transaction(&prepared).await?;
         let envelope = TransactionEnvelope::from_xdr_base64(&signed.signed_xdr, Limits::none())
             .map_err(|e| Error::Other(format!("invalid signed transaction xdr: {e}")))?;

--- a/sdk/native/src/chain/contract_state.rs
+++ b/sdk/native/src/chain/contract_state.rs
@@ -64,6 +64,11 @@ pub struct PreparedSorobanTx {
     /// Ledger number from `simulateTransaction` (`latestLedger`), for auth
     /// expiration.
     pub latest_ledger: u32,
+    /// Base64-encoded XDR of a `RestoreFootprint` transaction the caller must
+    /// submit before this invocation can succeed. `None` when every entry the
+    /// invocation touches is live.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub restore_tx_xdr: Option<String>,
 }
 
 impl StateFetcher {

--- a/sdk/native/src/chain/rpc.rs
+++ b/sdk/native/src/chain/rpc.rs
@@ -238,8 +238,21 @@ pub struct SimulateTransactionResponse {
     pub transaction_data: Option<String>,
     #[serde(rename = "minResourceFee", default)]
     pub min_resource_fee: Option<String>,
+    /// Present when the simulation's footprint touches an archived entry.
+    /// The entry must be restored before the invocation can succeed.
+    #[serde(rename = "restorePreamble", default)]
+    pub restore_preamble: Option<RestorePreamble>,
     #[serde(default)]
     pub error: Option<String>,
+}
+
+/// The footprint restore a simulation asks for before its invocation can run.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct RestorePreamble {
+    #[serde(rename = "minResourceFee")]
+    pub min_resource_fee: String,
+    #[serde(rename = "transactionData")]
+    pub transaction_data: String,
 }
 
 /// Response from Soroban RPC `sendTransaction`.

--- a/sdk/native/src/chain/signer.rs
+++ b/sdk/native/src/chain/signer.rs
@@ -469,6 +469,7 @@ mod tests {
                 .expect("tx xdr"),
             auth_entries: vec![entry.to_xdr_base64(Limits::none()).expect("auth entry xdr")],
             latest_ledger: 100,
+            restore_tx_xdr: None,
         }
     }
 

--- a/sdk/native/src/chain/tx_assemble.rs
+++ b/sdk/native/src/chain/tx_assemble.rs
@@ -5,7 +5,11 @@ use stellar_xdr::{
     self as xdr, Limits, ReadXdr, SorobanAuthorizationEntry, SorobanTransactionData, WriteXdr,
 };
 
-use super::{contract_state::PreparedSorobanTx, rpc::SimulateTransactionResponse};
+use super::{
+    contract_state::PreparedSorobanTx,
+    rpc::{RestorePreamble, SimulateTransactionResponse},
+    soroban_encode::BASE_FEE,
+};
 
 impl SimulateTransactionResponse {
     /// Returns the first host-function simulation result.
@@ -125,6 +129,61 @@ fn assemble_soroban_transaction(
     }))
 }
 
+/// Builds the `RestoreFootprint` transaction a simulation's restore preamble
+/// asks for.
+///
+/// The restore reuses the invocation's source account and sequence number, so
+/// it takes the sequence the invocation would have used and the retried
+/// invocation takes the one after it.
+///
+/// # Errors
+///
+/// Returns an error if `raw` is not a V1 transaction envelope, if the
+/// preamble's `transactionData` is not valid XDR, if its `minResourceFee` is
+/// not a number, or if the total fee does not fit into `u32`.
+fn restore_footprint_envelope(
+    raw: &xdr::TransactionEnvelope,
+    preamble: &RestorePreamble,
+) -> Result<xdr::TransactionEnvelope> {
+    let xdr::TransactionEnvelope::Tx(v1) = raw else {
+        return Err(anyhow!("expected TransactionEnvelope::Tx"));
+    };
+
+    let soroban_data =
+        SorobanTransactionData::from_xdr_base64(&preamble.transaction_data, Limits::none())
+            .map_err(|e| anyhow!("invalid restorePreamble transactionData xdr: {e}"))?;
+    let resource_fee = preamble.min_resource_fee.parse::<u64>().map_err(|_| {
+        anyhow!(
+            "invalid restorePreamble minResourceFee: {}",
+            preamble.min_resource_fee
+        )
+    })?;
+    let fee: u32 = u64::from(BASE_FEE)
+        .saturating_add(resource_fee)
+        .try_into()
+        .map_err(|_| anyhow!("restore fee does not fit into u32"))?;
+
+    let tx = xdr::Transaction {
+        source_account: v1.tx.source_account.clone(),
+        fee,
+        seq_num: v1.tx.seq_num.clone(),
+        cond: xdr::Preconditions::None,
+        memo: xdr::Memo::None,
+        operations: xdr::VecM::try_from(vec![xdr::Operation {
+            source_account: None,
+            body: xdr::OperationBody::RestoreFootprint(xdr::RestoreFootprintOp {
+                ext: xdr::ExtensionPoint::V0,
+            }),
+        }])?,
+        ext: xdr::TransactionExt::V1(soroban_data),
+    };
+
+    Ok(xdr::TransactionEnvelope::Tx(xdr::TransactionV1Envelope {
+        tx,
+        signatures: xdr::VecM::default(),
+    }))
+}
+
 impl PreparedSorobanTx {
     /// Builds a wallet-ready prepared tx from an unsigned envelope and
     /// simulation.
@@ -135,10 +194,19 @@ impl PreparedSorobanTx {
         let assembled = assemble_soroban_transaction(raw, sim)?;
         let latest_ledger = u32::try_from(sim.latest_ledger)
             .map_err(|_| anyhow!("latestLedger does not fit into u32"))?;
+        let restore_tx_xdr = sim
+            .restore_preamble
+            .as_ref()
+            .map(|preamble| -> Result<String> {
+                let envelope = restore_footprint_envelope(raw, preamble)?;
+                Ok(envelope.to_xdr_base64(Limits::none())?)
+            })
+            .transpose()?;
         Ok(Self {
             tx_xdr: assembled.to_xdr_base64(Limits::none())?,
             auth_entries: sim.auth_entries_base64()?,
             latest_ledger,
+            restore_tx_xdr,
         })
     }
 }
@@ -242,6 +310,7 @@ mod tests {
                     .expect("xdr base64"),
             ),
             min_resource_fee: Some("500".to_string()),
+            restore_preamble: None,
             error: None,
         };
         sim.results
@@ -273,6 +342,7 @@ mod tests {
                     .expect("xdr base64"),
             ),
             min_resource_fee: Some("0".to_string()),
+            restore_preamble: None,
             error: None,
         };
         sim.results
@@ -307,8 +377,140 @@ mod tests {
             results: vec![],
             transaction_data: None,
             min_resource_fee: None,
+            restore_preamble: None,
             error: Some("boom".to_string()),
         };
         assert!(assemble_soroban_transaction(&raw, &sim).is_err());
+    }
+
+    fn preamble(resource_fee: &str) -> RestorePreamble {
+        RestorePreamble {
+            min_resource_fee: resource_fee.to_string(),
+            transaction_data: empty_soroban_data()
+                .to_xdr_base64(Limits::none())
+                .expect("xdr"),
+        }
+    }
+
+    fn sim_with_preamble(preamble: Option<RestorePreamble>) -> SimulateTransactionResponse {
+        let mut sim = SimulateTransactionResponse {
+            latest_ledger: 1,
+            result: None,
+            results: vec![],
+            transaction_data: Some(
+                empty_soroban_data()
+                    .to_xdr_base64(Limits::none())
+                    .expect("xdr"),
+            ),
+            min_resource_fee: Some("500".to_string()),
+            restore_preamble: preamble,
+            error: None,
+        };
+        sim.results
+            .push(crate::chain::rpc::SimulateHostFunctionResult {
+                auth: vec![],
+                retval: None,
+                ..Default::default()
+            });
+        sim
+    }
+
+    #[test]
+    fn a_restore_preamble_yields_a_restore_footprint_transaction() {
+        let raw = empty_envelope();
+
+        let envelope = restore_footprint_envelope(&raw, &preamble("700")).expect("restore tx");
+
+        let xdr::TransactionEnvelope::Tx(v1) = envelope else {
+            panic!("expected v1 envelope");
+        };
+        assert_eq!(v1.tx.operations.len(), 1);
+        assert!(matches!(
+            v1.tx.operations[0].body,
+            xdr::OperationBody::RestoreFootprint(_)
+        ));
+        let TransactionExt::V1(data) = &v1.tx.ext else {
+            panic!("expected soroban transaction data on the restore");
+        };
+        assert_eq!(*data, empty_soroban_data());
+        assert_eq!(v1.tx.fee, BASE_FEE + 700);
+    }
+
+    /// The restore takes the sequence the invocation would have used, so the
+    /// invocation retried after it takes the one following.
+    #[test]
+    fn a_restore_reuses_the_source_and_sequence_of_the_invocation() {
+        let raw = empty_envelope();
+        let xdr::TransactionEnvelope::Tx(original) = &raw else {
+            panic!("expected v1 envelope");
+        };
+
+        let envelope = restore_footprint_envelope(&raw, &preamble("0")).expect("restore tx");
+
+        let xdr::TransactionEnvelope::Tx(v1) = &envelope else {
+            panic!("expected v1 envelope");
+        };
+        assert_eq!(v1.tx.source_account, original.tx.source_account);
+        assert_eq!(v1.tx.seq_num, original.tx.seq_num);
+    }
+
+    #[test]
+    fn a_restore_preamble_with_invalid_transaction_data_is_rejected() {
+        let raw = empty_envelope();
+        let preamble = RestorePreamble {
+            min_resource_fee: "1".to_string(),
+            transaction_data: "not base64 xdr".to_string(),
+        };
+
+        let err = restore_footprint_envelope(&raw, &preamble)
+            .expect_err("a preamble with unreadable transaction data must not assemble");
+
+        assert!(err.to_string().contains("transactionData"), "{err}");
+    }
+
+    #[test]
+    fn a_restore_preamble_with_a_non_numeric_fee_is_rejected() {
+        let raw = empty_envelope();
+        let preamble = RestorePreamble {
+            min_resource_fee: "lots".to_string(),
+            transaction_data: empty_soroban_data()
+                .to_xdr_base64(Limits::none())
+                .expect("xdr"),
+        };
+
+        let err = restore_footprint_envelope(&raw, &preamble)
+            .expect_err("a preamble with a non-numeric fee must not assemble");
+
+        assert!(err.to_string().contains("minResourceFee"), "{err}");
+    }
+
+    #[test]
+    fn a_simulation_with_a_preamble_carries_the_restore_xdr() {
+        let raw = empty_envelope();
+
+        let prepared =
+            PreparedSorobanTx::from_simulation(&raw, &sim_with_preamble(Some(preamble("300"))))
+                .expect("prepare");
+
+        let restore = prepared.restore_tx_xdr.expect("restore xdr");
+        let envelope =
+            xdr::TransactionEnvelope::from_xdr_base64(&restore, Limits::none()).expect("xdr");
+        let xdr::TransactionEnvelope::Tx(v1) = envelope else {
+            panic!("expected v1 envelope");
+        };
+        assert!(matches!(
+            v1.tx.operations[0].body,
+            xdr::OperationBody::RestoreFootprint(_)
+        ));
+    }
+
+    #[test]
+    fn a_simulation_without_a_preamble_leaves_the_restore_xdr_unset() {
+        let raw = empty_envelope();
+
+        let prepared =
+            PreparedSorobanTx::from_simulation(&raw, &sim_with_preamble(None)).expect("prepare");
+
+        assert!(prepared.restore_tx_xdr.is_none());
     }
 }

--- a/sdk/native/src/chain/tx_prepare.rs
+++ b/sdk/native/src/chain/tx_prepare.rs
@@ -176,15 +176,21 @@ mod tests {
 
     struct MockRpc {
         seq: xdr::SequenceNumber,
-        sim: SimulateTransactionResponse,
+        sims: Vec<SimulateTransactionResponse>,
         simulate_calls: AtomicUsize,
     }
 
     impl MockRpc {
         fn new(seq: i64, sim: SimulateTransactionResponse) -> Self {
+            Self::with_sims(seq, vec![sim])
+        }
+
+        /// Answers the nth call with the nth response, repeating the last one
+        /// once the list runs out.
+        fn with_sims(seq: i64, sims: Vec<SimulateTransactionResponse>) -> Self {
             Self {
                 seq: xdr::SequenceNumber(seq),
-                sim,
+                sims,
                 simulate_calls: AtomicUsize::new(0),
             }
         }
@@ -193,8 +199,9 @@ mod tests {
             &self,
             _tx: &xdr::TransactionEnvelope,
         ) -> Result<SimulateTransactionResponse, RpcError> {
-            self.simulate_calls.fetch_add(1, Ordering::SeqCst);
-            Ok(self.sim.clone())
+            let call = self.simulate_calls.fetch_add(1, Ordering::SeqCst);
+            let last = self.sims.len().saturating_sub(1);
+            Ok(self.sims[call.min(last)].clone())
         }
     }
 
@@ -209,6 +216,7 @@ mod tests {
                     .expect("xdr"),
             ),
             min_resource_fee: Some(resource_fee.to_string()),
+            restore_preamble: None,
             error: None,
         };
         sim.results.push(SimulateHostFunctionResult {
@@ -384,5 +392,46 @@ mod tests {
     #[test]
     fn next_sequence_rejects_overflow() {
         assert!(next_sequence(xdr::SequenceNumber(i64::MAX)).is_err());
+    }
+
+    fn fixture_sim_with_preamble(resource_fee: &str) -> SimulateTransactionResponse {
+        let mut sim = fixture_sim(resource_fee);
+        sim.restore_preamble = Some(crate::chain::rpc::RestorePreamble {
+            min_resource_fee: "400".to_string(),
+            transaction_data: empty_soroban_data()
+                .to_xdr_base64(Limits::none())
+                .expect("xdr"),
+        });
+        sim
+    }
+
+    /// A first simulation that asks for a restore is answered by submitting it
+    /// and preparing again; the second simulation asks for nothing, which is
+    /// what lets the caller stop rather than loop.
+    #[test]
+    fn a_register_simulation_asking_for_a_restore_prepares_twice() {
+        let pk = ed25519::PublicKey([9u8; 32]);
+        let source = pk.to_string();
+        let mock = MockRpc::with_sims(
+            4,
+            vec![fixture_sim_with_preamble("250"), fixture_sim("250")],
+        );
+
+        let first = block_on(prepare_register_with_mock(
+            &mock, &source, [0xAB; 32], [0xEE; 32],
+        ))
+        .expect("prepare register");
+        assert!(
+            first.restore_tx_xdr.is_some(),
+            "first pass asks for a restore"
+        );
+
+        let second = block_on(prepare_register_with_mock(
+            &mock, &source, [0xAB; 32], [0xEE; 32],
+        ))
+        .expect("prepare register after restore");
+
+        assert!(second.restore_tx_xdr.is_none());
+        assert_eq!(mock.simulate_calls.load(Ordering::SeqCst), 2);
     }
 }

--- a/sdk/native/src/pool.rs
+++ b/sdk/native/src/pool.rs
@@ -5,7 +5,9 @@ use crate::{
     types::{EncryptionPublicKey, NoteAmount, NotePublicKey, Sensitive, UserNoteSummary},
 };
 
-use crate::chain::{Limits, ReadXdr, StateFetcher, TransactionEnvelope, submit_tx};
+use crate::chain::{
+    Limits, PreparedSorobanTx, ReadXdr, StateFetcher, TransactionEnvelope, submit_tx,
+};
 
 use crate::{
     PreparedTransaction,
@@ -34,6 +36,33 @@ use crate::{
 };
 
 const POLL_INTERVAL_MS: u32 = 200;
+
+/// Submits the footprint restore a simulation asked for and waits for it to
+/// land, so the caller can prepare the same invocation again against
+/// unarchived entries.
+///
+/// # Errors
+///
+/// Returns [`Error::Other`] if the restore cannot be signed, submitted, or
+/// confirmed. A restore that fails on chain surfaces its result XDR.
+pub(crate) async fn restore_archived_entries(
+    rpc: &RpcClient,
+    signer: &Handle<dyn Signer>,
+    restore_tx_xdr: String,
+) -> Result<(), Error> {
+    let prepared = PreparedSorobanTx {
+        tx_xdr: restore_tx_xdr,
+        ..Default::default()
+    };
+    let signed = signer.sign_soroban_transaction(&prepared).await?;
+    let envelope = TransactionEnvelope::from_xdr_base64(&signed.signed_xdr, Limits::none())
+        .map_err(|e| Error::Other(format!("invalid signed restore transaction xdr: {e}")))?;
+    let hash = submit_tx(rpc, &envelope)
+        .await
+        .map_err(|e| Error::Other(format!("submit restore: {e:#}")))?;
+    confirm_tx(rpc, hash).await?;
+    Ok(())
+}
 const SYNC_MAX_RETRIES: u32 = 50;
 const DISCLOSE_MAX_RETRIES: u32 = 50;
 
@@ -249,11 +278,12 @@ impl<S: Storage> PrivatePool<S> {
 
     pub async fn simulate(&self, prepared: &mut PreparedTransaction) -> Result<(), Error> {
         let chain_config = self.core.config();
-        prepared.soroban_tx = self
+        let input = pool_transact_input(prepared);
+        let mut soroban_tx = self
             .fetcher
             .prepare_pool_transact(
                 &chain_config.pool_contract_id,
-                &pool_transact_input(prepared),
+                &input,
                 // The signing address becomes the contract's `sender`, the
                 // sequence-number lookup and the envelope source.
                 &chain_config.signer_address,
@@ -261,6 +291,25 @@ impl<S: Storage> PrivatePool<S> {
             .await
             .map_err(|e| Error::Other(format!("simulate transaction: {e:#}")))?;
 
+        if let Some(restore_tx_xdr) = soroban_tx.restore_tx_xdr.take() {
+            restore_archived_entries(&self.rpc, &self.signer, restore_tx_xdr).await?;
+            soroban_tx = self
+                .fetcher
+                .prepare_pool_transact(
+                    &chain_config.pool_contract_id,
+                    &input,
+                    &chain_config.signer_address,
+                )
+                .await
+                .map_err(|e| Error::Other(format!("simulate transaction after restore: {e:#}")))?;
+            if soroban_tx.restore_tx_xdr.is_some() {
+                return Err(Error::Other(
+                    "simulation still asks for a footprint restore after one was submitted".into(),
+                ));
+            }
+        }
+
+        prepared.soroban_tx = soroban_tx;
         Ok(())
     }
 


### PR DESCRIPTION
When a simulation's footprint touches an archived ledger entry, Soroban RPC does not return a
usable transaction. It returns a `restorePreamble` describing a `RestoreFootprint` transaction
that has to be submitted and land before the real invocation can run. Until now the SDK
ignored that field, so the caller saw an unexplained failure with no path forward.

## What happens now

On a preamble the SDK assembles the `RestoreFootprint` transaction the preamble describes,
signs and submits it through the existing signer, waits for it to land, and then prepares the
original invocation again against the restored entries.

The user sees one extra on-chain transaction and their original call succeeding, rather than
an error they cannot act on.

## Details worth checking in review

- The restore reuses the invocation's source account and sequence number. It therefore takes
  the sequence the invocation would have used, and the invocation retried after it takes the
  next one, which keeps both valid without a separate sequence lookup.
- Its fee is the base fee plus the preamble's `minResourceFee`.
- A second preamble after a restore is treated as an error, not as a reason to try again.
  Retrying would be an unbounded loop against an RPC that keeps asking for the same thing, and
  it almost certainly means something other than archival is wrong.
- A restore that fails on chain surfaces its result XDR in the error, so the failure is
  diagnosable rather than reported as a generic submission failure.

## Coverage

Both paths that submit an invocation handle a preamble: pool `simulate` and account
registration.

## Breaking change

`PreparedSorobanTx` gains `restore_tx_xdr`, under
`#[serde(default, skip_serializing_if = "Option::is_none")]`, so values serialized before this
change still decode and an invocation needing no restore serializes no new key.

The wallet flow is unchanged. The restore is signed through the same
`sign_soroban_transaction` as any other transaction, so no signer needs to learn a new shape.

Part of #372.
