### PR TITLE
GVK pool ASP update contract methods

### DIFF
--- a/contracts/pool-gvk/src/pool_gvk.rs
+++ b/contracts/pool-gvk/src/pool_gvk.rs
@@ -340,13 +340,15 @@ impl PoolGvkContract {
             .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
     }
 
+    /// Get the admin address.
+    fn get_admin(env: &Env) -> Result<Address, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)
+    }
+
     // ========== ASP Contract Functions ==========
-    //
-    // `pool` also exports `update_asp_membership`/`update_asp_non_membership`;
-    // this crate deliberately does not. A `pool-gvk` pool can therefore never
-    // repoint its ASP contracts after construction, unlike a `pool` one — a
-    // deployment-time constraint, not an oversight. Nothing in the repo calls
-    // those two methods today; add them here if that changes.
 
     /// Get the ASP Membership contract address.
     fn get_asp_membership(env: &Env) -> Result<Address, Error> {
@@ -364,7 +366,57 @@ impl PoolGvkContract {
             .ok_or(Error::NotInitialized)
     }
 
+    /// Update the ASP Membership contract address.
+    ///
+    /// Changes the ASP Membership contract address. Requires admin
+    /// authorization.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment
+    /// * `new_asp_membership` - New ASP Membership contract address
+    pub fn update_asp_membership(env: &Env, new_asp_membership: Address) -> Result<(), Error> {
+        let admin = Self::get_admin(env)?;
+        admin.require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::ASPMembership, &new_asp_membership);
+        Ok(())
+    }
+
+    /// Update the ASP Non-Membership contract address.
+    ///
+    /// Changes the ASP Non-Membership contract address. Requires admin
+    /// authorization.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment
+    /// * `new_asp_non_membership` - New ASP Non-Membership contract address
+    pub fn update_asp_non_membership(
+        env: &Env,
+        new_asp_non_membership: Address,
+    ) -> Result<(), Error> {
+        let admin = Self::get_admin(env)?;
+        admin.require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::ASPNonMembership, &new_asp_non_membership);
+        Ok(())
+    }
+
     /// Get the current Merkle root from the ASP Membership contract.
+    ///
+    /// Makes a cross-contract call to retrieve the current root of the
+    /// membership Merkle tree.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment
+    ///
+    /// # Returns
+    ///
+    /// The current membership Merkle root as U256
     pub fn get_asp_membership_root(env: &Env) -> Result<U256, Error> {
         let asp_address = Self::get_asp_membership(env)?;
         let client = ASPMembershipClient::new(env, &asp_address);
@@ -372,6 +424,17 @@ impl PoolGvkContract {
     }
 
     /// Get the current Merkle root from the ASP Non-Membership contract.
+    ///
+    /// Makes a cross-contract call to retrieve the current root of the
+    /// non-membership Sparse Merkle tree.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment
+    ///
+    /// # Returns
+    ///
+    /// The current non-membership Merkle root as U256
     pub fn get_asp_non_membership_root(env: &Env) -> Result<U256, Error> {
         let asp_address = Self::get_asp_non_membership(env)?;
         let client = ASPNonMembershipClient::new(env, &asp_address);

--- a/contracts/pool-gvk/src/test.rs
+++ b/contracts/pool-gvk/src/test.rs
@@ -411,6 +411,108 @@ fn update_admin_requires_admin() {
     pool.update_admin(&Address::generate(&env));
 }
 
+#[test]
+fn pool_gvk_update_asp_membership_transfers_control() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool_gvk(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        0,
+        mk_point(&env, 1, 1),
+        VIEW_ONLY,
+    );
+    let pool = PoolGvkContractClient::new(&env, &pool_id);
+    env.mock_all_auths();
+
+    let new_asp_membership = Address::generate(&env);
+    pool.update_asp_membership(&new_asp_membership);
+
+    let stored: Address = env.as_contract(&pool_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ASPMembership)
+            .unwrap_or_else(|| panic!("expected ASP membership address to be stored"))
+    });
+    assert_eq!(stored, new_asp_membership);
+}
+
+#[test]
+fn pool_gvk_update_asp_non_membership_transfers_control() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool_gvk(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        0,
+        mk_point(&env, 1, 1),
+        VIEW_ONLY,
+    );
+    let pool = PoolGvkContractClient::new(&env, &pool_id);
+    env.mock_all_auths();
+
+    let new_asp_non_membership = Address::generate(&env);
+    pool.update_asp_non_membership(&new_asp_non_membership);
+
+    let stored: Address = env.as_contract(&pool_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ASPNonMembership)
+            .unwrap_or_else(|| panic!("expected ASP non-membership address to be stored"))
+    });
+    assert_eq!(stored, new_asp_non_membership);
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn pool_gvk_update_asp_membership_requires_admin() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool_gvk(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        0,
+        mk_point(&env, 1, 1),
+        VIEW_ONLY,
+    );
+    let pool = PoolGvkContractClient::new(&env, &pool_id);
+
+    pool.update_asp_membership(&Address::generate(&env));
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn pool_gvk_update_asp_non_membership_requires_admin() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool_gvk(
+        &env,
+        &setup,
+        U256::from_u32(&env, 1000),
+        3,
+        0,
+        mk_point(&env, 1, 1),
+        VIEW_ONLY,
+    );
+    let pool = PoolGvkContractClient::new(&env, &pool_id);
+
+    pool.update_asp_non_membership(&Address::generate(&env));
+}
+
 fn mk_bytesn32(env: &Env, fill: u8) -> BytesN<32> {
     BytesN::from_array(env, &[fill; 32])
 }


### PR DESCRIPTION
Allow admin to update the ASP contracts.
The removed docs mention:
```rust
    // `pool` also exports `update_asp_membership`/`update_asp_non_membership`;
    // this crate deliberately does not. A `pool-gvk` pool can therefore never
    // repoint its ASP contracts after construction, unlike a `pool` one 
```

However GVK key/encryption is independent of this logic.