### PR TITLE
Name the signing account in the chain layer signing path

### DIFF
--- a/sdk/native/README.md
+++ b/sdk/native/README.md
@@ -41,7 +41,11 @@ let client = Client::init(
 )?;
 
 let signer = Handle::from_box(
-    Box::new(LocalSigner::new("S...", "Test SDF Network ; September 2015", "G...")?)
+    Box::new(LocalSigner::new(
+        "S...",
+        "Test SDF Network ; September 2015",
+        SignerAddress::new("G..."),
+    )?)
         as Box<dyn stellar_private_payments::Signer>,
 );
 

--- a/sdk/native/examples/common/mod.rs
+++ b/sdk/native/examples/common/mod.rs
@@ -205,14 +205,14 @@ pub fn user_address_from_secret(secret_key: &str) -> Result<String, String> {
         .to_string())
 }
 
-/// Build a signer handle from a raw secret key, network passphrase, and user
-/// address.
+/// Build a signer handle from a raw secret key, network passphrase, and
+/// signing account.
 pub fn build_signer(
     secret_key: &str,
     network_passphrase: &str,
-    user_address: &str,
+    signer_address: SignerAddress,
 ) -> Result<Handle<dyn Signer>, String> {
-    let signer = LocalSigner::new(secret_key, network_passphrase, user_address)
+    let signer = LocalSigner::new(secret_key, network_passphrase, signer_address)
         .map_err(|e| format!("build signer: {e}"))?;
     Ok(Handle::from_box(Box::new(signer) as Box<dyn Signer>))
 }
@@ -227,7 +227,11 @@ pub fn build_account(client: &Client) -> Result<Account, String> {
     let passphrase = network_passphrase(network).ok_or_else(|| {
         format!("unknown network '{network}'; set SPP_NETWORK_PASSPHRASE explicitly")
     })?;
-    let signer = build_signer(&secret, &passphrase, &user_address)?;
+    let signer = build_signer(
+        &secret,
+        &passphrase,
+        SignerAddress::new(user_address.as_str()),
+    )?;
     client
         .account(
             NoteOwnerAddress::new(user_address.as_str()),

--- a/sdk/native/src/chain/signer.rs
+++ b/sdk/native/src/chain/signer.rs
@@ -28,6 +28,7 @@ use stellar_xdr::{
 };
 
 use super::{contract_state::PreparedSorobanTx, conversions::scval_to_address_string};
+use crate::types::SignerAddress;
 
 /// Auth validity
 ///
@@ -157,17 +158,17 @@ impl LocalSigner {
         &self,
         prepared: &PreparedSorobanTx,
         network_passphrase: &str,
-        user_address: &str,
+        signer_address: &SignerAddress,
     ) -> Result<TransactionEnvelope> {
-        if self.public_key() != user_address {
-            bail!("secret key does not match user_address");
+        if self.public_key() != signer_address.as_str() {
+            bail!("secret key does not match signer_address");
         }
-        let steps = auth_sign_steps(prepared, network_passphrase, user_address)?;
+        let steps = auth_sign_steps(prepared, network_passphrase, signer_address)?;
         let mut auth_signatures = Vec::with_capacity(steps.len());
         for step in &steps {
             auth_signatures.push((step.entry_index, self.sign_auth_preimage(&step.preimage)?));
         }
-        let tx_b64 = unsigned_tx_for_signing(prepared, user_address, &auth_signatures)?;
+        let tx_b64 = unsigned_tx_for_signing(prepared, signer_address, &auth_signatures)?;
         let envelope = TransactionEnvelope::from_xdr_base64(&tx_b64, Limits::none())
             .context("invalid tx xdr")?;
         self.sign_transaction(envelope, network_passphrase)
@@ -190,18 +191,18 @@ impl AuthSignStep {
     }
 }
 
-/// Auth preimage steps required for `user_address` on a prepared transaction.
+/// Auth preimage steps required for `signer_address` on a prepared transaction.
 pub fn auth_sign_steps(
     prepared: &PreparedSorobanTx,
     network_passphrase: &str,
-    user_address: &str,
+    signer_address: &SignerAddress,
 ) -> Result<Vec<AuthSignStep>> {
     let expiration = auth_expiration_ledger(prepared);
     let mut steps = Vec::new();
     for (entry_index, entry_b64) in prepared.auth_entries.iter().enumerate() {
         let entry = SorobanAuthorizationEntry::from_xdr_base64(entry_b64, Limits::none())
             .context("invalid auth entry xdr")?;
-        if needs_wallet_auth(&entry, user_address)? {
+        if needs_wallet_auth(&entry, signer_address.as_str())? {
             steps.push(AuthSignStep {
                 entry_index,
                 preimage: soroban_auth_preimage(&entry, network_passphrase, expiration)?,
@@ -214,13 +215,14 @@ pub fn auth_sign_steps(
 /// Unsigned transaction envelope (base64) with signed auth entries attached.
 pub fn unsigned_tx_for_signing(
     prepared: &PreparedSorobanTx,
-    user_address: &str,
+    signer_address: &SignerAddress,
     auth_signatures: &[(usize, Signature)],
 ) -> Result<String> {
     let expiration = auth_expiration_ledger(prepared);
-    let public_key: ed25519::PublicKey = user_address
+    let public_key: ed25519::PublicKey = signer_address
+        .as_str()
         .parse()
-        .context("invalid user address strkey")?;
+        .context("invalid signer address strkey")?;
     let mut sigs_by_index: std::collections::BTreeMap<usize, Signature> =
         auth_signatures.iter().copied().collect();
 
@@ -229,7 +231,7 @@ pub fn unsigned_tx_for_signing(
     for (entry_index, entry_b64) in prepared.auth_entries.iter().enumerate() {
         let mut entry = SorobanAuthorizationEntry::from_xdr_base64(entry_b64, Limits::none())
             .context("invalid auth entry xdr")?;
-        if needs_wallet_auth(&entry, user_address)? {
+        if needs_wallet_auth(&entry, signer_address.as_str())? {
             needs_patch = true;
             let signature = sigs_by_index
                 .remove(&entry_index)
@@ -435,14 +437,15 @@ mod tests {
         LocalSigner::from_seed([7u8; 32])
     }
 
-    fn test_prepared_tx(user_address: &str) -> PreparedSorobanTx {
+    fn test_prepared_tx(signer_address: &SignerAddress) -> PreparedSorobanTx {
         use stellar_xdr::{
             AccountId, InvokeContractArgs, PublicKey, ScAddress, ScSymbol,
             SorobanAddressCredentials, SorobanAuthorizationEntry, SorobanAuthorizedFunction,
             SorobanAuthorizedInvocation, SorobanCredentials, Uint256, VecM, WriteXdr,
         };
 
-        let public_key: ed25519::PublicKey = user_address.parse().expect("parse address");
+        let public_key: ed25519::PublicKey =
+            signer_address.as_str().parse().expect("parse address");
         let wallet = ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
             public_key.0,
         ))));
@@ -509,16 +512,17 @@ mod tests {
     #[test]
     fn sign_prepared_transaction() {
         let signer = test_signer();
-        let user_address = signer.public_key().to_string();
-        let prepared = test_prepared_tx(&user_address);
+        let signer_address = SignerAddress::new(signer.public_key());
+        let prepared = test_prepared_tx(&signer_address);
 
-        let steps = auth_sign_steps(&prepared, TEST_PASSPHRASE, &user_address).expect("auth steps");
+        let steps =
+            auth_sign_steps(&prepared, TEST_PASSPHRASE, &signer_address).expect("auth steps");
         assert_eq!(steps.len(), 1);
 
         let signed = signer
-            .sign_prepared_transaction(&prepared, TEST_PASSPHRASE, &user_address)
+            .sign_prepared_transaction(&prepared, TEST_PASSPHRASE, &signer_address)
             .expect("sign prepared tx");
-        verify_tx(&signed, TEST_PASSPHRASE, &user_address, 0).expect("verify tx");
+        verify_tx(&signed, TEST_PASSPHRASE, signer_address.as_str(), 0).expect("verify tx");
 
         let xdr::TransactionEnvelope::Tx(v1) = &signed else {
             panic!("expected v1 envelope");

--- a/sdk/native/src/client.rs
+++ b/sdk/native/src/client.rs
@@ -277,7 +277,8 @@ mod signer_is_note_owner_tests {
 
     fn test_signer(address: &str) -> Handle<dyn Signer> {
         Handle::from_box(Box::new(
-            LocalSigner::new(SECRET, PASSPHRASE, address).expect("build signer"),
+            LocalSigner::new(SECRET, PASSPHRASE, SignerAddress::new(address))
+                .expect("build signer"),
         ) as Box<dyn Signer>)
     }
 

--- a/sdk/native/src/lib.rs
+++ b/sdk/native/src/lib.rs
@@ -20,7 +20,11 @@
 //!     Box::new(LocalProver::from_artifacts(&artifacts)?) as Box<dyn Prover>,
 //! );
 //! let signer = Handle::from_box(
-//!     Box::new(LocalSigner::new("S...", "Test SDF Network ; September 2015", "G...")?)
+//!     Box::new(LocalSigner::new(
+//!         "S...",
+//!         "Test SDF Network ; September 2015",
+//!         SignerAddress::new("G..."),
+//!     )?)
 //!         as Box<dyn stellar_private_payments::Signer>,
 //! );
 //!

--- a/sdk/native/src/signer/local.rs
+++ b/sdk/native/src/signer/local.rs
@@ -1,26 +1,30 @@
 use crate::chain::{Limits, LocalSigner as StellarSigner, PreparedSorobanTx, WriteXdr};
 
 use super::Signer;
-use crate::{PreparedTransaction, error::Error, types::SignedTransaction};
+use crate::{
+    PreparedTransaction,
+    error::Error,
+    types::{SignedTransaction, SignerAddress},
+};
 
 /// In-process Ed25519 signer for native CLI and tests.
 pub struct LocalSigner {
     stellar: StellarSigner,
     network_passphrase: String,
-    user_address: String,
+    signer_address: SignerAddress,
 }
 
 impl LocalSigner {
     pub fn new(
         secret_key: &str,
         network_passphrase: impl Into<String>,
-        user_address: impl Into<String>,
+        signer_address: SignerAddress,
     ) -> Result<Self, Error> {
         Ok(Self {
             stellar: StellarSigner::from_secret(secret_key)
                 .map_err(|e| Error::Other(format!("signer: {e:#}")))?,
             network_passphrase: network_passphrase.into(),
-            user_address: user_address.into(),
+            signer_address,
         })
     }
 
@@ -32,8 +36,8 @@ impl LocalSigner {
         &self.network_passphrase
     }
 
-    pub fn user_address(&self) -> &str {
-        &self.user_address
+    pub fn signer_address(&self) -> &SignerAddress {
+        &self.signer_address
     }
 }
 
@@ -52,7 +56,7 @@ impl Signer for LocalSigner {
     ) -> Result<SignedTransaction, Error> {
         let envelope = self
             .stellar
-            .sign_prepared_transaction(prepared, &self.network_passphrase, &self.user_address)
+            .sign_prepared_transaction(prepared, &self.network_passphrase, &self.signer_address)
             .map_err(|e| Error::Other(format!("sign transaction: {e:#}")))?;
         let signed_xdr = envelope
             .to_xdr_base64(Limits::none())

--- a/sdk/tests/src/pool.rs
+++ b/sdk/tests/src/pool.rs
@@ -118,7 +118,7 @@ fn test_signer() -> Result<Handle<dyn Signer>> {
     Ok(Handle::from_box(Box::new(LocalSigner::new(
         TEST_SIGNER_SECRET,
         "Test SDF Network ; September 2015",
-        USER_ADDRESS,
+        SignerAddress::new(USER_ADDRESS),
     )?) as Box<dyn Signer>))
 }
 

--- a/sdk/web/src/signer.rs
+++ b/sdk/web/src/signer.rs
@@ -63,12 +63,8 @@ impl WalletSigner {
         &self,
         prepared: &PreparedSorobanTx,
     ) -> Result<TransactionEnvelope, JsError> {
-        let steps = auth_sign_steps(
-            prepared,
-            &self.network_passphrase,
-            self.signer_address.as_str(),
-        )
-        .map_err(|e| JsError::new(&e.to_string()))?;
+        let steps = auth_sign_steps(prepared, &self.network_passphrase, &self.signer_address)
+            .map_err(|e| JsError::new(&e.to_string()))?;
 
         let mut auth_signatures = Vec::with_capacity(steps.len());
         for step in &steps {
@@ -84,9 +80,8 @@ impl WalletSigner {
             ));
         }
 
-        let tx_b64 =
-            unsigned_tx_for_signing(prepared, self.signer_address.as_str(), &auth_signatures)
-                .map_err(|e| JsError::new(&e.to_string()))?;
+        let tx_b64 = unsigned_tx_for_signing(prepared, &self.signer_address, &auth_signatures)
+            .map_err(|e| JsError::new(&e.to_string()))?;
 
         let signed_b64 = self
             .call("signTransaction", &[tx_b64.as_str().into()])


### PR DESCRIPTION
The chain layer named its signing account `user_address` and typed it `&str`.
That name belongs to the note owner, but every one of these parameters is a
payer role: the account whose sequence number is read, the envelope source, and
the address the wallet is asked to sign with. #548 split the two identities in
`types` (`NoteOwnerAddress` vs `SignerAddress`), and the signing path was still
below that split — an owner-derived string reached it unchanged.

## Change

`sign_prepared_transaction`, `auth_sign_steps` and `unsigned_tx_for_signing`
take `&SignerAddress`. `signer::local::LocalSigner` stores a `SignerAddress` and
exposes it as `signer_address()`. The wasm `WalletSigner` passes its
`SignerAddress` through instead of unwrapping it to `&str` at each call.

`tx_prepare::prepare_register` keeps `&str`: its argument is the registry key as
well as the envelope source, and which identity it should be once the two
diverge is unsettled.