### PR TITLE
Add --sign-as so a separate account pays for the owner's notes

### DIFF
--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -4,6 +4,10 @@
 //! named by an alias and resolved to an address through the Stellar CLI.
 //! Transaction signing is delegated to `stellar tx sign` via
 //! [`crate::signer::AliasSigner`].
+//!
+//! One of these stands behind each of the two roles a session holds: the owner
+//! that the notes belong to (`--account`) and the payer that sources and signs
+//! every envelope (`--sign-as`, defaulting to the owner).
 
 use std::path::Path;
 
@@ -11,7 +15,8 @@ use anyhow::Result;
 
 use crate::stellar_cli;
 
-/// A signing account backed by a Stellar CLI alias.
+/// An account backed by a Stellar CLI alias, in either the owner or the payer
+/// role.
 ///
 /// The alias fully identifies the account (the Stellar CLI stores each identity
 /// with its own derivation), so no HD path is threaded here.
@@ -23,9 +28,12 @@ pub struct Account {
     pub address: String,
 }
 
-/// Resolve a `--account` alias to an [`Account`] via the Stellar CLI.
-pub fn resolve(alias: &str, config_dir: Option<&Path>) -> Result<Account> {
-    stellar_cli::validate_alias(alias)?;
+/// Resolve an alias to an [`Account`] via the Stellar CLI.
+///
+/// `flag` is the option the alias came from (`--account`, `--sign-as`), so a
+/// value that is not an alias is reported against the one the user typed.
+pub fn resolve(flag: &str, alias: &str, config_dir: Option<&Path>) -> Result<Account> {
+    stellar_cli::validate_alias(flag, alias)?;
     let address = stellar_cli::public_key(alias, config_dir)?;
     Ok(Account {
         alias: alias.to_string(),

--- a/cli/src/config/mod.rs
+++ b/cli/src/config/mod.rs
@@ -3,7 +3,10 @@ mod toml;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
-use stellar_private_payments::{state::SqliteStorage, types::ContractConfig};
+use stellar_private_payments::{
+    state::SqliteStorage,
+    types::{ContractConfig, Sensitive},
+};
 
 use crate::{
     account::{Account, resolve},
@@ -24,6 +27,10 @@ pub const EMBEDDED_DEPLOYMENT_LABEL: &str = "embedded:testnet";
 /// Deployment config provisioned into the data dir by `scripts/install.sh`.
 pub const DEPLOYMENT_FILE_NAME: &str = "deployments.json";
 
+/// Flag names, so a rejected alias is reported against the option it came from.
+const ACCOUNT_FLAG: &str = "--account";
+const SIGN_AS_FLAG: &str = "--sign-as";
+
 /// CLI flag overrides used to build a [`CliConfig`].
 #[derive(Debug, Default)]
 pub struct CliConfigOverrides {
@@ -31,6 +38,7 @@ pub struct CliConfigOverrides {
     pub network: Option<String>,
     pub data_dir: Option<PathBuf>,
     pub account: Option<String>,
+    pub sign_as: Option<String>,
     pub stellar_config_dir: Option<PathBuf>,
     pub circuits_dir: Option<PathBuf>,
 }
@@ -38,8 +46,9 @@ pub struct CliConfigOverrides {
 /// Resolved (offline) CLI configuration.
 ///
 /// Loading never calls the `stellar` binary; the RPC/passphrase (via
-/// [`CliConfig::resolve_network`]) and the signing account (via
-/// [`CliConfig::require_account`]) are resolved on demand by the commands that
+/// [`CliConfig::resolve_network`]), the note owner (via
+/// [`CliConfig::require_account`]) and the payer (via
+/// [`CliConfig::require_signer`]) are resolved on demand by the commands that
 /// need them.
 #[derive(Debug, Clone)]
 pub struct CliConfig {
@@ -53,8 +62,11 @@ pub struct CliConfig {
     pub data_dir: PathBuf,
     /// Config dir passed through to the `stellar` CLI (`--config-dir`).
     pub stellar_config_dir: Option<PathBuf>,
-    /// `stellar keys` alias supplied via `--account`.
+    /// `stellar keys` alias supplied via `--account`: the note owner.
     pub account: Option<String>,
+    /// `stellar keys` alias supplied via `--sign-as`: the payer that sources
+    /// and signs every envelope. `None` means the owner pays for itself.
+    pub sign_as: Option<String>,
     pub circuits_dir: Option<PathBuf>,
 }
 
@@ -70,6 +82,7 @@ impl CliConfig {
             network,
             data_dir,
             account,
+            sign_as,
             stellar_config_dir,
             circuits_dir,
         } = overrides;
@@ -98,6 +111,7 @@ impl CliConfig {
             data_dir,
             stellar_config_dir,
             account,
+            sign_as,
             circuits_dir,
         })
     }
@@ -107,7 +121,7 @@ impl CliConfig {
         stellar_cli::network(&self.network, self.stellar_config_dir.as_deref())
     }
 
-    /// Resolve the signing account from its `--account` alias.
+    /// Resolve the note owner from its `--account` alias.
     pub fn require_account(&self) -> Result<Account> {
         let alias = self.account.as_deref().ok_or_else(|| {
             anyhow::anyhow!(
@@ -115,7 +129,31 @@ impl CliConfig {
                  (spp works with Stellar CLI identities; see `stellar keys`)"
             )
         })?;
-        resolve(alias, self.stellar_config_dir.as_deref())
+        resolve(ACCOUNT_FLAG, alias, self.stellar_config_dir.as_deref())
+    }
+
+    /// Resolve the payer that sources and signs this session's envelopes.
+    ///
+    /// Without `--sign-as` the owner pays for itself, and the returned account
+    /// is `owner` unchanged — the single-alias behaviour, with no second
+    /// lookup through the Stellar CLI.
+    pub fn require_signer(&self, owner: &Account) -> Result<Account> {
+        match self.sign_as.as_deref() {
+            None => Ok(owner.clone()),
+            Some(alias) => resolve(SIGN_AS_FLAG, alias, self.stellar_config_dir.as_deref()),
+        }
+    }
+
+    /// Refuse a separate payer for a step that only the owner can perform.
+    ///
+    /// Onboarding derives the note secret from the owner's own signature and
+    /// files it under the owner's address, so a payer has nothing it could
+    /// contribute — signing with the owner's key regardless would honour the
+    /// `--account` half of the request while silently discarding the
+    /// `--sign-as` half. Call this before touching any state; the SDK raises
+    /// the equivalent refusal for registration.
+    pub fn ensure_owner_signs(&self, owner: &Account) -> Result<()> {
+        ensure_owner_is_signer(owner, &self.require_signer(owner)?)
     }
 
     pub fn db_path(&self) -> PathBuf {
@@ -135,6 +173,23 @@ impl CliConfig {
         let path = self.db_path();
         SqliteStorage::connect_file(&path).with_context(|| format!("open {}", path.display()))
     }
+}
+
+/// The refusal itself, split from the lookup so it can be tested without the
+/// Stellar CLI. Mirrors the SDK's `ensure_signer_is_note_owner`, which raises
+/// the equivalent for registration.
+fn ensure_owner_is_signer(owner: &Account, signer: &Account) -> Result<()> {
+    if signer.address == owner.address {
+        return Ok(());
+    }
+    bail!(
+        "signing account {} cannot stand in for the note owner {}; \
+         this step needs the owner's own signature. \
+         Re-run it with --account {} and without --sign-as.",
+        Sensitive(&signer.address),
+        Sensitive(&owner.address),
+        owner.alias
+    )
 }
 
 pub fn default_data_dir() -> PathBuf {
@@ -183,5 +238,104 @@ pub fn validate_pool(pool: &str, deployment: &ContractConfig) -> Result<()> {
         Ok(())
     } else {
         bail!("pool {pool} is not an enabled pool in the deployment config");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CliConfig, CliConfigOverrides};
+    use crate::account::Account;
+
+    const OWNER_ADDRESS: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+    const PAYER_ADDRESS: &str = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB6BQ";
+    /// Shaped like a raw secret key: 56 characters starting with `S`.
+    const SECRET_SHAPED: &str = "SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    /// A config over the embedded testnet deployment. The data dir is a name
+    /// that holds no provisioned `deployments.json`, so loading stays offline
+    /// and independent of the machine's own wallet directory.
+    fn config_with(sign_as: Option<&str>) -> CliConfig {
+        CliConfig::load(
+            None,
+            None,
+            CliConfigOverrides {
+                data_dir: Some(std::env::temp_dir().join("spp-require-signer-tests")),
+                account: Some("owner".to_string()),
+                sign_as: sign_as.map(str::to_string),
+                ..Default::default()
+            },
+        )
+        .expect("the embedded testnet deployment should load")
+    }
+
+    fn owner() -> Account {
+        Account {
+            alias: "owner".to_string(),
+            address: OWNER_ADDRESS.to_string(),
+        }
+    }
+
+    #[test]
+    fn without_sign_as_the_owner_pays_for_itself() {
+        let owner = owner();
+        let signer = config_with(None)
+            .require_signer(&owner)
+            .expect("the owner needs no lookup to stand in for itself");
+
+        assert_eq!(signer.alias, owner.alias);
+        assert_eq!(signer.address, owner.address);
+    }
+
+    #[test]
+    fn onboarding_steps_refuse_a_payer_that_is_not_the_owner() {
+        let payer = Account {
+            alias: "payer".to_string(),
+            address: PAYER_ADDRESS.to_string(),
+        };
+        let error = super::ensure_owner_is_signer(&owner(), &payer)
+            .expect_err("the derivation signature is the note secret; only the owner has it");
+        let message = error.to_string();
+
+        assert!(
+            message.starts_with("signing account <redacted> cannot stand in for the note owner"),
+            "both addresses are Tier-1 and must be redacted, got: {message}"
+        );
+        assert!(
+            !message.contains(PAYER_ADDRESS) && !message.contains(OWNER_ADDRESS),
+            "no address may survive into the rendered message, got: {message}"
+        );
+        // The app classifies a wallet cancellation by substring; this refusal
+        // is not one, so it must not carry any of the words that classifier
+        // looks for.
+        let lowercased = message.to_lowercase();
+        for banned in ["rejected", "denied", "cancelled"] {
+            assert!(
+                !lowercased.contains(banned),
+                "`{banned}` would be read as a wallet cancellation, got: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_owner_signing_for_itself_is_accepted() {
+        super::ensure_owner_is_signer(&owner(), &owner())
+            .expect("the owner is always allowed to sign its own onboarding");
+        config_with(None)
+            .ensure_owner_signs(&owner())
+            .expect("without --sign-as the owner signs for itself");
+    }
+
+    #[test]
+    fn sign_as_is_validated_before_the_stellar_cli_is_asked() {
+        let error = config_with(Some(SECRET_SHAPED))
+            .require_signer(&owner())
+            .expect_err("a raw secret key must never reach the command line");
+
+        assert!(
+            error
+                .to_string()
+                .starts_with("--sign-as must be a `stellar keys` alias name, not a raw secret key"),
+            "the payer's alias should be reported against --sign-as, got: {error}"
+        );
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -27,6 +27,9 @@ use onboard::OnboardArgs;
         Accounts are managed by the Stellar CLI (`stellar keys`) and passed with \
         --account <alias>; the network (RPC + passphrase) is resolved from the Stellar CLI \
         (`stellar network`). Run `spp onboard` first to accept the disclaimer and derive your keys.\n\n\
+        --account names the account that owns the notes. By default it also sources and pays for \
+        every transaction; pass --sign-as <alias> to hand those to a separate payer. Deriving keys \
+        and registering them need the owner's own signature and refuse a separate payer.\n\n\
         Repository: https://github.com/NethermindEth/stellar-private-payments",
     version
 )]
@@ -59,9 +62,14 @@ struct Cli {
     #[arg(long, global = true)]
     circuits_dir: Option<PathBuf>,
 
-    /// `stellar keys` alias to act as (required by account commands)
+    /// `stellar keys` alias that owns the notes (required by account commands)
     #[arg(long, global = true, env = "STELLAR_ACCOUNT")]
     account: Option<String>,
+
+    /// `stellar keys` alias that sources, signs and pays for every envelope and
+    /// acts as the pool sender (default: --account)
+    #[arg(long, global = true)]
+    sign_as: Option<String>,
 
     /// Emit JSON instead of human-readable output
     #[arg(long, global = true)]
@@ -170,7 +178,8 @@ enum Commands {
         pool: String,
         /// Amount in token units (e.g. 1 or 0.0001)
         amount: String,
-        /// Public recipient (G…); defaults to the signing account
+        /// Public recipient (G…); defaults to the note owner (--account), not
+        /// the payer
         #[arg(long)]
         to: Option<String>,
     },
@@ -262,6 +271,7 @@ fn main() -> Result<()> {
             network: cli.network,
             data_dir: cli.data_dir,
             account: cli.account,
+            sign_as: cli.sign_as,
             stellar_config_dir: cli.stellar_config_dir,
             circuits_dir: cli.circuits_dir,
         },

--- a/cli/src/onboard.rs
+++ b/cli/src/onboard.rs
@@ -5,6 +5,9 @@
 //! → explorer → optional public-key registration. Consent gates every protocol
 //! operation; resolving an address via `stellar keys` is not itself an
 //! operation. Step texts are reused from the app.
+//!
+//! Every step here belongs to the note owner, so onboarding refuses a
+//! `--sign-as` payer outright instead of running as the owner anyway.
 
 use std::io::Write;
 
@@ -73,8 +76,12 @@ pub fn run(config: &CliConfig, args: &OnboardArgs, json: bool) -> Result<()> {
     let version = stellar_cli::ensure_installed()?;
     log::info!("Found Stellar CLI: {version}");
 
-    // 2. Resolve the account (via `stellar keys`).
+    // 2. Resolve the account (via `stellar keys`). Onboarding is the owner's
+    //    own errand end to end — the derivation signature *is* the note secret
+    //    — so a `--sign-as` payer is refused here, before consent is recorded
+    //    or any key is derived, rather than being quietly ignored.
     let account = config.require_account()?;
+    config.ensure_owner_signs(&account)?;
     let mut storage = config.open_storage()?;
 
     // 3. Consent.

--- a/cli/src/session.rs
+++ b/cli/src/session.rs
@@ -10,7 +10,7 @@ use stellar_private_payments::{
     Handle, LocalProver, LocalStorage, Prover, Signer,
     blocking::{Account as SdkAccount, Client, PrivatePool},
     types::{
-        EncryptionPublicKey, NoteAmount, NoteOwnerAddress, NotePublicKey, SignerAddress,
+        EncryptionPublicKey, NoteAmount, NoteOwnerAddress, NotePublicKey, Sensitive, SignerAddress,
         TransferRecipient,
     },
 };
@@ -24,9 +24,13 @@ pub struct ClientSession {
 impl ClientSession {
     /// Bind wallet + deployment. `readonly` skips circuit artifact load
     /// (balance/notes/sync only).
+    ///
+    /// `owner` holds the notes; the payer that sources and signs every
+    /// envelope comes from [`CliConfig::require_signer`] and is `owner` itself
+    /// unless `--sign-as` named another alias.
     pub fn new(
         config: &CliConfig,
-        account: &Account,
+        owner: &Account,
         network: &StellarNetwork,
         readonly: bool,
     ) -> Result<Self> {
@@ -63,13 +67,7 @@ impl ClientSession {
             )
             .map_err(|e| anyhow::anyhow!("init client: {e}"))?
         };
-        let sdk_account = client
-            .account(
-                NoteOwnerAddress::new(account.address.as_str()),
-                SignerAddress::new(account.address.as_str()),
-                alias_signer(config, account, network),
-            )
-            .map_err(|e| anyhow::anyhow!("open account session: {e}"))?;
+        let sdk_account = open_account(&client, config, owner, network)?;
 
         Ok(Self {
             client,
@@ -77,19 +75,14 @@ impl ClientSession {
         })
     }
 
+    /// As [`Self::new`], over a disclosure-only client.
     pub fn new_disclosure(
         config: &CliConfig,
-        account: &Account,
+        owner: &Account,
         network: &StellarNetwork,
     ) -> Result<Self> {
         let client = disclosure_client(config, network)?;
-        let sdk_account = client
-            .account(
-                NoteOwnerAddress::new(account.address.as_str()),
-                SignerAddress::new(account.address.as_str()),
-                alias_signer(config, account, network),
-            )
-            .map_err(|e| anyhow::anyhow!("open account session: {e}"))?;
+        let sdk_account = open_account(&client, config, owner, network)?;
         Ok(Self {
             client,
             account: sdk_account,
@@ -156,13 +149,41 @@ pub fn disclosure_prover(config: &CliConfig) -> Result<LocalProver> {
         .map_err(|e| anyhow::anyhow!("init disclosure prover: {e}"))
 }
 
+/// Open the SDK session for the two roles: `owner` is the address the notes
+/// belong to, the payer sources and signs the envelopes and is the one whose
+/// alias reaches [`AliasSigner`].
+fn open_account(
+    client: &Client,
+    config: &CliConfig,
+    owner: &Account,
+    network: &StellarNetwork,
+) -> Result<SdkAccount> {
+    let signer = config.require_signer(owner)?;
+    if signer.address != owner.address {
+        log::info!(
+            "Signing as {} for notes owned by {}",
+            Sensitive(&signer.address),
+            Sensitive(&owner.address)
+        );
+    }
+    client
+        .account(
+            NoteOwnerAddress::new(owner.address.as_str()),
+            SignerAddress::new(signer.address.as_str()),
+            alias_signer(config, &signer, network),
+        )
+        .map_err(|e| anyhow::anyhow!("open account session: {e}"))
+}
+
+/// The signer delegates identity to the Stellar CLI keystore, so it needs the
+/// payer's alias and nothing else.
 fn alias_signer(
     config: &CliConfig,
-    account: &Account,
+    signer: &Account,
     network: &StellarNetwork,
 ) -> Handle<dyn Signer> {
     Handle::from_box(Box::new(AliasSigner {
-        alias: account.alias.clone(),
+        alias: signer.alias.clone(),
         rpc_url: network.rpc_url.clone(),
         network_passphrase: network.passphrase.clone(),
         config_dir: config.stellar_config_dir.clone(),

--- a/cli/src/stellar_cli.rs
+++ b/cli/src/stellar_cli.rs
@@ -305,18 +305,77 @@ pub fn network(name: &str, config_dir: Option<&Path>) -> Result<StellarNetwork> 
 
 /// Enforce alias-only usage: reject raw secret keys and seed phrases so secrets
 /// never appear on the command line or in config.
-pub fn validate_alias(value: &str) -> Result<()> {
+///
+/// `flag` is the option the value came from (`--account`, `--sign-as`), so the
+/// error names the one the user actually typed.
+pub fn validate_alias(flag: &str, value: &str) -> Result<()> {
     if value.chars().any(char::is_whitespace) {
         bail!(
-            "--account must be a `stellar keys` alias name, not a seed phrase; \
+            "{flag} must be a `stellar keys` alias name, not a seed phrase; \
              register one with `stellar keys add`/`stellar keys generate`"
         );
     }
     if value.len() == 56 && value.starts_with('S') {
         bail!(
-            "--account must be a `stellar keys` alias name, not a raw secret key; \
+            "{flag} must be a `stellar keys` alias name, not a raw secret key; \
              register one with `stellar keys add`"
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_alias;
+
+    /// Shaped like a raw secret key: 56 characters starting with `S`.
+    const SECRET_SHAPED: &str = "SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    #[test]
+    fn an_alias_name_is_accepted_for_either_flag() {
+        validate_alias("--account", "alice").expect("a plain alias is what both flags want");
+        validate_alias("--sign-as", "payer").expect("a plain alias is what both flags want");
+    }
+
+    #[test]
+    fn a_seed_phrase_is_reported_against_the_flag_it_came_from() {
+        let account = validate_alias("--account", "abandon abandon abandon")
+            .expect_err("a seed phrase must never reach the command line");
+        assert!(
+            account
+                .to_string()
+                .starts_with("--account must be a `stellar keys` alias name, not a seed phrase"),
+            "got: {account}"
+        );
+
+        let sign_as = validate_alias("--sign-as", "abandon abandon abandon")
+            .expect_err("a seed phrase must never reach the command line");
+        assert!(
+            sign_as
+                .to_string()
+                .starts_with("--sign-as must be a `stellar keys` alias name, not a seed phrase"),
+            "got: {sign_as}"
+        );
+    }
+
+    #[test]
+    fn a_raw_secret_key_is_reported_against_the_flag_it_came_from() {
+        let account = validate_alias("--account", SECRET_SHAPED)
+            .expect_err("a raw secret key must never reach the command line");
+        assert!(
+            account
+                .to_string()
+                .starts_with("--account must be a `stellar keys` alias name, not a raw secret key"),
+            "got: {account}"
+        );
+
+        let sign_as = validate_alias("--sign-as", SECRET_SHAPED)
+            .expect_err("a raw secret key must never reach the command line");
+        assert!(
+            sign_as
+                .to_string()
+                .starts_with("--sign-as must be a `stellar keys` alias name, not a raw secret key"),
+            "got: {sign_as}"
+        );
+    }
 }


### PR DESCRIPTION
# Add `--sign-as` so a separate account pays for the owner's notes

An address plays six roles in this codebase, and the CLI fused two of them by construction: `session.rs` resolved a single `--account` alias and passed the same string to `NoteOwnerAddress::new` and `SignerAddress::new`, twice over, in `ClientSession::new` and `::new_disclosure`. #548 split the pair in `types` and #573 split `prepare_register`'s source, and 59dbe95 took the owner-must-equal-signer check off `Client::account` so a divergent session opens at all. The SDK has been able to hold two identities for three PRs; the CLI was still the place that guaranteed it never would.

## Change

`--sign-as <alias>` is a global flag beside `--account`. `--account` names the account that owns the notes; `--sign-as` names the payer that sources, signs and pays for every envelope and acts as the pool `sender`. Absent, the owner fills both roles.

`CliConfig` grows `require_signer(&owner)` alongside `require_account()`. Without the flag it returns the owner unchanged — not a second lookup that happens to agree, but the same `Account`, so the single-alias path resolves exactly what it resolved before and never shells out to `stellar keys public-key` twice. `session.rs` folds the two duplicated open blocks into one `open_account`, which is also what keeps `AliasSigner` pointed at the payer's alias rather than the owner's. Every `ClientSession` caller still passes only the owner; payer resolution is internal, so `cmd/` is untouched.

Onboarding refuses a payer outright. Its derivation signature *is* the note secret, so a session that signs with anyone else would derive the payer's keypair and file it under the owner's address. `ensure_owner_signs` runs immediately after `require_account` and before `open_storage`, so a divergent pair exits without a database, let alone a signature — the SDK's `SignerIsNotNoteOwner` fires at `register_public_keys`, which is the right place for registration and too late for local key derivation. `ensure_owner_is_signer` is a free function so the refusal is testable without the Stellar CLI, mirroring how the SDK made its own guard testable.

Two things that would otherwise rot: `validate_alias` hardcoded `--account` in both of its refusals, so it now takes the flag it is reporting on and a secret key passed to `--sign-as` is named against `--sign-as`. Withdrawal keeps defaulting its recipient to the owner — it reads `require_account()`, which is untouched — but its help said "defaults to the signing account", which after this change would read as the payer.

Both addresses in the new refusal and in the divergence log line go through `Sensitive`. The refusal carries none of the substrings the app's cancellation classifier matches on, and a test asserts that rather than leaving it to review.

## Testing

Seven unit tests: the owner-pays-for-itself default, the onboarding refusal with its redaction and its wording, self-signing accepted through both entry points, and flag-correct refusal of seed phrases and raw secret keys for each flag.

The acceptance scenario — deposit as A, `--sign-as B` withdraw to C — is not automated, because nothing in the repo drives the `spp` binary: `e2e-tests/` is a contract/SDK crate and the Makefile's e2e targets drive the web app through Freighter. It is a live-testnet check. The onboarding hole above was found and fixed against a mock `stellar` on `STELLAR_BIN`, which is the cheapest harness for anything that turns on which alias gets shelled out to.