### PR TITLE
Bind derived privacy keys to the note owner, not the signing account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5367,6 +5367,7 @@ dependencies = [
  "anyhow",
  "rusqlite",
  "serde_json",
+ "sha2 0.11.0",
  "stellar-private-payments",
  "tracing",
  "tracing-subscriber",

--- a/app/ARCHITECTURE.md
+++ b/app/ARCHITECTURE.md
@@ -194,11 +194,29 @@ Root-level `circuits/` in the deployed site holds **legal files only** (`NOTICE.
 
 ## Keypair derivation
 
-Keys are derived deterministically from Freighter wallet signatures:
+Keys are derived deterministically from Freighter wallet signatures. Which
+construction is used is a fixed property of the deployment
+(`signer_may_differ_from_owner` in `deployments.json`, default `false`) —
+never a per-user or per-session choice:
+
+**v1 (split-free deployments, the default and permanent for them):**
 
 1. User signs `KEY_DERIVATION_MESSAGE` from `sdk/native/src/zk/encryption.rs` (`"Privacy Pool Key Derivation [v1]"`).
 2. The worker derives the BN254 note identity keypair and the X25519 encryption keypair from that signature using domain-separated hashes.
 3. Derived keys are stored in SQLite; the signature is not persisted.
+
+**v2 (deployments that separate the fee-paying signer from the note owner):**
+
+1. User signs `key_derivation_message_v2(ownerAddress)`, which names the owner address in the signed text so it is recognisable in the wallet's approval dialog.
+2. Before deriving anything, the worker verifies the signature against the owner address's own Ed25519 public key (decoded from the `G...` address) — this, not which account the wallet claims to have signed with, is what stops a differently-signing payer from producing the owner's keys.
+3. The worker derives owner-bound keypairs using domain-separated hashes that also fold in the verified owner public key, and stores them alongside a discriminator recording which construction produced the row.
+
+A stored row's discriminator is checked against the deployment's required
+binding on every read; a row from the wrong construction is refused rather
+than used, and refusing never re-derives or overwrites it. v1 is not a
+legacy path pending removal — a split-free deployment must keep deriving it
+forever, so a reinstall regenerates the keys an existing account already
+holds.
 
 Signatures are prompted during onboarding so the app can scan for notes addressed to the user.
 

--- a/app/js/app-storage.js
+++ b/app/js/app-storage.js
@@ -30,6 +30,9 @@ export async function storageCall(storage, request, timeoutMs = 5_000) {
 export class AppStorage {
     #storage;
 
+    /**
+     * @param {object} storage SDK storage handle.
+     */
     constructor(storage) {
         this.#storage = storage;
     }
@@ -71,13 +74,36 @@ export class AppStorage {
         return response.DisclaimerState ?? null;
     }
 
-    /** Whether privacy keys are stored locally for an address (onboarding only). */
-    async userKeysExist(address) {
-        const response = await this.#call({ UserKeys: address }, 1_000);
-        return response.UserKeys != null;
+    /**
+     * Binding status for an address: 'Absent', 'Acceptable', or a
+     * `{ Mismatch: { stored } }` object.
+     *
+     * The deployment's requirement lives in the worker, which every route that
+     * touches key material reads from, so this carries no binding of its own:
+     * a second copy here could only go stale, and defaulting one would accept
+     * a v1 row on a deployment that requires v2.
+     *
+     * Metadata only — this route never returns key material, which is what
+     * lets the UI tell "not onboarded yet" from "keys exist but were derived
+     * for a different deployment configuration". Asking the key-material
+     * route that question is what previously made the two indistinguishable.
+     */
+    async keyBindingStatus(address) {
+        const response = await this.#call({ KeyBindingStatus: address }, 1_000);
+        return response.KeyBindingStatus ?? null;
     }
 
-    /** Public note/encryption keys only (onboarding; no ASP secret). */
+    /** Whether usable privacy keys are stored locally for an address (onboarding only). */
+    async userKeysExist(address) {
+        return (await this.keyBindingStatus(address)) === 'Acceptable';
+    }
+
+    /**
+     * Public note/encryption keys only (onboarding; no ASP secret).
+     *
+     * Request this only once {@link keyBindingStatus} reports 'Acceptable':
+     * on a mismatch it returns null, which must not be read as "no keys".
+     */
     async getUserPublicKeys(address) {
         const response = await this.#call({ UserKeys: address }, 1_000);
         return response.UserKeys ?? null;

--- a/app/js/ui/onboarding-wizard.js
+++ b/app/js/ui/onboarding-wizard.js
@@ -274,8 +274,18 @@ export async function runOnboardingWizard({
 
     const storage = client().storage();
     const disclaimerState = await storage.getDisclaimerState(address);
-    const storedPublicKeys = await storage.getUserPublicKeys(address).catch(() => null);
-    const keysExist = !!storedPublicKeys?.noteKeypair?.public;
+    // Ask the metadata route, not the key-material one. getUserPublicKeys
+    // returns null both when no keys exist and when the stored keys were
+    // derived for a different deployment configuration, so reading its null as
+    // "no keys" would offer the keys step to an account whose derivation will
+    // then be refused.
+    const keyBinding = await storage.keyBindingStatus(address).catch(() => null);
+    const keysExist = keyBinding === 'Acceptable';
+    // Only once the status says the stored keys are usable here: on a mismatch
+    // this route returns null, which must not be read as "no keys".
+    const storedPublicKeys = keysExist
+        ? await storage.getUserPublicKeys(address).catch(() => null)
+        : null;
     const explorerSetting = await storage.getExplorerSetting();
     const bootnodeSetting = await storage.getBootnodeConfig();
     const registryLookup = await client().recipientLookup(address).catch(() => null);
@@ -326,7 +336,7 @@ export async function runOnboardingWizard({
     closeBtn.onclick = cancelOnboarding;
 
     const state = {
-        keys: keysExist
+        keys: keysExist && storedPublicKeys
             ? {
                 pubKey: storedPublicKeys.noteKeypair.public,
                 encryptionKeypair: { publicKey: storedPublicKeys.encryptionKeypair.public },

--- a/app/js/wallet.js
+++ b/app/js/wallet.js
@@ -25,8 +25,7 @@ import {
     requestAccess,
     setAllowed,
     signAuthEntry,
-    signTransaction,
-    signMessage
+    signTransaction
 } from '@stellar/freighter-api';
 
 import { verifySignerAddress } from './wallet-signer-guard.js';

--- a/app/js/wasm-facade.js
+++ b/app/js/wasm-facade.js
@@ -21,7 +21,7 @@ import init, {
 } from 'stellar-private-payments';
 import { FreighterSigner } from 'stellar-private-payments/freighter';
 
-import { AppStorage } from './app-storage.js';
+import { AppStorage, storageCall } from './app-storage.js';
 
 export { DisclosureRequest };
 
@@ -75,6 +75,23 @@ export function circuitsBaseUrl() {
 
 function bindAppStorage(sdkStorage) {
     appStorageInstance = new AppStorage(sdkStorage);
+}
+
+/**
+ * Tell the worker which key binding this deployment requires.
+ *
+ * Fixed per deployment, never a per-user choice. Absent in the deployment file
+ * means the payer is the owner, which is the v1 binding. If the config cannot
+ * be read we configure nothing: every route that touches key material then
+ * refuses with a clear error, which is the same fail-closed behaviour as the
+ * native handle. Defaulting to v1 here would instead accept a v1 row on a
+ * deployment that requires v2 — the unbound material this binding exists to
+ * keep out.
+ */
+async function configureStorageBinding(sdkStorage) {
+    const config = await loadDeploymentConfig();
+    const required = config?.signer_may_differ_from_owner ? 'V2' : 'V1';
+    await storageCall(sdkStorage, { ConfigureBinding: required }, 5_000);
 }
 
 function wrapSdkClient(sdk) {
@@ -170,7 +187,23 @@ export function disposeClient() {
 export async function ensureStorage() {
     await ensureWasmInit();
     if (!storageHandle) {
-        storageHandle = await Storage.open();
+        const handle = await Storage.open();
+        try {
+            await configureStorageBinding(handle);
+        } catch (err) {
+            // Publish nothing on failure. Assigning storageHandle first would
+            // make the next call skip this block and hand back a null
+            // AppStorage, and leaving the worker running would keep its OPFS
+            // handles held — which surfaces to the next page as a spurious
+            // "another tab is using this app's local database".
+            try {
+                await handle.call('Pause', 1_000);
+            } catch {
+                // Best-effort release; the original failure is what matters.
+            }
+            throw err;
+        }
+        storageHandle = handle;
         bindAppStorage(storageHandle);
         installStoragePauseOnUnload();
     }

--- a/cli/src/config/mod.rs
+++ b/cli/src/config/mod.rs
@@ -133,7 +133,12 @@ impl CliConfig {
         std::fs::create_dir_all(&self.data_dir)
             .with_context(|| format!("create data dir {}", self.data_dir.display()))?;
         let path = self.db_path();
-        SqliteStorage::connect_file(&path).with_context(|| format!("open {}", path.display()))
+        let mut storage = SqliteStorage::connect_file(&path)
+            .with_context(|| format!("open {}", path.display()))?;
+        // Every reader that returns key material consults the handle, so the
+        // deployment's requirement is set here rather than at each call site.
+        storage.set_required_binding(self.deployment.required_binding());
+        Ok(storage)
     }
 }
 

--- a/cli/src/onboard.rs
+++ b/cli/src/onboard.rs
@@ -10,9 +10,11 @@ use std::io::Write;
 
 use anyhow::{Context, Result, bail};
 use stellar_private_payments::{
-    state::{DEFAULT_BOOTNODE_URL, SqliteStorage},
+    state::{BindingVersion, DEFAULT_BOOTNODE_URL, KeyBinding, KeyLookup, SqliteStorage},
     zk::encryption::{
-        KEY_DERIVATION_MESSAGE, derive_encryption_and_note_keypairs, derive_membership_blinding,
+        KEY_DERIVATION_MESSAGE, derive_encryption_and_note_keypairs,
+        derive_encryption_and_note_keypairs_v2, derive_membership_blinding,
+        derive_membership_blinding_v2, key_derivation_message_v2, verify_owner_signature,
     },
 };
 
@@ -34,6 +36,11 @@ const REGISTRATION_TEXT: &str = "If you register now, other users can transfer t
     address without asking for note and encryption public keys out of band. \
     Note: this is different from an ASP provider registration which should be handled separately \
     according to the procedures of a specific provider.";
+// Names the remedy without naming which binding is stored or required, and
+// avoids the app-level cancellation classifier's substrings ("rejected",
+// "denied", "cancelled").
+const WRONG_BINDING_TEXT: &str = "these privacy keys were derived for a different deployment \
+    configuration and cannot be used here";
 
 /// Non-interactive overrides for `onboard`.
 #[derive(Debug, Default)]
@@ -57,11 +64,20 @@ pub fn ensure_ready(config: &CliConfig, account: &Account) -> Result<()> {
             account.alias
         );
     }
-    if storage.get_user_keys(&account.address)?.is_none() {
-        bail!(
-            "Privacy keys are not set up. Run: spp onboard --account {}",
-            account.alias
-        );
+    match storage.get_user_keys_bound(&account.address, config.deployment.required_binding())? {
+        KeyLookup::Found(_) => {}
+        KeyLookup::Absent => {
+            bail!(
+                "Privacy keys are not set up. Run: spp onboard --account {}",
+                account.alias
+            );
+        }
+        KeyLookup::Mismatch(_) => {
+            bail!(
+                "{WRONG_BINDING_TEXT}. Run: spp onboard --account {}",
+                account.alias
+            );
+        }
     }
     Ok(())
 }
@@ -94,15 +110,29 @@ pub fn run(config: &CliConfig, args: &OnboardArgs, json: bool) -> Result<()> {
         say(interactive, "Disclaimer accepted.");
     }
 
-    // 4. Derive privacy keys.
-    if storage.get_user_keys(&account.address)?.is_some() {
-        say(interactive, "Privacy keys already present.");
-    } else {
-        if interactive {
-            println!("\n{KEYS_TEXT}");
+    // 4. Derive privacy keys. Three-way, mirroring the worker write matrix:
+    // an acceptable row is a no-op (a replay must not shadow it), an
+    // unacceptable row is refused outright (deriving and writing nothing -
+    // falling through to derivation here would insert a second row that
+    // shadows the one the account's notes may be under), and only a missing
+    // row derives.
+    match storage.get_user_keys_bound(&account.address, config.deployment.required_binding())? {
+        KeyLookup::Found(_) => {
+            say(interactive, "Privacy keys already present.");
         }
-        derive_and_save_keys(config, &account, &mut storage)?;
-        say(interactive, "Privacy keys derived and stored.");
+        KeyLookup::Mismatch(_) => {
+            bail!(
+                "{WRONG_BINDING_TEXT}. Run: spp onboard --account {}",
+                account.alias
+            );
+        }
+        KeyLookup::Absent => {
+            if interactive {
+                println!("\n{KEYS_TEXT}");
+            }
+            derive_and_save_keys(config, &account, &mut storage)?;
+            say(interactive, "Privacy keys derived and stored.");
+        }
     }
 
     // 5. Bootnode.
@@ -120,30 +150,77 @@ pub fn run(config: &CliConfig, args: &OnboardArgs, json: bool) -> Result<()> {
 
 /// Delegate the SEP-53 key-derivation signature to the Stellar CLI (the secret
 /// never enters this process) and store the derived privacy keys.
+///
+/// The CLI only ever opens a session where the signer is the account itself
+/// (0.3: `Session::new` passes `account.address` as both identities), so
+/// `--sign-with-key account.alias` already directs the request at the owner
+/// on both bindings; nothing here chooses a different signer.
 fn derive_and_save_keys(
     config: &CliConfig,
     account: &Account,
     storage: &mut SqliteStorage,
 ) -> Result<()> {
-    let signature = stellar_cli::sign_message(
-        &account.alias,
-        KEY_DERIVATION_MESSAGE,
-        config.stellar_config_dir.as_deref(),
-    )
-    .context("derive privacy-key signature via stellar CLI")?;
+    match config.deployment.required_binding() {
+        BindingVersion::V1 => {
+            let signature = stellar_cli::sign_message(
+                &account.alias,
+                KEY_DERIVATION_MESSAGE,
+                config.stellar_config_dir.as_deref(),
+            )
+            .context("derive privacy-key signature via stellar CLI")?;
 
-    let (note_keypair, encryption_keypair) = derive_encryption_and_note_keypairs(signature.clone())
-        .context("derive privacy keypairs from wallet signature")?;
-    let membership_blinding = derive_membership_blinding(&signature, &config.deployment.network)?;
+            let (note_keypair, encryption_keypair) =
+                derive_encryption_and_note_keypairs(signature.clone())
+                    .context("derive privacy keypairs from wallet signature")?;
+            let membership_blinding =
+                derive_membership_blinding(&signature, &config.deployment.network)?;
 
-    storage
-        .save_encryption_and_note_keypairs(
-            &account.address,
-            &note_keypair,
-            &encryption_keypair,
-            &membership_blinding,
-        )
-        .context("save privacy keys to local wallet database")
+            storage
+                .save_encryption_and_note_keypairs(
+                    &account.address,
+                    &note_keypair,
+                    &encryption_keypair,
+                    &membership_blinding,
+                )
+                .context("save privacy keys to local wallet database")
+        }
+        BindingVersion::V2 => {
+            let message = key_derivation_message_v2(&account.address);
+            let signature = stellar_cli::sign_message(
+                &account.alias,
+                &message,
+                config.stellar_config_dir.as_deref(),
+            )
+            .context("derive privacy-key signature via stellar CLI")?;
+
+            // Local verification is the binding's real mechanism, not the
+            // alias directing the request at the owner: reject and derive
+            // nothing if the signature does not verify against the owner.
+            let owner_pubkey = verify_owner_signature(&account.address, &message, &signature)?;
+
+            let (note_keypair, encryption_keypair) =
+                derive_encryption_and_note_keypairs_v2(&signature, &owner_pubkey)
+                    .context("derive privacy keypairs from wallet signature")?;
+            let membership_blinding = derive_membership_blinding_v2(
+                &signature,
+                &owner_pubkey,
+                &config.deployment.network,
+            )?;
+
+            storage
+                .save_encryption_and_note_keypairs_bound(
+                    &account.address,
+                    &note_keypair,
+                    &encryption_keypair,
+                    &membership_blinding,
+                    &KeyBinding {
+                        version: BindingVersion::V2,
+                        bound_owner: Some(account.address.clone()),
+                    },
+                )
+                .context("save privacy keys to local wallet database")
+        }
+    }
 }
 
 fn configure_bootnode(

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -194,11 +194,29 @@ Root-level `circuits/` in the deployed site holds **legal files only** (`NOTICE.
 
 ## Keypair derivation
 
-Keys are derived deterministically from Freighter wallet signatures:
+Keys are derived deterministically from Freighter wallet signatures. Which
+construction is used is a fixed property of the deployment
+(`signer_may_differ_from_owner` in `deployments.json`, default `false`) —
+never a per-user or per-session choice:
+
+**v1 (split-free deployments, the default and permanent for them):**
 
 1. User signs `KEY_DERIVATION_MESSAGE` from `sdk/native/src/zk/encryption.rs` (`"Privacy Pool Key Derivation [v1]"`).
 2. The worker derives the BN254 note identity keypair and the X25519 encryption keypair from that signature using domain-separated hashes.
 3. Derived keys are stored in SQLite; the signature is not persisted.
+
+**v2 (deployments that separate the fee-paying signer from the note owner):**
+
+1. User signs `key_derivation_message_v2(ownerAddress)`, which names the owner address in the signed text so it is recognisable in the wallet's approval dialog.
+2. Before deriving anything, the worker verifies the signature against the owner address's own Ed25519 public key (decoded from the `G...` address) — this, not which account the wallet claims to have signed with, is what stops a differently-signing payer from producing the owner's keys.
+3. The worker derives owner-bound keypairs using domain-separated hashes that also fold in the verified owner public key, and stores them alongside a discriminator recording which construction produced the row.
+
+A stored row's discriminator is checked against the deployment's required
+binding on every read; a row from the wrong construction is refused rather
+than used, and refusing never re-derives or overwrites it. v1 is not a
+legacy path pending removal — a split-free deployment must keep deriving it
+forever, so a reinstall regenerates the keys an existing account already
+holds.
 
 Signatures are prompted during onboarding so the app can scan for notes addressed to the user.
 

--- a/e2e-freighter/src/runner.mjs
+++ b/e2e-freighter/src/runner.mjs
@@ -89,8 +89,38 @@ export async function launch({ userDataDir, headless = true, video = false } = {
   try {
     const appOrigin = new URL(requireAppUrl()).origin;
     const page = context.pages()[0] || (await context.newPage());
+    // The grant is refused while the page sits on about:blank, whose origin is
+    // opaque, so it must actually reach the app origin first. Without a real
+    // grant the app's `navigator.storage.persisted()` falls back to Chrome's
+    // own heuristics, and the onboarding wizard's storage step re-fires
+    // whenever they happen not to have granted it — a flaky wizard on top of
+    // every test that assumes onboarding is done. A dev server mid-rebuild
+    // refuses the connection for a moment, and swallowing that leaves the page
+    // opaque and the grant failing for a reason its error never mentions, so
+    // retry and say so if it never lands.
+    let navigated = false;
+    for (let attempt = 0; attempt < 5 && !navigated; attempt += 1) {
+      try {
+        await page.goto(appOrigin);
+        navigated = page.url().startsWith(appOrigin);
+      } catch (navErr) {
+        log.warn(
+          `launch: ${appOrigin} not reachable yet (attempt ${attempt + 1}/5): ${navErr.message}`,
+        );
+        await page.waitForTimeout(500);
+      }
+    }
+    if (!navigated) {
+      log.warn(`launch: giving up on ${appOrigin}; page is at ${page.url()}`);
+    }
     const cdp = await context.newCDPSession(page);
     await cdp.send('Browser.grantPermissions', { origin: appOrigin, permissions: ['durableStorage'] });
+    const persisted = await page
+      .evaluate(() => navigator.storage?.persisted?.() ?? false)
+      .catch(() => false);
+    if (!persisted) {
+      log.warn('launch: durableStorage granted but navigator.storage.persisted() is still false');
+    }
   } catch (err) {
     log.warn('launch: could not grant durableStorage permission:', err.message);
   }
@@ -176,6 +206,17 @@ export async function connectApp(page, { appUrl = requireAppUrl(), context } = {
 
   // The caller completes onboarding before continuing with the scenario.
   if (await isOnboardingWizardVisible(page)) {
+    // Name the gate that re-fired: a wizard opening on an already-onboarded
+    // profile fails every test that assumes onboarding is done, and which
+    // step re-fired is the whole diagnosis.
+    const steps = await page
+      .evaluate(() =>
+        [...document.querySelectorAll('#onboarding-steps [data-step]')].map(
+          (el) => `${el.dataset.step}=${el.dataset.state}`,
+        ),
+      )
+      .catch((e) => [`evaluate failed: ${e.message}`]);
+    log.info(`connectApp: wizard steps -> ${steps.join(', ')}`);
     log.info('connectApp: onboarding wizard is open — returning for the caller to drive it');
   } else {
     // An address can render before the runtime and selected pool are usable.

--- a/sdk/native/README.md
+++ b/sdk/native/README.md
@@ -183,9 +183,27 @@ Method names mirror the async API; each call runs on an internal Tokio runtime.
 
 ### Privacy keys
 
+Two key-derivation bindings exist, selected per deployment by
+`ContractConfig::signer_may_differ_from_owner` (default `false`) — never by
+the user or by a runtime flag:
+
+| Binding | Deployments that use it | Wallet signs | Owner presence verified? |
+|---------|--------------------------|--------------|---------------------------|
+| v1 (`zk::encryption::KEY_DERIVATION_MESSAGE`, unbound) | Every deployment that does not enable the owner/payer split — the default, and permanent for such deployments | The constant `KEY_DERIVATION_MESSAGE` | No: the derivation trusts whatever signature it is given. Correct for these deployments because `Client::account` already requires the signer and note owner to be the same address. |
+| v2 (`zk::encryption::key_derivation_message_v2`, owner-bound) | Deployments with `signer_may_differ_from_owner = true` | `key_derivation_message_v2(owner_address)`, naming the owner | Yes: `verify_owner_signature` checks the signature against the owner address's own Ed25519 public key before anything is derived, so a differently-signing payer cannot produce the owner's keys. |
+
+`ContractConfig::required_binding()` reports which one a given deployment
+needs; storage reads and writes go through the bound accessors
+(`Storage::get_user_keys_bound`, `Storage::save_encryption_and_note_keypairs_bound`)
+so a row derived for the wrong binding is never returned as usable key
+material. v1 is not a legacy path pending removal — a split-free deployment
+must keep deriving it forever, so a reinstall regenerates the keys an
+existing account already holds.
+
 | API | Role |
 |-----|------|
-| `zk::encryption::KEY_DERIVATION_MESSAGE` | Wallet message to sign for key derivation (**native / CLI** — browser apps use `Client.account()`, which signs this internally) |
+| `zk::encryption::KEY_DERIVATION_MESSAGE` | v1 wallet message to sign for key derivation (**native / CLI** — browser apps use `Client.account()`, which signs this internally) |
+| `zk::encryption::key_derivation_message_v2(owner_address)` | v2 wallet message, naming the owner it binds to |
 | `Account::user_public_keys()` | Note + encryption public keys for the bound account |
 | `Account::asp_secret()` | ASP membership blinding for the bound account |
 | `Account::derive_asp_user_leaf()` | ASP membership tree leaf from stored keys |

--- a/sdk/native/src/client.rs
+++ b/sdk/native/src/client.rs
@@ -38,6 +38,11 @@ impl<S: Storage> Client<S> {
     ) -> Result<Self, Error> {
         let rpc = RpcClient::new(rpc_url.as_ref())
             .map_err(|e| Error::Other(format!("rpc error: {e:#}")))?;
+        // One place, so no construction site has to remember: every reader
+        // that returns key material consults this, and an unconfigured handle
+        // refuses rather than accepting a row the deployment does not require.
+        let mut storage = storage;
+        storage.set_required_binding(contract_config.required_binding());
         Ok(Self {
             rpc,
             storage,
@@ -269,6 +274,7 @@ mod signer_is_note_owner_tests {
                 verifiers: Default::default(),
                 public_key_registry: String::new(),
                 pools: Vec::new(),
+                signer_may_differ_from_owner: false,
             },
             None,
         )

--- a/sdk/native/src/state/mod.rs
+++ b/sdk/native/src/state/mod.rs
@@ -5,8 +5,8 @@ mod storage;
 
 pub use disclaimer::CURRENT_DISCLAIMER_TEXT_MD;
 pub use storage::{
-    APP_SETTING_BOOTNODE_CONFIG, APP_SETTING_EXPLORER, DEFAULT_BOOTNODE_URL, Storage,
-    Storage as SqliteStorage, StoredUserKeys,
+    APP_SETTING_BOOTNODE_CONFIG, APP_SETTING_EXPLORER, BindingVersion, DEFAULT_BOOTNODE_URL,
+    KeyBinding, KeyLookup, Storage, Storage as SqliteStorage, StoredUserKeys,
 };
 
 mod process_local;

--- a/sdk/native/src/state/schema_v3_key_binding.sql
+++ b/sdk/native/src/state/schema_v3_key_binding.sql
@@ -1,0 +1,9 @@
+-- Which construction produced a stored key row: 1 for the split-free (v1)
+-- construction, 2 for the owner-bound (v2) construction. Existing rows
+-- default to 1, since the signer-must-equal-owner guard in force before this
+-- migration made every stored row owner-bound already - they are known v1,
+-- not unknown.
+ALTER TABLE keypairs ADD COLUMN binding_version INTEGER NOT NULL DEFAULT 1;
+-- The owner address a v2 row was derived for. NULL for v1 rows, which carry
+-- no owner of their own.
+ALTER TABLE keypairs ADD COLUMN bound_owner TEXT;

--- a/sdk/native/src/state/storage.rs
+++ b/sdk/native/src/state/storage.rs
@@ -21,11 +21,21 @@ pub const DEFAULT_BOOTNODE_URL: &str = "https://bootnode.dev-nethermind.xyz";
 const MIGRATION_ARRAY: &[M] = &[
     M::up(include_str!("schema.sql")),
     M::up(include_str!("schema_v2_gvk_ciphertext.sql")),
+    M::up(include_str!("schema_v3_key_binding.sql")),
 ];
 const MIGRATIONS: Migrations = Migrations::from_slice(MIGRATION_ARRAY);
 
 pub struct Storage {
     conn: Connection,
+    /// The key binding this deployment requires, consulted by every reader
+    /// that returns key material.
+    ///
+    /// `None` until a deployment sets it. Unset is not the same as v1: a
+    /// handle that defaulted to v1 would *accept* a v1 row on a deployment
+    /// that requires v2, which is the exact case the binding exists to
+    /// refuse. Readers therefore refuse to return key material while this is
+    /// unset, rather than guessing. Set via [`Self::set_required_binding`].
+    required_binding: Option<BindingVersion>,
 }
 
 #[derive(Debug, Clone)]
@@ -46,6 +56,71 @@ pub struct StoredUserKeys {
     pub note_keypair: NoteKeyPair,
     pub encryption_keypair: EncryptionKeyPair,
     pub membership_blinding: Field,
+    /// Which construction produced this row, and (for v2) which owner it was
+    /// derived for.
+    pub binding: KeyBinding,
+}
+
+/// Which construction produced a stored `keypairs` row.
+///
+/// v1 is the split-free construction, retained permanently as the correct
+/// binding for any deployment that does not enable the owner/payer split. v2
+/// is the owner-bound construction. The two are never interchangeable: a
+/// database carried between deployments with different requirements must not
+/// have a v1 row satisfy a v2 requirement or vice versa.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BindingVersion {
+    V1 = 1,
+    V2 = 2,
+}
+
+impl TryFrom<i64> for BindingVersion {
+    type Error = anyhow::Error;
+
+    fn try_from(value: i64) -> Result<Self> {
+        match value {
+            1 => Ok(BindingVersion::V1),
+            2 => Ok(BindingVersion::V2),
+            other => Err(anyhow!("unknown key binding_version {other} in storage")),
+        }
+    }
+}
+
+/// The binding recorded on a stored key row: its [`BindingVersion`] and, for
+/// v2, the owner address it was derived for. Always `None` for v1, which
+/// carries no owner of its own.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeyBinding {
+    pub version: BindingVersion,
+    pub bound_owner: Option<String>,
+}
+
+/// Result of looking up one account's keys against a required
+/// [`BindingVersion`].
+///
+/// `Mismatch` carries only the stored version, deliberately not `bound_owner`
+/// or any other row content, so a caller can distinguish "no keys yet" from
+/// "keys exist but cannot be used here" without a lookup that fails ever
+/// exposing key material or address information from the stored row.
+#[derive(Debug, Clone)]
+pub enum KeyLookup {
+    Found(StoredUserKeys),
+    Absent,
+    Mismatch(BindingVersion),
+}
+
+impl KeyLookup {
+    /// The stored keys when the lookup was satisfied, `None` otherwise.
+    ///
+    /// Collapses `Absent` and `Mismatch` deliberately: a caller on a
+    /// key-material route must not be able to tell them apart, because that
+    /// distinction is a status question and belongs on the metadata route.
+    pub fn into_found(self) -> Option<StoredUserKeys> {
+        match self {
+            KeyLookup::Found(keys) => Some(keys),
+            KeyLookup::Absent | KeyLookup::Mismatch(_) => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -84,7 +159,10 @@ impl Storage {
     fn connect_with_connection(mut conn: Connection) -> Result<Self> {
         MIGRATIONS.to_latest(&mut conn)?;
         conn.pragma_update(None, "foreign_keys", "ON")?;
-        Ok(Self { conn })
+        Ok(Self {
+            conn,
+            required_binding: None,
+        })
     }
 
     pub fn save_events_batch(&mut self, data: &crate::types::ContractsEventData) -> Result<()> {
@@ -226,7 +304,73 @@ impl Storage {
                 encryption_public_key,
                 note_private_key,
                 note_public_key,
-                membership_blinding
+                membership_blinding,
+                binding_version,
+                bound_owner
+                FROM keypairs
+                JOIN accounts ON keypairs.account_id = accounts.id
+                WHERE accounts.address = ?1
+                ORDER BY keypairs.id DESC
+                LIMIT 1",
+                params![address],
+                Self::row_to_stored_user_keys,
+            )
+            .optional()
+            .context(format!("Failed to fetch keys for account: {}", address))
+    }
+
+    /// The key binding this handle requires of any row it returns, or `None`
+    /// when no deployment has configured it.
+    pub fn required_binding(&self) -> Option<BindingVersion> {
+        self.required_binding
+    }
+
+    /// The configured requirement, or an error naming the omission.
+    ///
+    /// Used by every reader that returns key material, so that an
+    /// unconfigured handle refuses rather than falling back to a binding that
+    /// would accept rows the deployment does not require.
+    pub fn require_binding(&self) -> Result<BindingVersion> {
+        self.required_binding.ok_or_else(|| {
+            anyhow!("the deployment's key binding requirement has not been configured")
+        })
+    }
+
+    /// Set the deployment's required key binding. Call once, after opening,
+    /// before any reader asks for key material.
+    pub fn set_required_binding(&mut self, required: BindingVersion) {
+        self.required_binding = Some(required);
+    }
+
+    /// Look up an account's keys against the binding this deployment requires.
+    ///
+    /// See [`KeyLookup`] for how the three outcomes are distinguished, and why
+    /// `Mismatch` is deliberately not the same answer as `Absent`.
+    pub fn get_user_keys_bound(
+        &self,
+        address: &str,
+        required: BindingVersion,
+    ) -> Result<KeyLookup> {
+        let found = self.get_user_keys(address)?;
+        Ok(match found {
+            None => KeyLookup::Absent,
+            Some(keys) if Self::binding_satisfies(&keys.binding, required, address) => {
+                KeyLookup::Found(keys)
+            }
+            Some(keys) => KeyLookup::Mismatch(keys.binding.version),
+        })
+    }
+
+    /// Metadata-only: reads a row's [`KeyBinding`] without selecting any key
+    /// blob column, so it is safe to expose to a caller that only needs to
+    /// know whether an account's keys can be used here, not what they are.
+    ///
+    /// Backs the worker's `KeyBindingStatus` route, which is how the client
+    /// and the UI ask about status without a route that returns secrets.
+    pub fn key_binding(&self, address: &str) -> Result<Option<KeyBinding>> {
+        self.conn
+            .query_row(
+                "SELECT binding_version, bound_owner
                 FROM keypairs
                 JOIN accounts ON keypairs.account_id = accounts.id
                 WHERE accounts.address = ?1
@@ -234,27 +378,54 @@ impl Storage {
                 LIMIT 1",
                 params![address],
                 |row| {
-                    let enc_priv: EncryptionPrivateKey = row.get(0)?;
-                    let enc_pub: EncryptionPublicKey = row.get(1)?;
-                    let note_priv: NotePrivateKey = row.get(2)?;
-                    let note_pub: NotePublicKey = row.get(3)?;
-                    let membership_blinding: Field = row.get(4)?;
-
-                    Ok(StoredUserKeys {
-                        note_keypair: NoteKeyPair {
-                            private: note_priv,
-                            public: note_pub,
-                        },
-                        encryption_keypair: EncryptionKeyPair {
-                            private: enc_priv,
-                            public: enc_pub,
-                        },
-                        membership_blinding,
-                    })
+                    let version: i64 = row.get(0)?;
+                    let bound_owner: Option<String> = row.get(1)?;
+                    key_binding_from_row(version, bound_owner)
                 },
             )
             .optional()
-            .context(format!("Failed to fetch keys for account: {}", address))
+            .context(format!(
+                "Failed to fetch key binding for account: {}",
+                address
+            ))
+    }
+
+    /// Whether a stored binding satisfies a required [`BindingVersion`] for
+    /// `address`: the versions must match and, for v2, `bound_owner` must
+    /// name `address`. v1 carries no owner, so v1-required rows are not
+    /// additionally checked against `address`.
+    fn binding_satisfies(binding: &KeyBinding, required: BindingVersion, address: &str) -> bool {
+        if binding.version != required {
+            return false;
+        }
+        match required {
+            BindingVersion::V1 => true,
+            BindingVersion::V2 => binding.bound_owner.as_deref() == Some(address),
+        }
+    }
+
+    fn row_to_stored_user_keys(row: &rusqlite::Row<'_>) -> rusqlite::Result<StoredUserKeys> {
+        let enc_priv: EncryptionPrivateKey = row.get(0)?;
+        let enc_pub: EncryptionPublicKey = row.get(1)?;
+        let note_priv: NotePrivateKey = row.get(2)?;
+        let note_pub: NotePublicKey = row.get(3)?;
+        let membership_blinding: Field = row.get(4)?;
+        let binding_version: i64 = row.get(5)?;
+        let bound_owner: Option<String> = row.get(6)?;
+        let binding = key_binding_from_row(binding_version, bound_owner)?;
+
+        Ok(StoredUserKeys {
+            note_keypair: NoteKeyPair {
+                private: note_priv,
+                public: note_pub,
+            },
+            encryption_keypair: EncryptionKeyPair {
+                private: enc_priv,
+                public: enc_pub,
+            },
+            membership_blinding,
+            binding,
+        })
     }
 
     pub fn save_encryption_and_note_keypairs(
@@ -271,6 +442,11 @@ impl Storage {
 
         let account_id = Self::get_or_create_account(&tx, account_address)?;
 
+        // Deliberately writes only the pre-v3 columns and lets
+        // `binding_version` take its DEFAULT of 1. The v1 write path must stay
+        // byte-identical to what it was before the discriminator existed, so
+        // that a database written by an older build and one written by this
+        // one are indistinguishable.
         tx.execute(
             "INSERT INTO keypairs (
                 encryption_private_key,
@@ -287,6 +463,57 @@ impl Storage {
                 &note_keypair.public,
                 membership_blinding,
                 account_id,
+            ],
+        )
+        .context("failed to insert keypairs")?;
+        tx.commit().context("failed to commit transaction")?;
+        tracing::debug!(
+            "[STORAGE] saved new keypairs for the account {}",
+            crate::types::Sensitive(&account_address)
+        );
+        Ok(())
+    }
+
+    /// Store a keypair row together with the binding that produced it.
+    ///
+    /// The unbound [`Self::save_encryption_and_note_keypairs`] delegates here
+    /// with a v1 binding, which is the correct and permanent binding for any
+    /// deployment that does not separate the payer from the owner.
+    pub fn save_encryption_and_note_keypairs_bound(
+        &mut self,
+        account_address: &str,
+        note_keypair: &NoteKeyPair,
+        encryption_keypair: &EncryptionKeyPair,
+        membership_blinding: &Field,
+        binding: &KeyBinding,
+    ) -> Result<()> {
+        let tx = self
+            .conn
+            .transaction()
+            .context("failed to start transaction")?;
+
+        let account_id = Self::get_or_create_account(&tx, account_address)?;
+
+        tx.execute(
+            "INSERT INTO keypairs (
+                encryption_private_key,
+                encryption_public_key,
+                note_private_key,
+                note_public_key,
+                membership_blinding,
+                account_id,
+                binding_version,
+                bound_owner
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                &encryption_keypair.private,
+                &encryption_keypair.public,
+                &note_keypair.private,
+                &note_keypair.public,
+                membership_blinding,
+                account_id,
+                binding.version as i64,
+                binding.bound_owner.as_deref(),
             ],
         )
         .context("failed to insert keypairs")?;
@@ -1310,15 +1537,43 @@ impl Storage {
         Ok(events)
     }
 
-    fn get_accounts_with_latest_keypairs(&self) -> Result<Vec<AccountKeys>> {
+    /// All-accounts keypair scan, filtered to rows whose binding satisfies
+    /// `required` for their own account, rather than surfacing a per-row
+    /// error. Scan semantics want omission - a database carried between
+    /// deployments should skip rows it cannot regenerate, not fail the whole
+    /// scan over one foreign-binding account.
+    ///
+    /// The sole production caller is
+    /// [`Self::scan_commitments_for_user_notes`]. An earlier, unbound form of
+    /// this query existed before every caller was migrated onto this one;
+    /// it was removed once it reached zero callers rather than left as dead
+    /// code that a later session might mistake for a still-needed fallback.
+    pub(crate) fn get_accounts_with_latest_keypairs_bound(
+        &self,
+        required: BindingVersion,
+    ) -> Result<Vec<AccountKeys>> {
+        Ok(self
+            .get_accounts_with_latest_keypairs_and_address()?
+            .into_iter()
+            .filter(|(address, account)| {
+                Self::binding_satisfies(&account.keys.binding, required, address)
+            })
+            .map(|(_, account)| account)
+            .collect())
+    }
+
+    fn get_accounts_with_latest_keypairs_and_address(&self) -> Result<Vec<(String, AccountKeys)>> {
         let mut stmt = self.conn.prepare(
             "SELECT
                 a.id,
+                a.address,
                 k.encryption_private_key,
                 k.encryption_public_key,
                 k.note_private_key,
                 k.note_public_key,
-                k.membership_blinding
+                k.membership_blinding,
+                k.binding_version,
+                k.bound_owner
              FROM accounts a
              JOIN (
                 SELECT account_id, MAX(id) AS max_id
@@ -1332,26 +1587,34 @@ impl Storage {
 
         let rows = stmt.query_map([], |row| {
             let account_id: i64 = row.get(0)?;
-            let enc_priv: EncryptionPrivateKey = row.get(1)?;
-            let enc_pub: EncryptionPublicKey = row.get(2)?;
-            let note_priv: NotePrivateKey = row.get(3)?;
-            let note_pub: NotePublicKey = row.get(4)?;
-            let membership_blinding: Field = row.get(5)?;
+            let address: String = row.get(1)?;
+            let enc_priv: EncryptionPrivateKey = row.get(2)?;
+            let enc_pub: EncryptionPublicKey = row.get(3)?;
+            let note_priv: NotePrivateKey = row.get(4)?;
+            let note_pub: NotePublicKey = row.get(5)?;
+            let membership_blinding: Field = row.get(6)?;
+            let binding_version: i64 = row.get(7)?;
+            let bound_owner: Option<String> = row.get(8)?;
+            let binding = key_binding_from_row(binding_version, bound_owner)?;
 
-            Ok(AccountKeys {
-                account_id,
-                keys: StoredUserKeys {
-                    note_keypair: NoteKeyPair {
-                        private: note_priv,
-                        public: note_pub,
+            Ok((
+                address,
+                AccountKeys {
+                    account_id,
+                    keys: StoredUserKeys {
+                        note_keypair: NoteKeyPair {
+                            private: note_priv,
+                            public: note_pub,
+                        },
+                        encryption_keypair: EncryptionKeyPair {
+                            private: enc_priv,
+                            public: enc_pub,
+                        },
+                        membership_blinding,
+                        binding,
                     },
-                    encryption_keypair: EncryptionKeyPair {
-                        private: enc_priv,
-                        public: enc_pub,
-                    },
-                    membership_blinding,
                 },
-            })
+            ))
         })?;
 
         let mut out = Vec::new();
@@ -1371,7 +1634,11 @@ impl Storage {
     ) -> Result<bool> {
         const ACCOUNT_CHUNK: u32 = 4;
 
-        let accounts = self.get_accounts_with_latest_keypairs()?;
+        // Skips rather than errors: trial decryption across accounts wants
+        // omission of foreign-binding rows, not a failure per row. Without
+        // this a database carried between deployments would attribute notes
+        // through keys this deployment does not require.
+        let accounts = self.get_accounts_with_latest_keypairs_bound(self.require_binding()?)?;
         if accounts.is_empty() || total_limit == 0 {
             return Ok(false);
         }
@@ -1743,6 +2010,18 @@ fn map_public_key_entry(row: &rusqlite::Row<'_>) -> Result<crate::types::PublicK
     })
 }
 
+fn key_binding_from_row(
+    binding_version: i64,
+    bound_owner: Option<String>,
+) -> rusqlite::Result<KeyBinding> {
+    let version = BindingVersion::try_from(binding_version)
+        .map_err(|e| SqlError::InvalidParameterName(format!("binding_version: {e:#}")))?;
+    Ok(KeyBinding {
+        version,
+        bound_owner,
+    })
+}
+
 fn encode_optional_gvk_ciphertext(
     ciphertext: Option<&GlobalViewKeyCiphertext>,
 ) -> Result<Option<String>> {
@@ -1790,6 +2069,7 @@ mod tests {
     #[test]
     fn scan_commitments_and_reconcile_nullifiers() -> Result<()> {
         let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
 
         // Create an account with keypairs.
         let signature = KeyDerivationSignature(vec![1u8; 64]);
@@ -1917,6 +2197,7 @@ mod tests {
     #[test]
     fn sync_metadata_tracks_progress_and_caught_up_tip() -> Result<()> {
         let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
 
         storage.save_events_batch(&ContractsEventData {
             cursor: "c1".to_string(),
@@ -1982,6 +2263,7 @@ mod tests {
     #[test]
     fn clamp_last_fully_indexed_ledger_after_handoff() -> Result<()> {
         let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
         const HANDOFF: u32 = 2_999_000;
         const TIP: u32 = 3_000_000;
 
@@ -2025,6 +2307,7 @@ mod tests {
     #[test]
     fn get_user_keys_returns_latest_keypair() -> Result<()> {
         let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
 
         let signature_1 = KeyDerivationSignature(vec![1u8; 64]);
         let signature_2 = KeyDerivationSignature(vec![3u8; 64]);
@@ -2064,8 +2347,234 @@ mod tests {
     }
 
     #[test]
+    fn migration_v3_preserves_pre_existing_rows_as_v1() -> Result<()> {
+        // Simulate a database written before this migration: only the first
+        // two migrations applied, exactly as an already-deployed build left
+        // it, rather than assuming the DEFAULT clause is enough.
+        let mut conn = Connection::open_in_memory()?;
+        Migrations::from_slice(&MIGRATION_ARRAY[..2]).to_latest(&mut conn)?;
+        conn.pragma_update(None, "foreign_keys", "ON")?;
+        let mut storage = Storage {
+            conn,
+            required_binding: None,
+        };
+
+        let signature = KeyDerivationSignature(vec![9u8; 64]);
+        let (note_keypair, enc_keypair) =
+            encryption::derive_encryption_and_note_keypairs(signature.clone())?;
+        let membership_blinding = encryption::derive_membership_blinding(&signature, "testnet")?;
+        storage.save_encryption_and_note_keypairs(
+            "GLEGACYOWNER",
+            &note_keypair,
+            &enc_keypair,
+            &membership_blinding,
+        )?;
+
+        // Reopen under the current binary: the same connection now migrates
+        // forward to v3.
+        MIGRATIONS.to_latest(&mut storage.conn)?;
+
+        let keys = storage
+            .get_user_keys("GLEGACYOWNER")?
+            .expect("expected the pre-existing row to remain readable");
+        assert_eq!(keys.note_keypair.public.0, note_keypair.public.0);
+        assert_eq!(keys.binding.version, BindingVersion::V1);
+        assert_eq!(keys.binding.bound_owner, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn stored_keys_default_to_v1_binding() -> Result<()> {
+        let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
+        let signature = KeyDerivationSignature(vec![1u8; 64]);
+        let (note_keypair, enc_keypair) =
+            encryption::derive_encryption_and_note_keypairs(signature.clone())?;
+        let membership_blinding = encryption::derive_membership_blinding(&signature, "testnet")?;
+        storage.save_encryption_and_note_keypairs(
+            "GTESTACCOUNT",
+            &note_keypair,
+            &enc_keypair,
+            &membership_blinding,
+        )?;
+
+        // A row written by the existing insert path, which knows nothing of
+        // binding_version, must migrate to v1 via the column DEFAULT rather
+        // than an unknown state.
+        let keys = storage
+            .get_user_keys("GTESTACCOUNT")?
+            .expect("expected keypairs to exist");
+        assert_eq!(keys.binding.version, BindingVersion::V1);
+        assert_eq!(keys.binding.bound_owner, None);
+
+        let metadata = storage
+            .key_binding("GTESTACCOUNT")?
+            .expect("expected binding metadata to exist");
+        assert_eq!(metadata.version, BindingVersion::V1);
+        assert_eq!(metadata.bound_owner, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn key_binding_is_absent_for_an_unknown_address() -> Result<()> {
+        let storage = Storage::connect_in_memory()?;
+        assert!(storage.key_binding("GUNKNOWN")?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn get_user_keys_bound_reports_absent_found_and_mismatch() -> Result<()> {
+        let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
+        let signature = KeyDerivationSignature(vec![1u8; 64]);
+        let (note_keypair, enc_keypair) =
+            encryption::derive_encryption_and_note_keypairs(signature.clone())?;
+        let membership_blinding = encryption::derive_membership_blinding(&signature, "testnet")?;
+
+        assert!(matches!(
+            storage.get_user_keys_bound("GTESTACCOUNT", BindingVersion::V1)?,
+            KeyLookup::Absent
+        ));
+
+        storage.save_encryption_and_note_keypairs(
+            "GTESTACCOUNT",
+            &note_keypair,
+            &enc_keypair,
+            &membership_blinding,
+        )?;
+
+        assert!(matches!(
+            storage.get_user_keys_bound("GTESTACCOUNT", BindingVersion::V1)?,
+            KeyLookup::Found(_)
+        ));
+
+        // Same row, v2 required: version mismatch, and the outcome carries
+        // only the stored version, never the row's (here absent) owner.
+        match storage.get_user_keys_bound("GTESTACCOUNT", BindingVersion::V2)? {
+            KeyLookup::Mismatch(BindingVersion::V1) => {}
+            other => panic!("expected Mismatch(V1), got {other:?}"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_user_keys_bound_v2_requires_the_matching_owner() -> Result<()> {
+        let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
+        let signature = KeyDerivationSignature(vec![1u8; 64]);
+        let (note_keypair, enc_keypair) =
+            encryption::derive_encryption_and_note_keypairs(signature.clone())?;
+        let membership_blinding = encryption::derive_membership_blinding(&signature, "testnet")?;
+        storage.save_encryption_and_note_keypairs(
+            "GOWNER",
+            &note_keypair,
+            &enc_keypair,
+            &membership_blinding,
+        )?;
+        // Written through save_encryption_and_note_keypairs_bound; simulate a
+        // v2 row bound to a different owner directly to exercise the read
+        // side the discriminator makes available.
+        storage.conn.execute(
+            "UPDATE keypairs SET binding_version = 2, bound_owner = ?1
+             WHERE account_id = (SELECT id FROM accounts WHERE address = ?2)",
+            params!["GDELEGATE", "GOWNER"],
+        )?;
+
+        match storage.get_user_keys_bound("GOWNER", BindingVersion::V2)? {
+            KeyLookup::Mismatch(BindingVersion::V2) => {}
+            other => panic!("expected Mismatch(V2) for a foreign-owner row, got {other:?}"),
+        }
+
+        storage.conn.execute(
+            "UPDATE keypairs SET bound_owner = ?1
+             WHERE account_id = (SELECT id FROM accounts WHERE address = ?2)",
+            params!["GOWNER", "GOWNER"],
+        )?;
+        assert!(matches!(
+            storage.get_user_keys_bound("GOWNER", BindingVersion::V2)?,
+            KeyLookup::Found(_)
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_user_keys_bound_still_sees_the_latest_row_after_shadowing() -> Result<()> {
+        let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
+        let signature_1 = KeyDerivationSignature(vec![1u8; 64]);
+        let signature_2 = KeyDerivationSignature(vec![3u8; 64]);
+        let (note_keypair_1, enc_keypair_1) =
+            encryption::derive_encryption_and_note_keypairs(signature_1.clone())?;
+        let (note_keypair_2, enc_keypair_2) =
+            encryption::derive_encryption_and_note_keypairs(signature_2.clone())?;
+        let membership_blinding_1 =
+            encryption::derive_membership_blinding(&signature_1, "testnet")?;
+        let membership_blinding_2 =
+            encryption::derive_membership_blinding(&signature_2, "testnet")?;
+
+        storage.save_encryption_and_note_keypairs(
+            "GTESTACCOUNT",
+            &note_keypair_1,
+            &enc_keypair_1,
+            &membership_blinding_1,
+        )?;
+        storage.save_encryption_and_note_keypairs(
+            "GTESTACCOUNT",
+            &note_keypair_2,
+            &enc_keypair_2,
+            &membership_blinding_2,
+        )?;
+
+        // The bound accessor still inspects only the ORDER BY id DESC row -
+        // adding the binding columns must not change which row is latest.
+        match storage.get_user_keys_bound("GTESTACCOUNT", BindingVersion::V1)? {
+            KeyLookup::Found(keys) => {
+                assert_eq!(keys.note_keypair.public.0, note_keypair_2.public.0);
+            }
+            other => panic!("expected Found with the latest row, got {other:?}"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_accounts_with_latest_keypairs_bound_filters_by_binding() -> Result<()> {
+        let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
+        let sig_v1 = KeyDerivationSignature(vec![1u8; 64]);
+        let sig_v2 = KeyDerivationSignature(vec![2u8; 64]);
+        let (note_v1, enc_v1) = encryption::derive_encryption_and_note_keypairs(sig_v1.clone())?;
+        let (note_v2, enc_v2) = encryption::derive_encryption_and_note_keypairs(sig_v2.clone())?;
+        let blinding_v1 = encryption::derive_membership_blinding(&sig_v1, "testnet")?;
+        let blinding_v2 = encryption::derive_membership_blinding(&sig_v2, "testnet")?;
+
+        storage.save_encryption_and_note_keypairs("GOWNERV1", &note_v1, &enc_v1, &blinding_v1)?;
+        storage.save_encryption_and_note_keypairs("GOWNERV2", &note_v2, &enc_v2, &blinding_v2)?;
+        storage.conn.execute(
+            "UPDATE keypairs SET binding_version = 2, bound_owner = ?1
+             WHERE account_id = (SELECT id FROM accounts WHERE address = ?2)",
+            params!["GOWNERV2", "GOWNERV2"],
+        )?;
+
+        let v1_accounts = storage.get_accounts_with_latest_keypairs_bound(BindingVersion::V1)?;
+        assert_eq!(v1_accounts.len(), 1);
+        assert_eq!(v1_accounts[0].keys.note_keypair.public.0, note_v1.public.0);
+
+        let v2_accounts = storage.get_accounts_with_latest_keypairs_bound(BindingVersion::V2)?;
+        assert_eq!(v2_accounts.len(), 1);
+        assert_eq!(v2_accounts[0].keys.note_keypair.public.0, note_v2.public.0);
+
+        Ok(())
+    }
+
+    #[test]
     fn save_keypairs_does_not_duplicate_accounts() -> Result<()> {
         let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
 
         let signature = KeyDerivationSignature(vec![1u8; 64]);
         let (note_keypair, enc_keypair) =
@@ -2098,6 +2607,7 @@ mod tests {
     #[test]
     fn asp_membership_precondition_partial_processing_returns_sync_required() -> Result<()> {
         let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
 
         let mut root_old_bytes = [0u8; 32];
         root_old_bytes[0] = 1;
@@ -2175,6 +2685,7 @@ mod tests {
     #[test]
     fn asp_membership_precondition_root_mismatch_at_same_ledger_errors() -> Result<()> {
         let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
 
         let mut root_old_bytes = [0u8; 32];
         root_old_bytes[0] = 1;
@@ -2234,6 +2745,7 @@ mod tests {
     #[test]
     fn asp_membership_precondition_allows_tip_without_recent_asp_events() -> Result<()> {
         let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
 
         let mut root_bytes = [0u8; 32];
         root_bytes[0] = 1;
@@ -2348,6 +2860,7 @@ mod tests {
     #[test]
     fn get_unspent_user_note_by_commitment_finds_unspent_note() -> Result<()> {
         let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
 
         let sig = KeyDerivationSignature(vec![1u8; 64]);
         let (note_keypair, enc_keypair) =
@@ -2424,6 +2937,7 @@ mod tests {
     #[test]
     fn get_unspent_user_note_by_commitment_rejects_spent_note() -> Result<()> {
         let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
 
         let sig = KeyDerivationSignature(vec![1u8; 64]);
         let (note_keypair, enc_keypair) =
@@ -2524,6 +3038,7 @@ mod tests {
     #[test]
     fn get_unspent_user_note_by_commitment_rejects_wrong_commitment() -> Result<()> {
         let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
 
         let sig = KeyDerivationSignature(vec![1u8; 64]);
         let (note_keypair, enc_keypair) =
@@ -2596,6 +3111,7 @@ mod tests {
     #[test]
     fn get_user_note_by_commitment_finds_unspent_note() -> Result<()> {
         let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
 
         let sig = KeyDerivationSignature(vec![1u8; 64]);
         let (note_keypair, enc_keypair) =
@@ -2671,6 +3187,7 @@ mod tests {
     #[test]
     fn get_user_note_by_commitment_finds_spent_note() -> Result<()> {
         let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
 
         let sig = KeyDerivationSignature(vec![1u8; 64]);
         let (note_keypair, enc_keypair) =
@@ -2783,6 +3300,7 @@ mod tests {
     #[test]
     fn get_pool_commitment_leaves_ordered_returns_ordered_leaves() -> Result<()> {
         let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
 
         let leaf0 = Field::try_from_le_bytes([0u8; 32])?;
         let leaf1 = Field::try_from_le_bytes([1u8; 32])?;
@@ -2833,6 +3351,7 @@ mod tests {
     #[test]
     fn get_pool_commitment_leaves_ordered_detects_gaps() -> Result<()> {
         let mut storage = Storage::connect_in_memory()?;
+        storage.set_required_binding(BindingVersion::V1);
 
         let leaf0 = Field::try_from_le_bytes([0u8; 32])?;
         let leaf2 = Field::try_from_le_bytes([2u8; 32])?;

--- a/sdk/native/src/storage/local.rs
+++ b/sdk/native/src/storage/local.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, collections::HashSet, path::PathBuf};
 use crate::{
     chain::ContractDataStorage,
     planner::SpendableNote,
-    state::{SqliteStorage, StoredUserKeys},
+    state::{BindingVersion, SqliteStorage, StoredUserKeys},
     types::{
         ContractConfig, ContractsEventData, EncryptionPublicKey, Field, NotePublicKey,
         OperationalFeedItem, PortfolioBalance, PortfolioPoolEntry, RecipientLookup, SyncMetadata,
@@ -28,6 +28,11 @@ use crate::{
 pub struct LocalStorage {
     path: PathBuf,
     db: RefCell<SqliteStorage>,
+    /// The deployment's required key binding, held here so that `fork` - which
+    /// opens a fresh connection rather than cloning one - can carry it onto
+    /// the new handle. Without this a forked session silently reverts to an
+    /// unconfigured handle, and every account session is a fork.
+    required_binding: Option<BindingVersion>,
 }
 
 impl LocalStorage {
@@ -38,7 +43,22 @@ impl LocalStorage {
         Ok(Self {
             path,
             db: RefCell::new(db),
+            required_binding: None,
         })
+    }
+
+    /// Bind this handle, and every handle forked from it, to the deployment's
+    /// required key binding.
+    pub fn with_required_binding(mut self, required: BindingVersion) -> Self {
+        self.set_required_binding(required);
+        self
+    }
+
+    /// Set the deployment's required key binding on this handle and its
+    /// underlying connection.
+    pub fn set_required_binding(&mut self, required: BindingVersion) {
+        self.required_binding = Some(required);
+        self.db.borrow_mut().set_required_binding(required);
     }
 
     pub fn storage(&self) -> std::cell::Ref<'_, SqliteStorage> {
@@ -73,11 +93,18 @@ impl ContractDataStorage for LocalStorage {
 #[async_trait::async_trait(?Send)]
 impl Storage for LocalStorage {
     fn fork(&self) -> Result<Self, Error> {
-        let db = SqliteStorage::connect_file(self.path.as_path())
+        let mut db = SqliteStorage::connect_file(self.path.as_path())
             .map_err(|e| Error::Other(format!("fork storage: {e:#}")))?;
+        // A fork opens a fresh connection, so the requirement must be carried
+        // over explicitly; every account session is a fork of the client's
+        // handle, so losing it here would unconfigure every session.
+        if let Some(required) = self.required_binding {
+            db.set_required_binding(required);
+        }
         Ok(Self {
             path: self.path.clone(),
             db: RefCell::new(db),
+            required_binding: self.required_binding,
         })
     }
 
@@ -145,6 +172,10 @@ impl Storage for LocalStorage {
             &self.storage(),
             req,
         ))
+    }
+
+    fn set_required_binding(&mut self, required: BindingVersion) {
+        LocalStorage::set_required_binding(self, required);
     }
 
     async fn user_keys(&self, user_address: &str) -> Result<StoredUserKeys, Error> {

--- a/sdk/native/src/storage/mod.rs
+++ b/sdk/native/src/storage/mod.rs
@@ -3,7 +3,7 @@
 use crate::{
     gvk::GvkEvent,
     planner::SpendableNote,
-    state::{SqliteStorage, StoredUserKeys},
+    state::{KeyLookup, SqliteStorage, StoredUserKeys},
     types::{
         ContractConfig, EncryptionPublicKey, Field, NotePublicKey, OperationalFeedItem,
         PortfolioBalance, PortfolioPoolEntry, RecipientLookup, UserNoteSummary,
@@ -36,16 +36,30 @@ pub(crate) fn map_user_keys(
     storage: &SqliteStorage,
     user_address: &str,
 ) -> Result<StoredUserKeys, Error> {
-    storage
-        .get_user_keys(user_address)
+    match storage
+        .get_user_keys_bound(
+            user_address,
+            storage
+                .require_binding()
+                .map_err(|e| Error::Other(e.to_string()))?,
+        )
         .map_err(|e| Error::Other(e.to_string()))?
-        .ok_or_else(|| {
-            // Escapes to CLI output and logs.
-            Error::Other(format!(
-                "address {} should generate privacy keys and ASP secret first",
-                crate::types::Sensitive(user_address)
-            ))
-        })
+    {
+        KeyLookup::Found(keys) => Ok(keys),
+        // Escapes to CLI output and logs.
+        KeyLookup::Absent => Err(Error::Other(format!(
+            "address {} should generate privacy keys and ASP secret first",
+            crate::types::Sensitive(user_address)
+        ))),
+        // Distinct from Absent on purpose: telling a user to generate keys
+        // they already have, and whose generation would be refused, sends
+        // them somewhere that cannot work.
+        KeyLookup::Mismatch(_) => Err(Error::Other(format!(
+            "the privacy keys stored for address {} were derived for a different deployment \
+             configuration and cannot be used here",
+            crate::types::Sensitive(user_address)
+        ))),
+    }
 }
 
 pub(crate) fn spendable_notes_from_storage(
@@ -170,6 +184,14 @@ pub trait Storage: crate::chain::ContractDataStorage {
         req: &DisclosureInputsRequest,
     ) -> Result<Vec<DisclosureInputs>, Error>;
 
+    /// Bind this handle to the deployment's required key binding.
+    ///
+    /// Every reader that returns key material consults it, and an
+    /// unconfigured handle refuses rather than guessing, so a client must
+    /// call this before any session reads keys. Implementors that fork or
+    /// reopen a connection must carry it onto the new handle.
+    fn set_required_binding(&mut self, required: crate::state::BindingVersion);
+
     async fn user_keys(&self, user_address: &str) -> Result<StoredUserKeys, Error>;
 
     async fn asp_secret(&self, user_address: &str) -> Result<Field, Error>;
@@ -229,12 +251,197 @@ mod tests {
     fn missing_user_keys_error_redacts_the_address() {
         let _guard = lock_reveal_flag();
         set_reveal_sensitive(false);
-        let storage = SqliteStorage::connect_in_memory().expect("in-memory storage");
+        let mut storage = SqliteStorage::connect_in_memory().expect("in-memory storage");
+        // v1 is the split-free binding these fixtures represent; an
+        // unconfigured handle now refuses to read key material at all.
+        storage.set_required_binding(crate::state::BindingVersion::V1);
 
         let err = map_user_keys(&storage, ADDRESS).expect_err("no keys are stored");
         let rendered = err.to_string();
 
         assert!(!rendered.contains(ADDRESS), "address leaked: {rendered}");
         assert!(rendered.contains("<redacted>"), "not redacted: {rendered}");
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod binding_enforcement_tests {
+    use super::*;
+    use crate::{
+        state::{BindingVersion, KeyBinding},
+        types::{
+            EncryptionKeyPair, EncryptionPrivateKey, EncryptionPublicKey, Field, NoteKeyPair,
+            NotePrivateKey, NotePublicKey,
+        },
+    };
+
+    const ADDRESS: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+    fn keys() -> (NoteKeyPair, EncryptionKeyPair, Field) {
+        (
+            NoteKeyPair {
+                private: NotePrivateKey([7u8; 32]),
+                public: NotePublicKey([8u8; 32]),
+            },
+            EncryptionKeyPair {
+                private: EncryptionPrivateKey([9u8; 32]),
+                public: EncryptionPublicKey([10u8; 32]),
+            },
+            Field::try_from_le_bytes([0u8; 32]).expect("field"),
+        )
+    }
+
+    /// A v2 row must not be readable on a deployment that requires v1, and a
+    /// mismatch must be distinguishable from an absent row: telling a user to
+    /// generate keys they already hold sends them somewhere that cannot work.
+    #[test]
+    fn reader_refuses_foreign_binding_with_a_distinct_error() {
+        let mut storage = SqliteStorage::connect_in_memory().expect("open storage");
+        let (note, enc, blinding) = keys();
+        storage
+            .save_encryption_and_note_keypairs_bound(
+                ADDRESS,
+                &note,
+                &enc,
+                &blinding,
+                &KeyBinding {
+                    version: BindingVersion::V2,
+                    bound_owner: Some(ADDRESS.to_string()),
+                },
+            )
+            .expect("save v2 row");
+
+        storage.set_required_binding(BindingVersion::V2);
+        map_user_keys(&storage, ADDRESS).expect("v2 row readable when v2 is required");
+
+        storage.set_required_binding(BindingVersion::V1);
+        let err = map_user_keys(&storage, ADDRESS)
+            .expect_err("v2 row must not be readable when v1 is required")
+            .to_string();
+        assert!(
+            err.contains("different deployment configuration"),
+            "mismatch must be distinct from absent, got: {err}"
+        );
+        assert!(
+            !err.contains("should generate privacy keys"),
+            "mismatch must not tell the user to generate keys they already have: {err}"
+        );
+        for forbidden in ["rejected", "denied", "cancelled"] {
+            assert!(
+                !err.to_lowercase().contains(forbidden),
+                "error wording must stay clear of the cancellation classifier: {err}"
+            );
+        }
+        assert!(
+            !err.contains(ADDRESS),
+            "the address must be redacted in the rendered error: {err}"
+        );
+    }
+
+    /// An unconfigured handle must refuse to return key material rather than
+    /// fall back to a binding. Falling back to v1 would *accept* a v1 row on a
+    /// deployment that requires v2 - the exact case the binding exists to
+    /// refuse - so "unset" and "v1" cannot be the same state.
+    #[test]
+    fn unconfigured_handle_refuses_key_material() {
+        let mut storage = SqliteStorage::connect_in_memory().expect("open storage");
+        let (note, enc, blinding) = keys();
+        storage
+            .save_encryption_and_note_keypairs(ADDRESS, &note, &enc, &blinding)
+            .expect("save v1 row");
+
+        let err = map_user_keys(&storage, ADDRESS)
+            .expect_err("an unconfigured handle must not return key material")
+            .to_string();
+        assert!(
+            err.contains("has not been configured"),
+            "expected a configuration error, got: {err}"
+        );
+
+        storage.set_required_binding(BindingVersion::V1);
+        map_user_keys(&storage, ADDRESS).expect("readable once the requirement is configured");
+    }
+
+    /// Every account session is a fork of the client's handle, and a fork
+    /// opens a fresh connection rather than cloning one, so a requirement that
+    /// did not survive forking would leave every session unconfigured - or,
+    /// worse under a v1 default, accepting rows a v2 deployment must refuse.
+    #[test]
+    fn fork_preserves_the_required_binding() {
+        use crate::storage::{Storage as StorageTrait, local::LocalStorage};
+
+        let path = std::env::temp_dir().join(format!(
+            "spp-binding-fork-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        {
+            let mut db = SqliteStorage::connect_file(&path).expect("open db");
+            let (note, enc, blinding) = keys();
+            db.save_encryption_and_note_keypairs_bound(
+                ADDRESS,
+                &note,
+                &enc,
+                &blinding,
+                &KeyBinding {
+                    version: BindingVersion::V2,
+                    bound_owner: Some(ADDRESS.to_string()),
+                },
+            )
+            .expect("save v2 row");
+        }
+
+        let local = LocalStorage::open(path.to_str().expect("utf-8 path"))
+            .expect("open local storage")
+            .with_required_binding(BindingVersion::V2);
+        let forked = StorageTrait::fork(&local).expect("fork");
+        map_user_keys(&forked.storage(), ADDRESS)
+            .expect("a forked handle must keep the deployment's requirement");
+
+        let unset = LocalStorage::open(path.to_str().expect("utf-8 path")).expect("open again");
+        map_user_keys(&unset.storage(), ADDRESS)
+            .expect_err("an unconfigured handle must refuse even a well-formed row");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Background scanning attributes notes by trying every account's keys, so
+    /// a row this deployment does not require must be omitted from that set
+    /// rather than trial-decrypted.
+    #[test]
+    fn scan_skips_foreign_binding_rows() {
+        let mut storage = SqliteStorage::connect_in_memory().expect("open storage");
+        let (note, enc, blinding) = keys();
+        storage
+            .save_encryption_and_note_keypairs_bound(
+                ADDRESS,
+                &note,
+                &enc,
+                &blinding,
+                &KeyBinding {
+                    version: BindingVersion::V2,
+                    bound_owner: Some(ADDRESS.to_string()),
+                },
+            )
+            .expect("save v2 row");
+
+        assert_eq!(
+            storage
+                .get_accounts_with_latest_keypairs_bound(BindingVersion::V2)
+                .expect("bound scan")
+                .len(),
+            1,
+            "the row is visible to a deployment that requires v2"
+        );
+        assert!(
+            storage
+                .get_accounts_with_latest_keypairs_bound(BindingVersion::V1)
+                .expect("bound scan")
+                .is_empty(),
+            "a v2 row must be omitted from the scan set when v1 is required"
+        );
     }
 }

--- a/sdk/native/src/transact.rs
+++ b/sdk/native/src/transact.rs
@@ -3,7 +3,7 @@
 use crate::{
     chain::{OnchainProofPublicInputs, PreparedSorobanTx},
     planner::Transact,
-    state::{SqliteStorage, StoredUserKeys},
+    state::{KeyLookup, SqliteStorage, StoredUserKeys},
     types::{
         AspMembershipProof, AspMembershipSync, AspNonMembershipProof, BabyJubJubPoint,
         EncryptionKeyPair, EncryptionPublicKey, ExtAmount, ExtData, Field, GlobalViewKeyCiphertext,
@@ -214,13 +214,24 @@ pub(crate) fn load_user_key_material(
             public: enc_pub, ..
         },
         membership_blinding,
-    } = storage.get_user_keys(user_address)?.ok_or_else(|| {
+        ..
+    } = match storage.get_user_keys_bound(user_address, storage.require_binding()?)? {
+        KeyLookup::Found(keys) => keys,
         // Escapes to a UI toast and the telemetry ring buffer.
-        anyhow::anyhow!(
-            "address {} should generate privacy keys and ASP secret first",
-            crate::types::Sensitive(user_address)
-        )
-    })?;
+        KeyLookup::Absent => {
+            return Err(anyhow::anyhow!(
+                "address {} should generate privacy keys and ASP secret first",
+                crate::types::Sensitive(user_address)
+            ));
+        }
+        KeyLookup::Mismatch(_) => {
+            return Err(anyhow::anyhow!(
+                "the privacy keys stored for address {} were derived for a different deployment \
+                 configuration and cannot be used here",
+                crate::types::Sensitive(user_address)
+            ));
+        }
+    };
 
     Ok((private, note_pub, enc_pub, membership_blinding))
 }
@@ -368,7 +379,10 @@ mod tests {
     fn missing_user_keys_error_redacts_the_address() {
         let _guard = lock_reveal_flag();
         set_reveal_sensitive(false);
-        let storage = SqliteStorage::connect_in_memory().expect("in-memory storage");
+        let mut storage = SqliteStorage::connect_in_memory().expect("in-memory storage");
+        // v1 is the split-free binding these fixtures represent; an
+        // unconfigured handle now refuses to read key material at all.
+        storage.set_required_binding(crate::state::BindingVersion::V1);
 
         let err = load_user_key_material(&storage, ADDRESS).expect_err("no keys are stored");
         let rendered = format!("{err:#}");

--- a/sdk/native/src/types/client.rs
+++ b/sdk/native/src/types/client.rs
@@ -130,6 +130,7 @@ mod split_tests {
                 verifiers: Default::default(),
                 public_key_registry: String::new(),
                 pools: Vec::new(),
+                signer_may_differ_from_owner: false,
             },
             pool_contract_id: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".into(),
             user_address: NoteOwnerAddress::new(user),

--- a/sdk/native/src/types/mod.rs
+++ b/sdk/native/src/types/mod.rs
@@ -44,6 +44,15 @@ pub struct ContractConfig {
     pub public_key_registry: String,
     /// Pool deployments (one per supported asset/token).
     pub pools: Vec<PoolConfigEntry>,
+    /// Whether this deployment separates the fee-paying signer from the note
+    /// owner.
+    ///
+    /// Fixed per deployment, never a per-user choice. It selects which key
+    /// binding the deployment requires: owner-bound v2 when true, v1 when
+    /// false. Absent in a deployment file means false, so existing files
+    /// keep parsing and keep their current behaviour unchanged.
+    #[serde(default)]
+    pub signer_may_differ_from_owner: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -346,6 +355,19 @@ impl From<&PoolConfigEntry> for PortfolioPoolEntry {
 }
 
 impl ContractConfig {
+    /// Which key binding this deployment requires.
+    ///
+    /// A deployment accepts exactly the binding it derives, so that any
+    /// stored state it accepts is state it can regenerate from the owner's
+    /// secret alone after a clean install.
+    pub fn required_binding(&self) -> crate::state::BindingVersion {
+        if self.signer_may_differ_from_owner {
+            crate::state::BindingVersion::V2
+        } else {
+            crate::state::BindingVersion::V1
+        }
+    }
+
     pub fn enabled_pools(&self) -> impl Iterator<Item = &PoolConfigEntry> {
         self.pools.iter().filter(|p| p.enabled)
     }

--- a/sdk/native/src/zk/encryption.rs
+++ b/sdk/native/src/zk/encryption.rs
@@ -16,12 +16,12 @@
 //! ```text
 //! Freighter Wallet (Ed25519)
 //!        │
-//!        └── signMessage("Privacy Pool Key Derivation [v2]")
+//!        └── signMessage("Privacy Pool Key Derivation [v1]")
 //!                   │
-//!                   ├── SHA-256("privacy-pool/note-key/v2" || sig)
+//!                   ├── SHA-256("privacy-pool/note-key/v1" || sig)
 //!                   │          └── BN254 Note Private Key → Poseidon2 → Note Public Key
 //!                   │
-//!                   └── SHA-256("privacy-pool/encryption-key/v2" || sig)
+//!                   └── SHA-256("privacy-pool/encryption-key/v1" || sig)
 //!                              └── X25519 Encryption Keypair
 //! ```
 //! Note: the original scheme had separate signatures for spending and
@@ -29,6 +29,26 @@
 //! accepting some associated risks like a user signing the message at a scam
 //! website (2 separate signatures could create a safety pause to stop and
 //! think)
+//!
+//! ## v2: owner-bound derivation
+//!
+//! Deployments with the owner/payer split enabled additionally bind every
+//! branch to the owner account's identity, so a delegate payer's signature
+//! can never be replayed to derive the owner's key material:
+//!
+//! ```text
+//! Owner Wallet (Ed25519)
+//!        │
+//!        └── signMessage("Privacy Pool Key Derivation [v2] owner=<G-address>")
+//!                   │  verified locally against the owner's decoded public key
+//!                   │  (see `verify_owner_signature`) before any derivation
+//!                   │
+//!                   ├── SHA-256("privacy-pool/note-key/v2" || 0 || owner_pubkey || 0 || 0 || sig)
+//!                   ├── SHA-256("privacy-pool/encryption-key/v2" || 0 || owner_pubkey || 0 || 0 || sig)
+//!                   └── SHA-256("privacy-pool/asp-secret/v2" || 0 || owner_pubkey || 0 || network || 0 || sig)
+//! ```
+//! v1 remains the permanent, correct derivation for split-free deployments
+//! and is unchanged by the above.
 use crate::{
     types::{
         EncryptionKeyPair, EncryptionPrivateKey, EncryptionPublicKey, Field,
@@ -41,6 +61,7 @@ use ark_bn254::Fr;
 use ark_ff::PrimeField;
 use ark_serialize::CanonicalSerialize;
 use crypto_secretbox::{KeyInit, Nonce, XSalsa20Poly1305, aead::Aead};
+use ed25519_dalek::{Signature as DalekSignature, Verifier, VerifyingKey};
 use sha2::{Digest, Sha256};
 use x25519_dalek::{PublicKey, StaticSecret};
 
@@ -48,13 +69,29 @@ use x25519_dalek::{PublicKey, StaticSecret};
 // These MUST remain constant for backwards compatibility.
 
 /// Message signed to derive both privacy keypairs.
+///
+/// Permanent for every deployment that does not enable the owner/payer split
+/// (`ContractConfig::signer_may_differ_from_owner == false`, the default).
+/// Not deprecated: such a deployment must keep deriving v1 so a reinstall
+/// regenerates the keys an existing account already holds, per the standing
+/// constraint that no existing account may be required to re-derive. See
+/// [`crate::zk::encryption::derive_encryption_and_note_keypairs_v2`] for the
+/// owner-bound construction split-enabled deployments use instead.
 pub const KEY_DERIVATION_MESSAGE: &str = "Privacy Pool Key Derivation [v1]";
 
 const NOTE_KEY_DOMAIN: &[u8] = b"privacy-pool/note-key/v1";
 const ENCRYPTION_KEY_DOMAIN: &[u8] = b"privacy-pool/encryption-key/v1";
 const MEMBERSHIP_BLINDING_DOMAIN: &[u8] = b"privacy-pool/asp-secret/v1";
 
-/// Keypairs derivation
+/// Keypairs derivation.
+///
+/// Production-required and permanent, not a legacy path pending removal:
+/// every deployment with `signer_may_differ_from_owner == false` (the
+/// default) derives with this function forever, called from
+/// cli/src/onboard.rs's V1 branch and sdk/web/src/workers/storage.rs's V1
+/// branch. A stored v1 row is the correct, permanent binding for such a
+/// deployment, since the signer-must-equal-owner guard already made every
+/// such row owner-bound before the owner-bound (v2) construction existed.
 pub fn derive_encryption_and_note_keypairs(
     signature: KeyDerivationSignature,
 ) -> Result<(NoteKeyPair, EncryptionKeyPair)> {
@@ -75,6 +112,12 @@ pub fn derive_encryption_and_note_keypairs(
 
 /// Deterministically derive the account-scoped ASP membership blinding from
 /// the wallet signature plus a stable network context.
+///
+/// Production-required and permanent for every deployment that does not
+/// enable the owner/payer split, for the same reason as
+/// [`derive_encryption_and_note_keypairs`]: called from the same two V1
+/// branches (cli/src/onboard.rs, sdk/web/src/workers/storage.rs) and not a
+/// candidate for removal while any split-free deployment exists.
 pub fn derive_membership_blinding(
     signature: &KeyDerivationSignature,
     network_context: &str,
@@ -198,6 +241,204 @@ fn hash_signature_with_domain_and_context(
     hasher.update([0u8]);
     hasher.update(signature);
     hasher.finalize().into()
+}
+
+// --- Owner-bound (v2) derivation ---
+//
+// Additive alongside v1 above: same three key branches, same signature
+// shape, but every branch also binds to the owner account's identity so a
+// delegate payer's signature can never be replayed to derive the owner's
+// key material. v1 stays the permanent, correct derivation for split-free
+// deployments; callers choose between the two starting in phase 3.
+
+/// SEP-53 prefix applied by both signing paths (the Stellar CLI's `message
+/// sign`, `cli/src/stellar_cli.rs:105`, and the Freighter/wallet
+/// `signMessage` API) before hashing and signing. Verifying against this
+/// reconstruction in [`verify_owner_signature`] is how the two platforms'
+/// agreement is checked at runtime rather than assumed from a doc comment.
+const SEP53_MESSAGE_PREFIX: &str = "Stellar Signed Message:\n";
+
+const NOTE_KEY_DOMAIN_V2: &[u8] = b"privacy-pool/note-key/v2";
+const ENCRYPTION_KEY_DOMAIN_V2: &[u8] = b"privacy-pool/encryption-key/v2";
+const MEMBERSHIP_BLINDING_DOMAIN_V2: &[u8] = b"privacy-pool/asp-secret/v2";
+
+/// Builds the v2 key-derivation message for `owner_address`: a single ASCII
+/// line with no leading or trailing whitespace, carrying the owner's
+/// G-address so it is recognisable in a wallet approval dialog. The network
+/// is deliberately absent — including it would make note and encryption
+/// keys network-dependent, which only the membership blinding branch is.
+pub fn key_derivation_message_v2(owner_address: &str) -> String {
+    format!("Privacy Pool Key Derivation [v2] owner={owner_address}")
+}
+
+/// Verifies that `signature` is a genuine Ed25519 signature by
+/// `owner_address` over the SEP-53-framed digest of `message` —
+/// `SHA-256("Stellar Signed Message:\n" || message)` — and returns the
+/// owner's decoded 32-byte public key on success.
+///
+/// This local verification is the binding's real mechanism. Directing a
+/// wallet's signing request at the owner address is not sufficient on its
+/// own: nothing on the web path confirms the wallet honoured that request
+/// rather than signing as whoever is actually connected. Callers must
+/// reject a signature that fails this check and derive nothing from it.
+pub fn verify_owner_signature(
+    owner_address: &str,
+    message: &str,
+    signature: &KeyDerivationSignature,
+) -> Result<[u8; 32]> {
+    let KeyDerivationSignature(sig_bytes) = signature;
+    let sig_bytes: &[u8; 64] = sig_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| anyhow!("Signature must be 64 bytes (Ed25519)"))?;
+
+    let owner_pubkey = stellar_strkey::ed25519::PublicKey::from_string(owner_address)
+        .map_err(|_| anyhow!("invalid owner address strkey"))?;
+    let verifying_key = VerifyingKey::from_bytes(&owner_pubkey.0)
+        .map_err(|e| anyhow!("invalid verifying key: {e}"))?;
+
+    let mut preimage = Vec::with_capacity(SEP53_MESSAGE_PREFIX.len().saturating_add(message.len()));
+    preimage.extend_from_slice(SEP53_MESSAGE_PREFIX.as_bytes());
+    preimage.extend_from_slice(message.as_bytes());
+    let digest: [u8; 32] = Sha256::digest(&preimage).into();
+
+    let dalek_signature = DalekSignature::from_bytes(sig_bytes);
+    verifying_key
+        .verify(&digest, &dalek_signature)
+        .map_err(|_| {
+            anyhow!("the wallet returned a signature that does not verify against the note owner")
+        })?;
+
+    Ok(owner_pubkey.0)
+}
+
+/// NUL-framed, owner-bound analogue of
+/// [`hash_signature_with_domain_and_context`]:
+/// `SHA-256(domain || 0x00 || owner_pubkey || 0x00 || context || 0x00 ||
+/// signature)`. Used for every v2 branch so that a v1 signature — hashed
+/// without an owner — can never coincide with v2 output, and so two owners with
+/// identical signature bytes diverge on every branch.
+fn hash_signature_with_domain_owner_and_context(
+    signature: &[u8],
+    domain: &[u8],
+    owner_pubkey: &[u8; 32],
+    context: &[u8],
+) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(domain);
+    hasher.update([0u8]);
+    hasher.update(owner_pubkey);
+    hasher.update([0u8]);
+    hasher.update(context);
+    hasher.update([0u8]);
+    hasher.update(signature);
+    hasher.finalize().into()
+}
+
+/// Owner-bound (v2) note private key derivation. See
+/// [`derive_note_private_key`] for the unbound v1 analogue, which is
+/// unchanged and remains the correct derivation for split-free deployments.
+fn derive_note_private_key_v2(
+    signature: &KeyDerivationSignature,
+    owner_pubkey: &[u8; 32],
+) -> Result<NotePrivateKey> {
+    let KeyDerivationSignature(signature) = signature;
+    if signature.len() != 64 {
+        return Err(anyhow!("Signature must be 64 bytes (Ed25519)"));
+    }
+
+    let key = hash_signature_with_domain_owner_and_context(
+        signature,
+        NOTE_KEY_DOMAIN_V2,
+        owner_pubkey,
+        &[],
+    );
+
+    let field = Fr::from_le_bytes_mod_order(&key[..]);
+
+    let mut result = [0u8; 32];
+    field
+        .serialize_compressed(&mut result[..])
+        .expect("Serialization failed");
+
+    Ok(NotePrivateKey(result))
+}
+
+/// Owner-bound (v2) X25519 encryption keypair derivation. See
+/// [`derive_keypair_from_signature`] for the unbound v1 analogue.
+fn derive_keypair_from_signature_v2(
+    signature: &KeyDerivationSignature,
+    owner_pubkey: &[u8; 32],
+) -> Result<EncryptionKeyPair> {
+    let KeyDerivationSignature(signature) = signature;
+    if signature.len() != 64 {
+        return Err(anyhow!("Signature must be 64 bytes (Ed25519)"));
+    }
+
+    let seed = hash_signature_with_domain_owner_and_context(
+        signature,
+        ENCRYPTION_KEY_DOMAIN_V2,
+        owner_pubkey,
+        &[],
+    );
+
+    let secret = StaticSecret::from(seed);
+    let public = PublicKey::from(&secret);
+
+    Ok(EncryptionKeyPair {
+        private: EncryptionPrivateKey(secret.to_bytes()),
+        public: EncryptionPublicKey(public.to_bytes()),
+    })
+}
+
+/// Owner-bound (v2) note and encryption keypair derivation. See
+/// [`derive_encryption_and_note_keypairs`] for the unbound v1 analogue,
+/// which is unchanged and remains the correct binding for deployments
+/// that do not separate the payer from the owner.
+pub fn derive_encryption_and_note_keypairs_v2(
+    signature: &KeyDerivationSignature,
+    owner_pubkey: &[u8; 32],
+) -> Result<(NoteKeyPair, EncryptionKeyPair)> {
+    let note_private_key = derive_note_private_key_v2(signature, owner_pubkey)?;
+    let pubkey = derive_public_key(&note_private_key.0)?;
+    let note_public_key = NotePublicKey(
+        pubkey
+            .try_into()
+            .map_err(|e: Vec<u8>| anyhow::anyhow!("Expected 32 bytes, but got {}", e.len()))?,
+    );
+    let note_keypair = NoteKeyPair {
+        private: note_private_key,
+        public: note_public_key,
+    };
+    let encryption_keypair = derive_keypair_from_signature_v2(signature, owner_pubkey)?;
+    Ok((note_keypair, encryption_keypair))
+}
+
+/// Owner-bound (v2) ASP membership blinding derivation. See
+/// [`derive_membership_blinding`] for the unbound v1 analogue.
+pub fn derive_membership_blinding_v2(
+    signature: &KeyDerivationSignature,
+    owner_pubkey: &[u8; 32],
+    network_context: &str,
+) -> Result<Field> {
+    let KeyDerivationSignature(signature) = signature;
+    if signature.len() != 64 {
+        return Err(anyhow!("Signature must be 64 bytes (Ed25519)"));
+    }
+
+    let key = hash_signature_with_domain_owner_and_context(
+        signature,
+        MEMBERSHIP_BLINDING_DOMAIN_V2,
+        owner_pubkey,
+        network_context.as_bytes(),
+    );
+    let field = Fr::from_le_bytes_mod_order(&key);
+
+    let mut result = [0u8; 32];
+    field
+        .serialize_compressed(&mut result[..])
+        .expect("Serialization failed");
+    Field::try_from_le_bytes(result)
 }
 
 /// Generate a cryptographically random blinding factor for a note.
@@ -455,6 +696,72 @@ mod tests {
         let second = derive_membership_blinding(&KeyDerivationSignature(vec![9u8; 64]), "testnet")
             .expect("derivation failed");
         assert_ne!(first.to_le_bytes(), second.to_le_bytes());
+    }
+
+    #[test]
+    fn two_owners_same_signature_diverge() {
+        let signature = KeyDerivationSignature(vec![11u8; 64]);
+        let owner_a = [1u8; 32];
+        let owner_b = [2u8; 32];
+
+        let (note_a, enc_a) = derive_encryption_and_note_keypairs_v2(&signature, &owner_a)
+            .expect("owner a derivation failed");
+        let (note_b, enc_b) = derive_encryption_and_note_keypairs_v2(&signature, &owner_b)
+            .expect("owner b derivation failed");
+        assert_ne!(note_a.private.0, note_b.private.0);
+        assert_ne!(enc_a.private.0, enc_b.private.0);
+
+        let blinding_a = derive_membership_blinding_v2(&signature, &owner_a, "testnet")
+            .expect("owner a blinding failed");
+        let blinding_b = derive_membership_blinding_v2(&signature, &owner_b, "testnet")
+            .expect("owner b blinding failed");
+        assert_ne!(blinding_a.to_le_bytes(), blinding_b.to_le_bytes());
+    }
+
+    #[test]
+    fn v1_signature_cannot_produce_v2_material() {
+        let signature = KeyDerivationSignature(vec![12u8; 64]);
+        let owner = [3u8; 32];
+
+        let v1_note = derive_note_private_key(&signature).expect("v1 note derivation failed");
+        let v1_enc =
+            derive_keypair_from_signature(&signature).expect("v1 encryption derivation failed");
+        let v1_blinding = derive_membership_blinding(&signature, "testnet")
+            .expect("v1 blinding derivation failed");
+
+        let (v2_note, v2_enc) = derive_encryption_and_note_keypairs_v2(&signature, &owner)
+            .expect("v2 derivation failed");
+        let v2_blinding = derive_membership_blinding_v2(&signature, &owner, "testnet")
+            .expect("v2 blinding derivation failed");
+
+        assert_ne!(v1_note.0, v2_note.private.0);
+        assert_ne!(v1_enc.private.0, v2_enc.private.0);
+        assert_ne!(v1_blinding.to_le_bytes(), v2_blinding.to_le_bytes());
+    }
+
+    #[test]
+    fn sep53_preimage_matches_a_pinned_vector() {
+        use ed25519_dalek::{Signer as _, SigningKey};
+
+        // Fixed test seed; this is not a real account key.
+        let signing_key = SigningKey::from_bytes(&[42u8; 32]);
+        let owner_address =
+            stellar_strkey::ed25519::PublicKey(signing_key.verifying_key().to_bytes())
+                .to_string()
+                .to_string();
+
+        let message = key_derivation_message_v2(&owner_address);
+        let mut preimage = Vec::new();
+        preimage.extend_from_slice(SEP53_MESSAGE_PREFIX.as_bytes());
+        preimage.extend_from_slice(message.as_bytes());
+        let digest: [u8; 32] = Sha256::digest(&preimage).into();
+
+        let signature = signing_key.sign(&digest);
+        let signature = KeyDerivationSignature(signature.to_bytes().to_vec());
+
+        let recovered_owner = verify_owner_signature(&owner_address, &message, &signature)
+            .expect("genuine signature must verify against the pinned SEP-53 reconstruction");
+        assert_eq!(recovered_owner, signing_key.verifying_key().to_bytes());
     }
 
     #[test]

--- a/sdk/tests/Cargo.toml
+++ b/sdk/tests/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 stellar-private-payments = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/sdk/tests/src/pool.rs
+++ b/sdk/tests/src/pool.rs
@@ -38,7 +38,10 @@ const TEST_CONFIG_JSON: &str = r#"{
 
 const POOL_CONTRACT_ID: &str = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
 const ASP_MEMBERSHIP_CONTRACT_ID: &str = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
-const USER_ADDRESS: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+/// `pub(crate)` so sibling test modules (e.g. `tests::wallet`) can derive the
+/// same expected keys via `seed::seeded_user_public_keys` rather than
+/// hardcoding a second copy of this address.
+pub(crate) const USER_ADDRESS: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
 /// Ed25519 secret for `SigningKey::from_bytes(&[7u8; 32])` (stellar signer unit
 /// tests).
 const TEST_SIGNER_SECRET: &str = "SADQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQP54X";

--- a/sdk/tests/src/seed.rs
+++ b/sdk/tests/src/seed.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use rusqlite::{Connection, params};
+use sha2::{Digest, Sha256};
 use stellar_private_payments::{
     state::SqliteStorage,
     types::{
@@ -19,15 +20,34 @@ pub const ASP_MEMBERSHIP_LEVELS: u32 = 10;
 pub const TEST_NETWORK: &str = "test";
 const TEST_LEDGER: u32 = 1;
 
-fn test_derivation_signature() -> KeyDerivationSignature {
-    KeyDerivationSignature(vec![42u8; 64])
+/// A deterministic stand-in for a wallet's SEP-53 signature, keyed on the
+/// owner address rather than a shared constant.
+///
+/// This is not a real Ed25519 signature and nothing here verifies it as one -
+/// v1 derivation only hashes these 64 bytes as key-derivation material. Two
+/// SHA-256 outputs supply the 64 bytes every v1 derivation function requires
+/// (`signature.len() != 64` is an error on every branch), and keying on
+/// `owner_address` is what makes distinct seeded accounts produce distinct
+/// keys: a single shared constant here previously made every seeded account
+/// share identical note, encryption and blinding material regardless of
+/// which address it was filed under.
+fn test_derivation_signature(owner_address: &str) -> KeyDerivationSignature {
+    let mut bytes = Vec::with_capacity(64);
+    bytes.extend_from_slice(&Sha256::digest([owner_address.as_bytes(), b":0"].concat()));
+    bytes.extend_from_slice(&Sha256::digest([owner_address.as_bytes(), b":1"].concat()));
+    KeyDerivationSignature(bytes)
 }
 
-pub fn seeded_user_public_keys() -> Result<(
+/// The note/encryption public keys [`seed_prove_wallet`] and
+/// [`apply_proved_step`] derive for `owner_address`, for tests to assert
+/// against without re-deriving by hand.
+pub fn seeded_user_public_keys(
+    owner_address: &str,
+) -> Result<(
     stellar_private_payments::types::NotePublicKey,
     stellar_private_payments::types::EncryptionPublicKey,
 )> {
-    let signature = test_derivation_signature();
+    let signature = test_derivation_signature(owner_address);
     let (note_keypair, encryption_keypair) =
         encryption::derive_encryption_and_note_keypairs(signature)?;
     Ok((note_keypair.public, encryption_keypair.public))
@@ -52,7 +72,7 @@ pub fn seed_prove_wallet(
 
     let mut storage = SqliteStorage::connect_file(storage_path).context("open seeded database")?;
 
-    let signature = test_derivation_signature();
+    let signature = test_derivation_signature(user_address);
     let (note_keypair, encryption_keypair) =
         encryption::derive_encryption_and_note_keypairs(signature.clone())?;
     let membership_blinding = encryption::derive_membership_blinding(&signature, network)?;
@@ -166,6 +186,7 @@ pub fn seed_prove_wallet(
         pool_contract_id,
         asp_membership_contract_id,
         network,
+        user_address,
     )
 }
 
@@ -180,7 +201,7 @@ pub fn apply_proved_step(
 ) -> Result<TransactChainContext> {
     use stellar_private_payments::zk::notes;
 
-    let signature = test_derivation_signature();
+    let signature = test_derivation_signature(user_address);
     let (note_keypair, encryption_keypair) =
         encryption::derive_encryption_and_note_keypairs(signature.clone())?;
 
@@ -208,6 +229,7 @@ pub fn apply_proved_step(
         pool_contract_id,
         asp_membership_contract_id,
         network,
+        user_address,
     )?;
     let mut leaf_index = chain.pool_next_index;
 
@@ -278,6 +300,7 @@ pub fn apply_proved_step(
         pool_contract_id,
         asp_membership_contract_id,
         network,
+        user_address,
     )
 }
 
@@ -286,10 +309,11 @@ fn chain_snapshot_from_storage(
     pool_contract_id: &str,
     asp_membership_contract_id: &str,
     _network: &str,
+    user_address: &str,
 ) -> Result<TransactChainContext> {
     let storage =
         SqliteStorage::connect_file(storage_path).context("open storage for chain snapshot")?;
-    let signature = test_derivation_signature();
+    let signature = test_derivation_signature(user_address);
     let (note_keypair, _) = encryption::derive_encryption_and_note_keypairs(signature)?;
     let note_pubkey_field = Field::try_from_le_bytes(*note_keypair.public.as_ref())?;
 

--- a/sdk/tests/src/tests/wallet.rs
+++ b/sdk/tests/src/tests/wallet.rs
@@ -2,7 +2,7 @@
 //! [`stellar_private_payments::blocking::PrivatePool`].
 
 use crate::{
-    pool::{test_account, test_pool},
+    pool::{USER_ADDRESS, test_account, test_pool},
     seed::seeded_user_public_keys,
 };
 use stellar_private_payments::types::NoteAmount;
@@ -79,7 +79,7 @@ fn user_public_keys_on_account() {
     let account = test_account(Some(&[2, 3, 5])).expect("test account");
 
     let (note, enc) = account.user_public_keys().expect("user public keys");
-    let (expected_note, expected_enc) = seeded_user_public_keys().expect("seeded keys");
+    let (expected_note, expected_enc) = seeded_user_public_keys(USER_ADDRESS).expect("seeded keys");
 
     assert_eq!(note.0, expected_note.0);
     assert_eq!(enc.0, expected_enc.0);

--- a/sdk/web/src/client/mod.rs
+++ b/sdk/web/src/client/mod.rs
@@ -15,10 +15,12 @@ use stellar_private_payments::{
     chain::{RpcClient, StateFetcher},
     crypto::derive_asp_user_leaf as derive_asp_user_leaf_native,
     disclosure::verify_disclosure_receipt,
+    state::BindingVersion,
     types::{
         ContractConfig, DisclosureReceipt, Field, KeyDerivationSignature, NoteOwnerAddress,
         NotePublicKey, SignerAddress,
     },
+    zk::encryption::key_derivation_message_v2,
 };
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
@@ -31,7 +33,7 @@ use crate::{
         DisclosureVerificationReport, OperationalFeedItem, RecipientLookup,
         VerifyDisclosureOptions, operational_feed_items,
     },
-    protocol::{StorageWorkerRequest, StorageWorkerResponse},
+    protocol::{KeyBindingStatus, StorageWorkerRequest, StorageWorkerResponse},
     signer::WalletSigner,
     storage::Storage,
     workers::{
@@ -126,6 +128,14 @@ impl Client {
             .map_err(|e| JsError::new(&e.to_string()))?;
 
         let contract_config = parse_contract_config(contract_config)?;
+        // Configure the worker before anything can ask it to read or derive.
+        // It holds the only copy: every route that touches key material takes
+        // the requirement from there rather than from a request, so a caller
+        // can neither select a weaker binding nor be served by a stale one.
+        storage_bridge
+            .configure_binding(contract_config.required_binding())
+            .await
+            .map_err(|e| JsError::new(&e.to_string()))?;
         let circuits_base_url = require_circuits_base_url(circuits_base_url)?;
         let prover = ProverBridge::new(
             ProverWorker::spawner()
@@ -227,13 +237,35 @@ impl Client {
                 signer_address,
             )?;
 
-            if !self.user_keys_exist(&user_address).await? {
-                let message =
-                    stellar_private_payments::zk::encryption::KEY_DERIVATION_MESSAGE.to_string();
-                let sig_hex = wallet_signer.sign_wallet_message(&message).await?;
-                let signature = crate::signer::wallet_message_signature_to_bytes(&sig_hex)?;
-                self.derive_save_user_keys(user_address.clone(), signature)
-                    .await?;
+            // Three-way, mirroring the worker: absent derives, acceptable
+            // skips, and a row derived for a different deployment
+            // configuration is refused without deriving or writing anything.
+            let required = self.contract_config.required_binding();
+            match self.key_binding_status(&user_address).await? {
+                KeyBindingStatus::Acceptable => {}
+                KeyBindingStatus::Mismatch { .. } => {
+                    return Err(JsError::new(
+                        "these privacy keys were derived for a different deployment \
+                         configuration and cannot be used here",
+                    ));
+                }
+                KeyBindingStatus::Absent => {
+                    let message = match required {
+                        BindingVersion::V1 => {
+                            stellar_private_payments::zk::encryption::KEY_DERIVATION_MESSAGE
+                                .to_string()
+                        }
+                        BindingVersion::V2 => key_derivation_message_v2(&user_address),
+                    };
+                    // Directed at the note owner, never at the payer: the
+                    // owner's secret is what the keys must be a function of.
+                    let sig_hex = wallet_signer
+                        .sign_wallet_message_as(&user_address, &message)
+                        .await?;
+                    let signature = crate::signer::wallet_message_signature_to_bytes(&sig_hex)?;
+                    self.derive_save_user_keys(user_address.clone(), signature)
+                        .await?;
+                }
             }
 
             Ok(Account::new(Rc::new(
@@ -403,11 +435,16 @@ impl Client {
             .map_err(pool_err)
     }
 
-    async fn user_keys_exist(&self, address: &str) -> Result<bool, JsError> {
-        let req = StorageWorkerRequest::UserKeys(address.to_string());
+    /// Metadata-only binding probe.
+    ///
+    /// Deliberately does not go through the `UserKeys` route: that route
+    /// returns key material, and asking it a status question is what made an
+    /// unusable account indistinguishable from an un-onboarded one. This
+    /// carries no key material in any outcome.
+    async fn key_binding_status(&self, address: &str) -> Result<KeyBindingStatus, JsError> {
+        let req = StorageWorkerRequest::KeyBindingStatus(address.to_string());
         match self.storage_request(req, 1_000).await? {
-            StorageWorkerResponse::UserKeys(Some(_)) => Ok(true),
-            StorageWorkerResponse::UserKeys(None) => Ok(false),
+            StorageWorkerResponse::KeyBindingStatus(status) => Ok(status),
             other => Err(JsError::new(&format!("unexpected response: {other:?}"))),
         }
     }

--- a/sdk/web/src/protocol.rs
+++ b/sdk/web/src/protocol.rs
@@ -15,6 +15,7 @@ pub use stellar_private_payments::{
 
 use stellar_private_payments::{
     gvk::GvkEvent,
+    state::BindingVersion,
     types::{
         AspMembershipSync, ContractsEventData, DisclosureReceipt, EncryptionPublicKey, Field,
         KeyDerivationSignature, NotePublicKey, OperationalFeedItem, PortfolioBalance,
@@ -50,6 +51,51 @@ pub struct AspSecret {
     pub membership_blinding: Field,
 }
 
+/// Which key binding a request requires, mirrored across the worker boundary.
+///
+/// A deployment requires exactly the binding it derives, so this is a function
+/// of the deployment's configuration and never a per-user choice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RequiredBinding {
+    V1,
+    V2,
+}
+
+impl From<RequiredBinding> for BindingVersion {
+    fn from(required: RequiredBinding) -> Self {
+        match required {
+            RequiredBinding::V1 => BindingVersion::V1,
+            RequiredBinding::V2 => BindingVersion::V2,
+        }
+    }
+}
+
+impl From<BindingVersion> for RequiredBinding {
+    fn from(version: BindingVersion) -> Self {
+        match version {
+            BindingVersion::V1 => RequiredBinding::V1,
+            BindingVersion::V2 => RequiredBinding::V2,
+        }
+    }
+}
+
+/// Metadata-only answer to "can this account's stored keys be used here?".
+///
+/// Carries no key material and no address in any variant: it exists so the
+/// client and the UI can tell "no keys yet" from "keys exist but were derived
+/// for a different deployment configuration" without a status question ever
+/// travelling over a route that returns secrets.
+// No serde rename: the rest of this protocol crosses the JS boundary with
+// variant names as written - StorageWorkerRequest/Response and RequiredBinding
+// all do - and the JS side matches on exactly those, so renaming only this
+// enum would make every JS comparison silently fail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KeyBindingStatus {
+    Absent,
+    Acceptable,
+    Mismatch { stored: RequiredBinding },
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DisclaimerStatePayload {
@@ -72,6 +118,15 @@ pub enum StorageWorkerRequest {
     },
     ClearIndexingCursors,
     ClampLastFullyIndexedLedger(u32),
+    /// Set the key binding this deployment requires. Sent once by the client
+    /// at startup; a later attempt to set a different value is refused, so the
+    /// requirement cannot be relaxed by a subsequent request.
+    ConfigureBinding(RequiredBinding),
+    /// Derive and store an account's privacy keys.
+    ///
+    /// Deliberately does NOT carry the required binding: the worker takes that
+    /// from its own configuration. A caller-supplied value would let a request
+    /// select the unverified v1 path on a deployment that requires v2.
     DeriveSaveUserKeys(Address, KeyDerivationSignature, String),
     DisclaimerState(Address),
     AcceptDisclaimer(Address, String),
@@ -82,6 +137,8 @@ pub enum StorageWorkerRequest {
     },
     UserKeys(Address),
     AspSecret(Address),
+    /// Metadata-only binding probe. Never returns key material.
+    KeyBindingStatus(Address),
     UserNotes(Address, u32),
     PortfolioBalances {
         address: Address,
@@ -145,6 +202,7 @@ pub enum StorageWorkerResponse {
     Setting(Option<String>),
     UserKeys(Option<UserKeys>),
     AspSecret(Option<AspSecret>),
+    KeyBindingStatus(KeyBindingStatus),
     UserNotes(Vec<UserNoteSummary>),
     PortfolioBalances(Vec<PortfolioBalance>),
     Operations(Vec<UserOperation>),

--- a/sdk/web/src/signer.rs
+++ b/sdk/web/src/signer.rs
@@ -55,8 +55,28 @@ impl WalletSigner {
         &self.signer_address
     }
 
-    pub(crate) async fn sign_wallet_message(&self, message: &str) -> Result<String, JsError> {
-        self.call("signMessage", &[message.into()]).await
+    /// Ask the wallet to sign `message` as `address`, and report back both the
+    /// signature and the account the wallet says it signed with.
+    ///
+    /// Key derivation is directed at the note owner rather than at the payer
+    /// this signer was built for, so it cannot reuse [`Self::wallet_opts`].
+    /// The returned signer address is advisory: the caller may reject an
+    /// obvious mismatch cheaply, but a wallet that misreports it is caught by
+    /// verifying the signature itself against the owner's public key.
+    pub(crate) async fn sign_wallet_message_as(
+        &self,
+        address: &str,
+        message: &str,
+    ) -> Result<String, JsError> {
+        let opts = Object::new();
+        let _ = Reflect::set(&opts, &"address".into(), &JsValue::from_str(address));
+        let _ = Reflect::set(
+            &opts,
+            &"networkPassphrase".into(),
+            &self.network_passphrase.clone().into(),
+        );
+        self.call_reporting_signer("signMessage", &[message.into()], opts, address)
+            .await
     }
 
     pub(crate) async fn sign_prepared_transaction(
@@ -128,7 +148,7 @@ impl WalletSigner {
             .map_err(|e| wallet_js_error(method, "failed", e))?;
 
         let (signature, reported) = normalize_sign_result(method, result)?;
-        self.verify_signer_address(method, reported.as_deref())?;
+        self.verify_signer_address(method, reported.as_deref(), self.signer_address.as_str())?;
         Ok(signature)
     }
 
@@ -144,18 +164,62 @@ impl WalletSigner {
     /// `WalletSigner` takes any object with the three sign methods, and the
     /// bare-string return shape carries nothing to compare. Freighter always
     /// reports one, so its substitution path stays covered.
-    fn verify_signer_address(&self, method: &str, reported: Option<&str>) -> Result<(), JsError> {
+    /// `expected` is the account the request was directed at: the payer for
+    /// ordinary signing, the note owner for key derivation. Both need the same
+    /// guarantee, so both go through here.
+    fn verify_signer_address(
+        &self,
+        method: &str,
+        reported: Option<&str>,
+        expected: &str,
+    ) -> Result<(), JsError> {
         let Some(reported) = reported else {
             return Ok(());
         };
-        if reported == self.signer_address.as_str() {
+        if reported == expected {
             return Ok(());
         }
         Err(JsError::new(&format!(
             "signer.{method}: wallet signed as {}, not the requested {}",
             Sensitive(reported),
-            Sensitive(self.signer_address.as_str()),
+            Sensitive(expected),
         )))
+    }
+
+    /// Like [`Self::call`] but with caller-supplied options, returning the
+    /// wallet's reported signer address alongside the signature instead of
+    /// discarding it.
+    async fn call_reporting_signer(
+        &self,
+        method: &str,
+        extra_args: &[JsValue],
+        opts: Object,
+        expected: &str,
+    ) -> Result<String, JsError> {
+        let func: Function = Reflect::get(&self.signer, &JsValue::from_str(method))
+            .map_err(|e| JsError::new(&format!("signer.{method}: {e:?}")))?
+            .dyn_into()
+            .map_err(|_| JsError::new(&format!("signer.{method} must be a function")))?;
+
+        let js_args = Array::new();
+        for arg in extra_args {
+            js_args.push(arg);
+        }
+        js_args.push(&opts.into());
+
+        let promise_val = func
+            .apply(&self.signer, &js_args)
+            .map_err(|e| wallet_js_error(method, "failed", e))?;
+        let promise: Promise = promise_val
+            .dyn_into()
+            .map_err(|_| JsError::new(&format!("signer.{method} must return a Promise")))?;
+        let result = JsFuture::from(promise)
+            .await
+            .map_err(|e| wallet_js_error(method, "failed", e))?;
+
+        let (signature, reported) = normalize_sign_result(method, result)?;
+        self.verify_signer_address(method, reported.as_deref(), expected)?;
+        Ok(signature)
     }
 }
 
@@ -540,7 +604,10 @@ mod signer_address_tests {
             "{{ signedMessage: '{SIGNATURE}', signerAddress: '{REQUESTED}' }}"
         ))
         .unwrap();
-        assert_eq!(wallet.sign_wallet_message("m").await.unwrap(), SIGNATURE);
+        assert_eq!(
+            wallet.sign_wallet_message_as(REQUESTED, "m").await.unwrap(),
+            SIGNATURE
+        );
     }
 
     /// Freighter reports success while having signed with whatever account was
@@ -552,7 +619,7 @@ mod signer_address_tests {
         ))
         .unwrap();
         let error = wallet
-            .sign_wallet_message("m")
+            .sign_wallet_message_as(REQUESTED, "m")
             .await
             .expect_err("a substituted signing account must be refused");
         assert!(
@@ -569,7 +636,12 @@ mod signer_address_tests {
             "{{ signedMessage: '{SIGNATURE}', signerAddress: '{SUBSTITUTED}' }}"
         ))
         .unwrap();
-        let message = error_message(wallet.sign_wallet_message("m").await.unwrap_err());
+        let message = error_message(
+            wallet
+                .sign_wallet_message_as(REQUESTED, "m")
+                .await
+                .unwrap_err(),
+        );
         assert!(!message.contains(SUBSTITUTED), "leaked: {message}");
         assert!(!message.contains(REQUESTED), "leaked: {message}");
     }
@@ -582,8 +654,13 @@ mod signer_address_tests {
             "{{ signedMessage: '{SIGNATURE}', signerAddress: '{SUBSTITUTED}' }}"
         ))
         .unwrap();
-        let message =
-            error_message(wallet.sign_wallet_message("m").await.unwrap_err()).to_ascii_lowercase();
+        let message = error_message(
+            wallet
+                .sign_wallet_message_as(REQUESTED, "m")
+                .await
+                .unwrap_err(),
+        )
+        .to_ascii_lowercase();
         for word in ["rejected", "denied", "cancelled"] {
             assert!(!message.contains(word), "'{word}' in: {message}");
         }
@@ -594,6 +671,9 @@ mod signer_address_tests {
     #[wasm_bindgen_test]
     async fn a_reply_without_an_address_is_accepted() {
         let wallet = wallet_returning(&format!("'{SIGNATURE}'")).unwrap();
-        assert_eq!(wallet.sign_wallet_message("m").await.unwrap(), SIGNATURE);
+        assert_eq!(
+            wallet.sign_wallet_message_as(REQUESTED, "m").await.unwrap(),
+            SIGNATURE
+        );
     }
 }

--- a/sdk/web/src/workers/storage.rs
+++ b/sdk/web/src/workers/storage.rs
@@ -1,7 +1,7 @@
 use crate::protocol::{
     AdminASPRequest, AspSecret, CorrelatedRequest, DisclaimerStatePayload, DisclosureInputs,
-    DisclosureInputsRequest, PublicEncryptionKeyPair, PublicNoteKeyPair, StorageWorkerRequest,
-    StorageWorkerResponse, UserKeys,
+    DisclosureInputsRequest, KeyBindingStatus, PublicEncryptionKeyPair, PublicNoteKeyPair,
+    StorageWorkerRequest, StorageWorkerResponse, UserKeys,
 };
 use anyhow::{Result, anyhow};
 use futures::{FutureExt, channel::mpsc, stream::StreamExt};
@@ -16,7 +16,10 @@ use stellar_private_payments::{
     chain::ContractDataStorage,
     disclosure::{BuildDisclosureInputs, build_disclosure_inputs},
     planner::SpendableNote,
-    state::{SqliteStorage, StoredUserKeys, process_local_state_batch},
+    state::{
+        BindingVersion, KeyBinding, KeyLookup, SqliteStorage, StoredUserKeys,
+        process_local_state_batch,
+    },
     transact::{BuildTransactParams, TransactRequest, build_transact_params},
     types::{
         ContractConfig, ContractsEventData, EncryptionPublicKey, Field, NotePublicKey,
@@ -25,7 +28,11 @@ use stellar_private_payments::{
     },
     zk::{
         crypto::asp_membership_leaf,
-        encryption::{derive_encryption_and_note_keypairs, derive_membership_blinding},
+        encryption::{
+            derive_encryption_and_note_keypairs, derive_encryption_and_note_keypairs_v2,
+            derive_membership_blinding, derive_membership_blinding_v2, key_derivation_message_v2,
+            verify_owner_signature,
+        },
         flows::TransactParams,
     },
 };
@@ -66,8 +73,27 @@ thread_local! {
     static STORAGE: RefCell<Option<SqliteStorage>> = const { RefCell::new(None) };
     static PROCESSOR_TX: RefCell<Option<mpsc::Sender<()>>> = const { RefCell::new(None) };
     static INIT_STATE: RefCell<InitState> = const { RefCell::new(InitState::Pending) };
+    /// The key binding this deployment requires, set once by the client at
+    /// startup. Held here rather than taken from each request so that no
+    /// caller can select the unverified v1 derivation path on a deployment
+    /// that requires owner-bound keys.
+    static REQUIRED_BINDING: RefCell<Option<BindingVersion>> = const { RefCell::new(None) };
     #[cfg(target_arch = "wasm32")]
     static SAH_POOL: RefCell<Option<sqlite_wasm_vfs::sahpool::OpfsSAHPoolUtil>> = const { RefCell::new(None) };
+}
+
+/// The key binding this deployment requires, or an error naming the omission.
+///
+/// Every route that touches key material - the reads as well as the write -
+/// takes the requirement from here rather than from its request. A
+/// request-supplied value would let a caller pick, and a default would be
+/// worse still: falling back to v1 ACCEPTS a v1 row on a deployment that
+/// requires v2, which is the unbound material this binding exists to keep out.
+/// Unconfigured therefore refuses, matching the native handle.
+fn configured_binding() -> Result<BindingVersion> {
+    REQUIRED_BINDING
+        .with(|cell| *cell.borrow())
+        .ok_or_else(|| anyhow!("the deployment's key binding requirement has not been configured"))
 }
 
 macro_rules! with_storage {
@@ -177,6 +203,13 @@ async fn init() -> Result<(), JsError> {
         }
     };
 
+    // A ConfigureBinding may have arrived before storage was installed; carry
+    // the requirement onto the new handle so the readers that run in this
+    // worker never fall back to the v1 default.
+    let mut storage = storage;
+    if let Some(required) = REQUIRED_BINDING.with(|cell| *cell.borrow()) {
+        storage.set_required_binding(required);
+    }
     STORAGE.with(|s| {
         *s.borrow_mut() = Some(storage);
     });
@@ -304,15 +337,122 @@ pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerRes
             with_storage_mut!(s => s.clamp_last_fully_indexed_ledger(max_ledger)?)?;
             StorageWorkerResponse::Saved
         }
+        StorageWorkerRequest::ConfigureBinding(required) => {
+            let required: BindingVersion = required.into();
+            REQUIRED_BINDING.with(|cell| {
+                let mut slot = cell.borrow_mut();
+                match *slot {
+                    // Refuse a conflicting re-configure: the requirement is a
+                    // property of the deployment, so a second, different value
+                    // is either a bug or an attempt to relax it.
+                    Some(existing) if existing != required => Err(anyhow!(
+                        "the key binding requirement is already configured and cannot be changed"
+                    )),
+                    _ => {
+                        *slot = Some(required);
+                        Ok(())
+                    }
+                }
+            })?;
+            // The readers that run inside this worker - the spend witness, the
+            // disclosure inputs and background note attribution - consult the
+            // storage handle rather than this thread-local, so it must carry
+            // the same requirement.
+            STORAGE.with(|s| {
+                if let Some(storage) = s.borrow_mut().as_mut() {
+                    storage.set_required_binding(required);
+                }
+            });
+            StorageWorkerResponse::Saved
+        }
         StorageWorkerRequest::DeriveSaveUserKeys(address, signature, network_context) => {
             tracing::trace!(
                 "[{WORKER_NAME}] deriving and saving user keys for the account {}",
                 Sensitive(&address)
             );
-            let (note_keypair, encryption_keypair) =
-                derive_encryption_and_note_keypairs(signature.clone())?;
-            let membership_blinding = derive_membership_blinding(&signature, &network_context)?;
-            with_storage_mut!(s => s.save_encryption_and_note_keypairs(&address, &note_keypair, &encryption_keypair, &membership_blinding)?)?;
+            // The worker is the authoritative gate, not the client: this arm
+            // accepts an (address, signature) pair from anything that can post
+            // to it, so the pair is correlated here rather than trusted. The
+            // requirement comes from the worker's own configuration for the
+            // same reason - a request-supplied value would let a caller pick
+            // the v1 path, which performs no signature verification, and plant
+            // key material under an owner's address.
+            let required = configured_binding()?;
+            match with_storage!(s => s.get_user_keys_bound(&address, required)?)? {
+                // (iii) already bound acceptably: a replay must not insert a
+                // second row. `get_user_keys` takes the newest row, so an
+                // extra insert would shadow the one this account's notes are
+                // encrypted under.
+                KeyLookup::Found(_) => {
+                    tracing::trace!(
+                        "[{WORKER_NAME}] acceptable keys already present for the account {}",
+                        Sensitive(&address)
+                    );
+                    return Ok(StorageWorkerResponse::Saved);
+                }
+                // (iv) a row exists that this deployment cannot use. Refuse
+                // without writing: overwriting or inserting alongside would
+                // hide usable key material behind unusable material.
+                KeyLookup::Mismatch(_) => {
+                    return Err(anyhow!(
+                        "these privacy keys were derived for a different deployment \
+                         configuration and cannot be used here"
+                    ));
+                }
+                KeyLookup::Absent => {}
+            }
+
+            let (note_keypair, encryption_keypair, membership_blinding, binding) = match required {
+                // (i) v1: the split-free construction, unchanged.
+                BindingVersion::V1 => {
+                    let (note_keypair, encryption_keypair) =
+                        derive_encryption_and_note_keypairs(signature.clone())?;
+                    let membership_blinding =
+                        derive_membership_blinding(&signature, &network_context)?;
+                    (
+                        note_keypair,
+                        encryption_keypair,
+                        membership_blinding,
+                        KeyBinding {
+                            version: BindingVersion::V1,
+                            bound_owner: None,
+                        },
+                    )
+                }
+                // (i)/(ii) v2: verify the signature against the address it is
+                // being filed under before deriving anything from it. A
+                // signature from any other key produces no key material and
+                // no row.
+                BindingVersion::V2 => {
+                    let message = key_derivation_message_v2(&address);
+                    let owner_pubkey = verify_owner_signature(&address, &message, &signature)?;
+                    let (note_keypair, encryption_keypair) =
+                        derive_encryption_and_note_keypairs_v2(&signature, &owner_pubkey)?;
+                    let membership_blinding =
+                        derive_membership_blinding_v2(&signature, &owner_pubkey, &network_context)?;
+                    (
+                        note_keypair,
+                        encryption_keypair,
+                        membership_blinding,
+                        KeyBinding {
+                            version: BindingVersion::V2,
+                            bound_owner: Some(address.clone()),
+                        },
+                    )
+                }
+            };
+
+            match binding.version {
+                // v1 keeps the original write path exactly, DEFAULT-ing the
+                // discriminator, so nothing about a split-free deployment's
+                // stored state changes.
+                BindingVersion::V1 => {
+                    with_storage_mut!(s => s.save_encryption_and_note_keypairs(&address, &note_keypair, &encryption_keypair, &membership_blinding)?)?;
+                }
+                BindingVersion::V2 => {
+                    with_storage_mut!(s => s.save_encryption_and_note_keypairs_bound(&address, &note_keypair, &encryption_keypair, &membership_blinding, &binding)?)?;
+                }
+            }
             tracing::trace!(
                 "[{WORKER_NAME}] saved notes, encryption keys, and ASP secret for the account {}",
                 Sensitive(&address)
@@ -357,7 +497,12 @@ pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerRes
                 "[{WORKER_NAME}] fetch user keys for the account {}",
                 Sensitive(&address)
             );
-            let opt = with_storage!(s => s.get_user_keys(&address)?)?;
+            // Key-material route: returns nothing for a row this deployment
+            // cannot use, and deliberately does not report the stored binding.
+            // Status questions go to KeyBindingStatus, so no path returns
+            // secrets in order to answer one.
+            let required = configured_binding()?;
+            let opt = with_storage!(s => s.get_user_keys_bound(&address, required)?)?.into_found();
             if opt.is_some() {
                 tracing::trace!(
                     "[{WORKER_NAME}] fetched notes and encryption keys for the account {}",
@@ -383,10 +528,35 @@ pub(crate) async fn router(req: StorageWorkerRequest) -> Result<StorageWorkerRes
                 "[{WORKER_NAME}] fetch ASP secret for the account {}",
                 Sensitive(&address)
             );
-            let opt = with_storage!(s => s.get_user_keys(&address)?)?;
+            let required = configured_binding()?;
+            let opt = with_storage!(s => s.get_user_keys_bound(&address, required)?)?.into_found();
             StorageWorkerResponse::AspSecret(opt.map(|keys| AspSecret {
                 membership_blinding: keys.membership_blinding,
             }))
+        }
+        StorageWorkerRequest::KeyBindingStatus(address) => {
+            tracing::trace!(
+                "[{WORKER_NAME}] key binding status for the account {}",
+                Sensitive(&address)
+            );
+            // Metadata-only: reads the binding columns, never a key blob.
+            let required = configured_binding()?;
+            let status = match with_storage!(s => s.key_binding(&address)?)? {
+                None => KeyBindingStatus::Absent,
+                Some(binding) => {
+                    if binding.version == required
+                        && (binding.version == BindingVersion::V1
+                            || binding.bound_owner.as_deref() == Some(address.as_str()))
+                    {
+                        KeyBindingStatus::Acceptable
+                    } else {
+                        KeyBindingStatus::Mismatch {
+                            stored: binding.version.into(),
+                        }
+                    }
+                }
+            };
+            StorageWorkerResponse::KeyBindingStatus(status)
         }
         StorageWorkerRequest::UserNotes(address, limit) => {
             tracing::trace!(
@@ -615,6 +785,28 @@ impl Clone for StorageBridge {
 impl StorageBridge {
     pub(crate) fn new(bridge: OneshotBridge<StorageWorker>) -> Self {
         Self { bridge }
+    }
+
+    /// Tell the worker which binding this deployment requires.
+    ///
+    /// Must be sent before any request that touches key material. The worker
+    /// holds the only copy of the requirement and every route reads it from
+    /// there, so this bridge deliberately keeps none of its own: a second copy
+    /// could go stale, and defaulting one would accept a v1 row on a
+    /// deployment that requires v2.
+    pub(crate) async fn configure_binding(&self, required: BindingVersion) -> Result<()> {
+        match self
+            .call(
+                StorageWorkerRequest::ConfigureBinding(required.into()),
+                5_000,
+            )
+            .await?
+        {
+            StorageWorkerResponse::Saved => Ok(()),
+            other => Err(anyhow!(
+                "unexpected response configuring binding: {other:?}"
+            )),
+        }
     }
 
     pub(crate) async fn call(
@@ -923,6 +1115,15 @@ impl Storage for StorageBridge {
             ))),
             Err(e) => Err(Error::Other(e.to_string())),
         }
+    }
+
+    fn set_required_binding(&mut self, required: BindingVersion) {
+        // The worker holds the single copy and every route that touches key
+        // material reads it from there, so there is nothing to store here. The
+        // client configures it with `configure_binding`, which is async and so
+        // can actually reach the worker; a copy on this side could only go
+        // stale, and a defaulted one would be worse than none.
+        let _ = required;
     }
 
     async fn user_keys(&self, user_address: &str) -> Result<StoredUserKeys, Error> {


### PR DESCRIPTION
Privacy keys are derived from a wallet signature over a constant message, so the signer owns the derived note key, encryption key and ASP membership blinding. That holds together only because `ensure_signer_is_note_owner` currently refuses any session where the two differ (#548). The moment a deployment separates the fee-paying signer from the note owner, a delegate's signature becomes the owner's key material — the delegate can decrypt the owner's notes and forge spend proofs, and the owner cannot recover without them.

This lands the binding ahead of that split, so the split can be enabled without the derivation being wrong the day it is.

## What

A key binding selected per deployment by `ContractConfig::signer_may_differ_from_owner`:

- **v1** — the existing split-free derivation, unchanged and byte-identical, retained permanently as the correct binding wherever the payer is the owner.
- **v2** — derives from a signature over `Privacy Pool Key Derivation [v2] owner=<G-address>`, verified locally against the Ed25519 key decoded from the owner's address before anything is derived from it.

Deployment-selected rather than per-account, because a client always knows which deployment it is on, but cannot tell a new account from a recovering one on empty storage. Each deployment accepts exactly the binding it derives, so recovery from the owner's secret alone always works and no account is asked to re-derive.

## Enforcement

- `schema_v3_key_binding.sql` adds `binding_version` (defaulted to 1, so existing rows are classified, not unknown) and `bound_owner`.
- Both SQL reads of `keypairs` take the required binding — the only place both platforms pass through. A wrapper-level check would cover native only, since `Storage` has two implementations and every web read goes over the worker protocol.
- An unconfigured handle **refuses**. Defaulting to v1 would accept a v1 row on a v2 deployment, which is fail-open in the one direction that matters.
- The storage worker holds the requirement, set once and refusing a conflicting change; reads and the write both take it from there, so no request can select the unverified path.
- Status moves to a metadata-only route that never touches a key blob, so "is this account onboarded" is answerable without a route that returns secrets — and the UI can distinguish *no keys* from *keys unusable here*.

## Verification

- native lib **317 passed**, web wasm32 **12 passed**, e2e-freighter unit **43 passed**
- `cargo clippy --workspace --all-targets` and `cargo fmt --check` clean
- e2e-freighter `01-connect` run 20× against a freshly provisioned profile
- migration test applies only the first two migrations, writes through the pre-v3 path, then forward-migrates — rather than trusting the DEFAULT clause
- tests pin: two owners with the same signature diverging on all three branches, v1 signatures unable to produce v2 material, non-owner signatures refused before anything is stored, clean-install recovery on both bindings, fork preserving the requirement, and an unconfigured handle refusing

## Out of scope

- **Sessions where signer ≠ owner remain refused**, natively and on web. This PR makes the derivation correct for that world; enabling it is separate work.
- **Enabling the flag on a deployment with live v1 accounts.** Those hold notes under v1 keys and re-deriving would shadow rather than replace them; making both usable needs per-note binding provenance.
- **The SEP-53 test vector is self-consistent.** It verifies the reconstruction against itself, not against a signature captured from the real Stellar CLI or Freighter, so cross-platform agreement is argued rather than pinned.
