### PR TITLE
Refuse a signature the wallet made with a substituted account

### DIFF
--- a/app/js/wallet-signer-guard.js
+++ b/app/js/wallet-signer-guard.js
@@ -1,0 +1,37 @@
+/**
+ * The rule that a wallet must sign with the account it was asked to sign with.
+ *
+ * Kept in its own module, free of any import, so it is reachable from Node for
+ * unit testing: `wallet.js` pulls in `@stellar/freighter-api`, whose package
+ * exports cannot be resolved outside the browser bundle.
+ */
+
+/**
+ * Refuse a signature the wallet produced with an account other than the one
+ * requested.
+ *
+ * Freighter returns success with `signerAddress` set to the *active* account
+ * when it does not hold the requested one: no error, no rejection, and nothing
+ * in the approval prompt naming the address that was asked for. Comparing the
+ * two is what catches the substitution.
+ *
+ * Skipped when the caller pinned no address (nothing to compare) or the wallet
+ * reported none. The wording deliberately avoids "rejected"/"denied"/
+ * "cancelled": normalizeWalletError's classifier substring-matches those, and a
+ * substitution is not a user cancellation.
+ *
+ * @param {string} method - Wallet method name, for the message.
+ * @param {string | undefined} requested - Address the caller asked to sign with.
+ * @param {string | undefined} reported - Address the wallet says signed.
+ * @throws {Error} with `code = 'SIGNER_ADDRESS_MISMATCH'` when the two differ.
+ */
+export function verifySignerAddress(method, requested, reported) {
+    if (!requested || !reported || requested === reported) {
+        return;
+    }
+    const err = new Error(
+        `${method}: the wallet signed with a different account than the one requested.`,
+    );
+    err.code = 'SIGNER_ADDRESS_MISMATCH';
+    throw err;
+}

--- a/app/js/wallet.js
+++ b/app/js/wallet.js
@@ -28,6 +28,9 @@ import {
     signTransaction,
     signMessage
 } from '@stellar/freighter-api';
+
+import { verifySignerAddress } from './wallet-signer-guard.js';
+
 /**
  * Request wallet access and return the active public key.
  *
@@ -224,6 +227,7 @@ export async function signWalletTransaction(transactionXdr, opts = {}) {
     if (error) {
         throw normalizeWalletError(error, 'Transaction signature failed');
     }
+    verifySignerAddress('signTransaction', opts.address, signerAddress);
 
     return { signedTxXdr, signerAddress };
 }
@@ -246,6 +250,7 @@ export async function signWalletAuthEntry(entryXdr, opts = {}) {
     if (error) {
         throw normalizeWalletError(error, 'Auth entry signature failed');
     }
+    verifySignerAddress('signAuthEntry', opts.address, signerAddress);
 
     return { signedAuthEntry, signerAddress };
 }
@@ -288,6 +293,8 @@ export async function signWalletMessage(message, opts = {}) {
         err.code = 'USER_REJECTED';
         throw err;
     }
+
+    verifySignerAddress('signMessage', freighterOpts.address, signerAddress);
 
     return { signedMessage, signerAddress };
 }

--- a/e2e-freighter/tests/unit/app-wallet-signer.test.mjs
+++ b/e2e-freighter/tests/unit/app-wallet-signer.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { verifySignerAddress } from '../../../app/js/wallet-signer-guard.js';
+
+const REQUESTED = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+const SUBSTITUTED = 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+
+test('a wallet reporting the requested account is accepted', () => {
+  assert.doesNotThrow(() => verifySignerAddress('signTransaction', REQUESTED, REQUESTED));
+});
+
+// Freighter returns success with signerAddress set to whichever account was
+// active when it does not hold the requested one, with nothing in the approval
+// prompt naming the address that was asked for.
+test('a wallet reporting a substituted account is refused', () => {
+  assert.throws(
+    () => verifySignerAddress('signTransaction', REQUESTED, SUBSTITUTED),
+    (error) => {
+      assert.equal(error.code, 'SIGNER_ADDRESS_MISMATCH');
+      assert.match(error.message, /signTransaction/);
+      return true;
+    },
+  );
+});
+
+test('the refusal leaks neither address', () => {
+  try {
+    verifySignerAddress('signAuthEntry', REQUESTED, SUBSTITUTED);
+    assert.fail('expected a refusal');
+  } catch (error) {
+    assert.ok(!error.message.includes(REQUESTED), error.message);
+    assert.ok(!error.message.includes(SUBSTITUTED), error.message);
+  }
+});
+
+// normalizeWalletError's classifier substring-matches these words to decide a
+// signing failure was the user's choice; a substitution is not.
+test('the refusal does not read as a user cancellation', () => {
+  try {
+    verifySignerAddress('signMessage', REQUESTED, SUBSTITUTED);
+    assert.fail('expected a refusal');
+  } catch (error) {
+    const message = error.message.toLowerCase();
+    for (const word of ['rejected', 'denied', 'cancelled']) {
+      assert.ok(!message.includes(word), `'${word}' in: ${error.message}`);
+    }
+  }
+});
+
+test('nothing to compare is not a failure', () => {
+  assert.doesNotThrow(() => verifySignerAddress('signTransaction', undefined, SUBSTITUTED));
+  assert.doesNotThrow(() => verifySignerAddress('signTransaction', REQUESTED, undefined));
+});

--- a/sdk/web/src/signer.rs
+++ b/sdk/web/src/signer.rs
@@ -8,7 +8,7 @@ use stellar_private_payments::{
         Limits, PreparedSorobanTx, ReadXdr, Signature, TransactionEnvelope, WriteXdr,
         auth_sign_steps, unsigned_tx_for_signing,
     },
-    types::{SignedTransaction, SignerAddress},
+    types::{Sensitive, SignedTransaction, SignerAddress},
 };
 use wasm_bindgen::{JsCast, JsError, JsValue};
 use wasm_bindgen_futures::JsFuture;
@@ -132,7 +132,35 @@ impl WalletSigner {
             .await
             .map_err(|e| wallet_js_error(method, "failed", e))?;
 
-        normalize_sign_result(method, result)
+        let (signature, reported) = normalize_sign_result(method, result)?;
+        self.verify_signer_address(method, reported.as_deref())?;
+        Ok(signature)
+    }
+
+    /// Refuse a signature the wallet produced with an account other than the
+    /// one requested.
+    ///
+    /// Freighter returns success with `signerAddress` set to the *active*
+    /// account when it does not hold the requested one, with no error and no
+    /// indication to the user that a substitution occurred. Comparing the
+    /// reported address against the requested one is what catches that.
+    ///
+    /// A signer that reports no address cannot be checked, and is accepted:
+    /// `WalletSigner` takes any object with the three sign methods, and the
+    /// bare-string return shape carries nothing to compare. Freighter always
+    /// reports one, so its substitution path stays covered.
+    fn verify_signer_address(&self, method: &str, reported: Option<&str>) -> Result<(), JsError> {
+        let Some(reported) = reported else {
+            return Ok(());
+        };
+        if reported == self.signer_address.as_str() {
+            return Ok(());
+        }
+        Err(JsError::new(&format!(
+            "signer.{method}: wallet signed as {}, not the requested {}",
+            Sensitive(reported),
+            Sensitive(self.signer_address.as_str()),
+        )))
     }
 }
 
@@ -187,9 +215,14 @@ fn wallet_sign_error(error: JsError) -> Error {
     }
 }
 
-fn normalize_sign_result(method: &str, result: JsValue) -> Result<String, JsError> {
+/// Split a wallet reply into its signature and the address the wallet reports
+/// having signed with. A bare-string reply carries no address.
+fn normalize_sign_result(
+    method: &str,
+    result: JsValue,
+) -> Result<(String, Option<String>), JsError> {
     if let Some(s) = result.as_string() {
-        return Ok(s);
+        return Ok((s, None));
     }
 
     let field = match method {
@@ -205,9 +238,16 @@ fn normalize_sign_result(method: &str, result: JsValue) -> Result<String, JsErro
 
     let value = Reflect::get(&result, &JsValue::from_str(field))
         .map_err(|e| JsError::new(&format!("signer.{method}: missing {field}: {e:?}")))?;
-    value
+    let signature = value
         .as_string()
-        .ok_or_else(|| JsError::new(&format!("signer.{method}: {field} must be a string")))
+        .ok_or_else(|| JsError::new(&format!("signer.{method}: {field} must be a string")))?;
+
+    let reported = Reflect::get(&result, &JsValue::from_str("signerAddress"))
+        .ok()
+        .and_then(|v| v.as_string())
+        .filter(|s| !s.is_empty());
+
+    Ok((signature, reported))
 }
 
 #[async_trait::async_trait(?Send)]
@@ -455,5 +495,110 @@ mod spike_tests {
             96,
             "128 hex chars decode as base64, not as hex"
         );
+    }
+}
+
+/// Tests for the reported-signer check in
+/// [`WalletSigner::verify_signer_address`].
+///
+/// Node mode is sufficient: the wallet is a plain JS object whose methods
+/// resolve immediately, and no browser API is involved.
+#[cfg(all(test, target_arch = "wasm32"))]
+mod signer_address_tests {
+    // Tests favour `unwrap()` for brevity; the workspace-wide `unwrap_used`
+    // deny is meant for production paths, not assertions.
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+    use wasm_bindgen_test::*;
+
+    const PASSPHRASE: &str = "Test SDF Network ; September 2015";
+    const REQUESTED: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+    const SUBSTITUTED: &str = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+    const SIGNATURE: &str = "c2lnbmF0dXJl";
+
+    /// A wallet whose three sign methods resolve to `js_expr`.
+    fn wallet_returning(js_expr: &str) -> Result<WalletSigner, JsError> {
+        let wallet = Object::new();
+        for method in SIGN_METHODS {
+            let body = format!("return Promise.resolve({js_expr});");
+            let resolving: JsValue = Function::new_no_args(&body).into();
+            Reflect::set(&wallet, &JsValue::from_str(method), &resolving).unwrap();
+        }
+        WalletSigner::new(
+            wallet.into(),
+            PASSPHRASE.to_string(),
+            SignerAddress::new(REQUESTED),
+        )
+    }
+
+    fn error_message(error: JsError) -> String {
+        Reflect::get(&JsValue::from(error), &JsValue::from_str("message"))
+            .unwrap()
+            .as_string()
+            .unwrap()
+    }
+
+    #[wasm_bindgen_test]
+    async fn a_reply_reporting_the_requested_address_is_accepted() {
+        let wallet = wallet_returning(&format!(
+            "{{ signedMessage: '{SIGNATURE}', signerAddress: '{REQUESTED}' }}"
+        ))
+        .unwrap();
+        assert_eq!(wallet.sign_wallet_message("m").await.unwrap(), SIGNATURE);
+    }
+
+    /// Freighter reports success while having signed with whatever account was
+    /// active, because it does not hold the requested one.
+    #[wasm_bindgen_test]
+    async fn a_reply_reporting_a_substituted_address_is_refused() {
+        let wallet = wallet_returning(&format!(
+            "{{ signedMessage: '{SIGNATURE}', signerAddress: '{SUBSTITUTED}' }}"
+        ))
+        .unwrap();
+        let error = wallet
+            .sign_wallet_message("m")
+            .await
+            .expect_err("a substituted signing account must be refused");
+        assert!(
+            error_message(error).contains("signer.signMessage"),
+            "the message should name the wallet call that was substituted"
+        );
+    }
+
+    /// Addresses are Tier-1, and this message reaches a UI toast.
+    #[wasm_bindgen_test]
+    async fn the_refusal_redacts_both_addresses() {
+        stellar_private_payments::types::set_reveal_sensitive(false);
+        let wallet = wallet_returning(&format!(
+            "{{ signedMessage: '{SIGNATURE}', signerAddress: '{SUBSTITUTED}' }}"
+        ))
+        .unwrap();
+        let message = error_message(wallet.sign_wallet_message("m").await.unwrap_err());
+        assert!(!message.contains(SUBSTITUTED), "leaked: {message}");
+        assert!(!message.contains(REQUESTED), "leaked: {message}");
+    }
+
+    /// The cancellation classifier substring-matches signer error text; a
+    /// substitution is not a user cancellation and must not read as one.
+    #[wasm_bindgen_test]
+    async fn the_refusal_does_not_read_as_a_cancellation() {
+        let wallet = wallet_returning(&format!(
+            "{{ signedMessage: '{SIGNATURE}', signerAddress: '{SUBSTITUTED}' }}"
+        ))
+        .unwrap();
+        let message =
+            error_message(wallet.sign_wallet_message("m").await.unwrap_err()).to_ascii_lowercase();
+        for word in ["rejected", "denied", "cancelled"] {
+            assert!(!message.contains(word), "'{word}' in: {message}");
+        }
+    }
+
+    /// A wallet that reports no address carries nothing to compare, and the
+    /// bare-string reply shape is what the e2e stub signers use.
+    #[wasm_bindgen_test]
+    async fn a_reply_without_an_address_is_accepted() {
+        let wallet = wallet_returning(&format!("'{SIGNATURE}'")).unwrap();
+        assert_eq!(wallet.sign_wallet_message("m").await.unwrap(), SIGNATURE);
     }
 }


### PR DESCRIPTION
When Freighter does not hold the account it was asked to sign with, it does not fail: it signs with whichever account is active and returns success, with `signerAddress` naming the substitute and nothing in the approval prompt naming the address that was requested. Both signing paths read the signature out of that reply and discarded `signerAddress`, so a signature made by the wrong account was accepted as if it were the right one.

## Change

`normalize_sign_result` returns the signature together with the address the wallet reports, and `WalletSigner::call` refuses a reply whose reported address is not the requested one. `app/js/wallet.js` applies the same check at `signTransaction`, `signAuthEntry` and `signMessage`, since the admin page reaches Freighter without going through the SDK; the rule lives in `app/js/wallet-signer-guard.js`, importless so Node can unit-test it without resolving `@stellar/freighter-api`.

A reply that carries no address is still accepted — a bare-string return has nothing to compare, and the e2e stub signers use that shape. Freighter always reports an address, so the substitution path stays covered.

The mismatch message wraps both addresses in `Sensitive` and avoids "rejected"/"denied"/"cancelled", which `normalizeWalletError` substring-matches to classify user cancellations.