### PR TITLE
Check for the note owner where an owner signature is needed

### DIFF
--- a/sdk/native/src/account.rs
+++ b/sdk/native/src/account.rs
@@ -142,11 +142,20 @@ impl<S: Storage> Account<S> {
     }
 
     /// Register this account's public keys on the deployment-wide registry.
+    ///
+    /// # Errors
+    /// Returns [`Error::SignerIsNotNoteOwner`] on a delegated session. The
+    /// registry entry is the owner's, so simulation returns an auth entry
+    /// keyed to the owner; the payer's wallet is only asked to sign for its
+    /// own account and has nothing to put there. Checked before the call so a
+    /// delegated session stops here rather than at an unfillable auth entry.
     pub async fn register_public_keys(
         &self,
         note_public_key: Option<NotePublicKey>,
         encryption_public_key: Option<EncryptionPublicKey>,
     ) -> Result<TransactionResult, Error> {
+        ensure_signer_is_note_owner(&self.user_address, &self.signer_address)?;
+
         let (note_pk, enc_pk) = match (note_public_key, encryption_public_key) {
             (Some(note), Some(enc)) => (note, enc),
             (None, None) => {
@@ -164,9 +173,8 @@ impl<S: Storage> Account<S> {
         let fetcher = StateFetcher::new(self.rpc.clone(), self.contract_config.clone())
             .map_err(|e| Error::Other(format!("state fetcher: {e:#}")))?;
         let prepared = fetcher
-            // The owner is the registration; the signer only pays for it. When
-            // the two differ the simulation returns an auth entry for the
-            // owner, which the signer cannot supply on its own.
+            // The owner is the registration; the signer only pays for it.
+            // Both are the owner here, per the check above.
             .prepare_register(
                 &self.user_address,
                 &self.signer_address,
@@ -207,5 +215,97 @@ impl<S: Storage> Account<S> {
         self.sync
             .ensure_synced(&self.rpc, &self.storage, &self.contract_config)
             .await
+    }
+}
+
+/// Refuse an operation that needs the note owner's own signature when the
+/// session signs with a different account.
+///
+/// Call this only from the steps whose signature the owner alone can produce.
+/// Opening a session and spending from it are not among them: both run
+/// entirely on the payer's signature.
+pub(crate) fn ensure_signer_is_note_owner(
+    user_address: &NoteOwnerAddress,
+    signer_address: &SignerAddress,
+) -> Result<(), Error> {
+    if signer_address.as_str() == user_address.as_str() {
+        return Ok(());
+    }
+    Err(Error::SignerIsNotNoteOwner {
+        owner: user_address.as_str().to_string(),
+        signer: signer_address.as_str().to_string(),
+    })
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod signer_is_note_owner_tests {
+    use super::*;
+
+    const OWNER: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+    const DELEGATE: &str = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB6BQ";
+
+    #[test]
+    fn the_owner_signing_for_itself_is_accepted() {
+        let result =
+            ensure_signer_is_note_owner(&NoteOwnerAddress::new(OWNER), &SignerAddress::new(OWNER));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn a_delegate_signing_for_the_owner_is_refused() {
+        let error = ensure_signer_is_note_owner(
+            &NoteOwnerAddress::new(OWNER),
+            &SignerAddress::new(DELEGATE),
+        )
+        .expect_err("a payer that is not the note owner must not produce an owner signature");
+
+        match &error {
+            Error::SignerIsNotNoteOwner { owner, signer } => {
+                assert_eq!(owner, OWNER);
+                assert_eq!(signer, DELEGATE);
+            }
+            other => panic!("expected SignerIsNotNoteOwner, got {other:?}"),
+        }
+
+        // Both addresses stay available to code; the rendered string redacts
+        // them. Not asserted here: the reveal flag is a process global that
+        // logging.rs's own tests toggle under a mutex this module cannot reach.
+    }
+
+    /// The app classifies a wallet cancellation by substring. An
+    /// owner-signature refusal is not one, and must not read like one.
+    #[test]
+    fn the_refusal_does_not_read_as_a_wallet_cancellation() {
+        let rendered = ensure_signer_is_note_owner(
+            &NoteOwnerAddress::new(OWNER),
+            &SignerAddress::new(DELEGATE),
+        )
+        .expect_err("a divergent pair must be refused")
+        .to_string()
+        .to_ascii_lowercase();
+
+        for word in ["rejected", "denied", "cancelled", "canceled"] {
+            assert!(
+                !rendered.contains(word),
+                "{word:?} would be read as a wallet cancellation: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_comparison_is_exact() {
+        // Strkeys are canonical; near-misses are different accounts.
+        let owner = NoteOwnerAddress::new(OWNER);
+        for near_miss in [
+            OWNER.to_ascii_lowercase(),
+            format!(" {OWNER}"),
+            String::new(),
+        ] {
+            assert!(
+                ensure_signer_is_note_owner(&owner, &SignerAddress::new(near_miss.as_str()))
+                    .is_err(),
+                "near-miss signer {near_miss:?} must be refused"
+            );
+        }
     }
 }

--- a/sdk/native/src/client.rs
+++ b/sdk/native/src/client.rs
@@ -137,10 +137,14 @@ impl<S: Storage> Client<S> {
 
     /// Create an [`Account`] session.
     ///
+    /// `signer_address` need not be `user_address`: the signer pays and
+    /// sources every envelope, the owner holds the notes. The two operations
+    /// that need the owner's own signature check for themselves — see
+    /// [`Account::register_public_keys`] and [`Error::SignerIsNotNoteOwner`].
+    ///
     /// # Errors
-    /// Returns [`Error::SignerIsNotNoteOwner`] if `signer_address` is not the
-    /// same account as `user_address`, or a storage error if the session's
-    /// storage handle cannot be forked.
+    /// Returns a storage error if the session's storage handle cannot be
+    /// forked.
     #[tracing::instrument(
         name = "client_account",
         skip_all,
@@ -152,7 +156,6 @@ impl<S: Storage> Client<S> {
         signer_address: SignerAddress,
         signer: Handle<dyn Signer>,
     ) -> Result<Account<S>, Error> {
-        ensure_signer_is_note_owner(&user_address, &signer_address)?;
         Ok(Account::new(
             self.rpc.clone(),
             self.storage.fork()?,
@@ -178,23 +181,8 @@ impl<S: Storage> Client<S> {
     }
 }
 
-/// Reject a session whose signing account is not the note owner. See
-/// [`Error::SignerIsNotNoteOwner`] for why the two may not differ.
-fn ensure_signer_is_note_owner(
-    user_address: &NoteOwnerAddress,
-    signer_address: &SignerAddress,
-) -> Result<(), Error> {
-    if signer_address.as_str() == user_address.as_str() {
-        return Ok(());
-    }
-    Err(Error::SignerIsNotNoteOwner {
-        owner: user_address.as_str().to_string(),
-        signer: signer_address.as_str().to_string(),
-    })
-}
-
 #[cfg(all(test, not(target_arch = "wasm32")))]
-mod signer_is_note_owner_tests {
+mod divergent_session_tests {
     use super::*;
     use crate::{LocalSigner, LocalStorage};
 
@@ -203,51 +191,6 @@ mod signer_is_note_owner_tests {
     /// Ed25519 secret for `SigningKey::from_bytes(&[7u8; 32])`.
     const SECRET: &str = "SADQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQP54X";
     const PASSPHRASE: &str = "Test SDF Network ; September 2015";
-
-    #[test]
-    fn the_owner_signing_for_itself_is_accepted() {
-        let result =
-            ensure_signer_is_note_owner(&NoteOwnerAddress::new(OWNER), &SignerAddress::new(OWNER));
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn a_delegate_signing_for_the_owner_is_refused() {
-        let error = ensure_signer_is_note_owner(
-            &NoteOwnerAddress::new(OWNER),
-            &SignerAddress::new(DELEGATE),
-        )
-        .expect_err("a signer that is not the note owner must not open a session");
-
-        match &error {
-            Error::SignerIsNotNoteOwner { owner, signer } => {
-                assert_eq!(owner, OWNER);
-                assert_eq!(signer, DELEGATE);
-            }
-            other => panic!("expected SignerIsNotNoteOwner, got {other:?}"),
-        }
-
-        // Both addresses stay available to code; the rendered string redacts
-        // them. Not asserted here: the reveal flag is a process global that
-        // logging.rs's own tests toggle under a mutex this module cannot reach.
-    }
-
-    #[test]
-    fn the_comparison_is_exact() {
-        // Strkeys are canonical; near-misses are different accounts.
-        let owner = NoteOwnerAddress::new(OWNER);
-        for near_miss in [
-            OWNER.to_ascii_lowercase(),
-            format!(" {OWNER}"),
-            String::new(),
-        ] {
-            assert!(
-                ensure_signer_is_note_owner(&owner, &SignerAddress::new(near_miss.as_str()))
-                    .is_err(),
-                "near-miss signer {near_miss:?} must be refused"
-            );
-        }
-    }
 
     fn test_client() -> Client<LocalStorage> {
         static RUN: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
@@ -282,18 +225,20 @@ mod signer_is_note_owner_tests {
         ) as Box<dyn Signer>)
     }
 
-    // Through the public API, so moving or dropping the guard fails here too.
+    // A delegated session signs and pays as one account and owns notes as
+    // another. Nothing here asks for an owner signature, so nothing here has
+    // cause to compare the two.
     #[test]
-    fn client_account_refuses_a_divergent_pair() {
-        let error = test_client()
+    fn client_account_opens_a_divergent_pair() {
+        let account = test_client()
             .account(
                 NoteOwnerAddress::new(OWNER),
                 SignerAddress::new(DELEGATE),
                 test_signer(DELEGATE),
             )
-            .err()
-            .expect("Client::account must refuse a signer that is not the note owner");
-        assert!(matches!(error, Error::SignerIsNotNoteOwner { .. }));
+            .expect("a payer that is not the note owner must still open a session");
+        assert_eq!(account.user_address().as_str(), OWNER);
+        assert_eq!(account.signer_address().as_str(), DELEGATE);
     }
 
     #[test]

--- a/sdk/native/src/error.rs
+++ b/sdk/native/src/error.rs
@@ -29,15 +29,17 @@ pub enum Error {
     #[error("wallet request rejected by user: {0}")]
     UserRejected(String),
 
-    /// The signing account is not the note owner.
+    /// An operation needs the note owner's own signature, and the session
+    /// signs with a different account.
     ///
-    /// The two transaction paths disagree on which identity drives them:
-    /// transact sources the envelope, `sender` and sequence number from the
-    /// signer, registration from the owner. Which is right when they differ is
-    /// unsettled, so a divergent pair is refused rather than resolved here.
+    /// A session may hold a divergent pair: the payer sources the envelope,
+    /// `sender` and sequence number, and spending needs nothing else. Two
+    /// operations do need the owner itself — key derivation, whose signature
+    /// *is* the note secret, and registration, whose simulated auth entry is
+    /// the owner's. Those raise this; the session as a whole does not.
     // Escapes to a UI toast, the telemetry ring buffer and CLI logs.
     #[error(
-        "signing account {} is not the note owner {}; a session where they differ is not supported",
+        "signing account {} cannot sign for the note owner {}; this step needs the owner's own signature",
         crate::types::Sensitive(signer),
         crate::types::Sensitive(owner)
     )]

--- a/sdk/web/src/client/mod.rs
+++ b/sdk/web/src/client/mod.rs
@@ -209,6 +209,11 @@ impl Client {
 
     /// Bind a wallet signer, derive privacy keys when missing, and return an
     /// [`Account`] session.
+    ///
+    /// `signerAddress` may name an account other than the note owner; that
+    /// session signs and pays while the owner holds the notes. Deriving the
+    /// owner's keys is the one part of opening a session that the owner alone
+    /// can do, so it — and only it — refuses a divergent pair.
     pub async fn account(&self, options: JsValue, signer: JsValue) -> Result<Account, JsError> {
         with_correlation_id(new_correlation_id(), async {
             let opts = AccountOptions::from_value(options)?;
@@ -220,7 +225,6 @@ impl Client {
                     .map(str::to_string)
                     .unwrap_or_else(|| user_address.clone()),
             );
-            ensure_signer_is_note_owner(&user_address, &signer_address).map_err(pool_err)?;
             let wallet_signer = WalletSigner::new(
                 signer,
                 opts.network_passphrase().to_string(),
@@ -228,6 +232,14 @@ impl Client {
             )?;
 
             if !self.user_keys_exist(&user_address).await? {
+                // The derivation signature *is* the note secret. WalletSigner
+                // asks the wallet for the account it signs with, so on a
+                // divergent pair the wallet would sign with the payer and the
+                // payer's keypair would be filed under the owner's address —
+                // wrong keys, silently, and persisted. Refuse instead. An
+                // owner whose keys already exist skips this and delegates.
+                ensure_signer_is_note_owner(&user_address, wallet_signer.signer_address())
+                    .map_err(pool_err)?;
                 let message =
                     stellar_private_payments::zk::encryption::KEY_DERIVATION_MESSAGE.to_string();
                 let sig_hex = wallet_signer.sign_wallet_message(&message).await?;
@@ -441,13 +453,12 @@ impl Client {
     }
 }
 
-/// Refuse a session whose signing account is not the note owner.
+/// Refuse key derivation on a session that signs with an account other than
+/// the note owner.
 ///
-/// The native client refuses the same pair, but only once the wallet has
-/// already been asked to sign the derivation message and the resulting keys
-/// have been filed under the owner. This runs first, so a rejected pair costs
-/// no signature request and writes nothing. It raises the native error rather
-/// than a parallel message, so the two cannot drift.
+/// Checked before the wallet is asked for the derivation signature, so a
+/// divergent pair costs no signature request and writes nothing. It raises the
+/// native error rather than a parallel message, so the two cannot drift.
 fn ensure_signer_is_note_owner(
     user_address: &str,
     signer_address: &SignerAddress,
@@ -502,28 +513,48 @@ async fn resolve_user_address(
         .ok_or_else(|| JsError::new("getPublicKey did not return a string"))
 }
 
-#[cfg(test)]
+// `wasm_bindgen_test`, not `test`: this crate's suite runs under the
+// wasm32 harness, which does not collect plain `#[test]` functions.
+#[cfg(all(test, target_arch = "wasm32"))]
 mod signer_is_note_owner_tests {
     use super::*;
+    use wasm_bindgen_test::*;
 
     const OWNER: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
     const DELEGATE: &str = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB6BQ";
 
-    #[test]
+    #[wasm_bindgen_test]
     fn the_owner_signing_for_itself_is_accepted() {
         assert!(ensure_signer_is_note_owner(OWNER, &SignerAddress::new(OWNER)).is_ok());
     }
 
-    #[test]
+    #[wasm_bindgen_test]
     fn a_delegate_signing_for_the_owner_is_refused() {
         let error = ensure_signer_is_note_owner(OWNER, &SignerAddress::new(DELEGATE))
-            .expect_err("a signer that is not the note owner must not open a session");
+            .expect_err("a payer that is not the note owner must not derive the owner's keys");
         match &error {
             Error::SignerIsNotNoteOwner { owner, signer } => {
                 assert_eq!(owner, OWNER);
                 assert_eq!(signer, DELEGATE);
             }
             other => panic!("expected SignerIsNotNoteOwner, got {other:?}"),
+        }
+    }
+
+    /// The app classifies a wallet cancellation by substring, and this refusal
+    /// reaches the same handler. It must not read like one.
+    #[wasm_bindgen_test]
+    fn the_refusal_does_not_read_as_a_wallet_cancellation() {
+        let rendered = ensure_signer_is_note_owner(OWNER, &SignerAddress::new(DELEGATE))
+            .expect_err("a divergent pair must be refused")
+            .to_string()
+            .to_ascii_lowercase();
+
+        for word in ["rejected", "denied", "cancelled", "canceled"] {
+            assert!(
+                !rendered.contains(word),
+                "{word:?} would be read as a wallet cancellation: {rendered}"
+            );
         }
     }
 }


### PR DESCRIPTION
Client::account refused any session whose signer was not the note owner, so no session could hold a divergent pair. Spending never needed the owner: pool.rs builds transact from the signer address, and the contract asks only for sender.require_auth() plus the funding transfer. The check comes off session open, and a delegated session now opens.

Two operations do need the owner itself, and each now checks for it. Key derivation's signature is the note secret, and WalletSigner asks the wallet for the single account it holds; on a divergent pair the wallet would sign with the payer and the payer's keypair would be filed under the owner's address, silently and persisted. The web client checks inside the missing-keys branch, before the wallet is asked for anything. Registration's simulated auth entry is keyed to the owner and the payer has nothing to put there, so Account::register_public_keys checks before preparing the call rather than failing at an unfillable entry.

The check itself moves from client.rs to account.rs, beside its native caller. SignerIsNotNoteOwner said a session where the two differ is not supported, which is no longer true: it now names the step that needs the signature rather than the session, and stays clear of the substrings the app's cancellation classifier matches.

A delegated session still cannot bootstrap an owner that has never derived keys — the owner opens a session once with its own account first. Lifting that means a second address on WalletSigner for message signing, which is not this change.

The web guard tests were plain #[test] in a crate whose suite runs under the wasm32 harness, so nothing ever collected them. They run as wasm_bindgen_test now, alongside a new one on each side asserting the refusal does not read as a wallet cancellation.

## Before merging

This is the change that turns delegation on, so the deposit debit wants a decision. pool.rs:448 is `token_client.transfer(&sender, &this, &amount)` and `sender` is the payer, so under a divergent pair the payer's token balance funds the deposit while the note is credited to the owner. The payer is not only covering fees, it is covering the principal. That may be the intent for a funding-agent deployment, but nothing at the call site makes the size of the grant visible.