### PR TITLE
Add the pausable module and one admin accessor

### DIFF
--- a/contracts/asp-membership/src/lib.rs
+++ b/contracts/asp-membership/src/lib.rs
@@ -8,7 +8,9 @@
 use soroban_sdk::{
     Address, Env, U256, Vec, contract, contracterror, contractevent, contractimpl, contracttype,
 };
-use soroban_utils::{bump_entry, bump_instance, get_zeroes, poseidon2_compress};
+use soroban_utils::{
+    AdminError, bump_entry, bump_instance, get_admin, get_zeroes, poseidon2_compress,
+};
 
 /// Storage keys for contract persistent data
 #[contracttype]
@@ -54,6 +56,12 @@ struct LeafAddedEvent {
     index: u64,
     /// New Merkle root after insertion
     root: U256,
+}
+
+impl From<AdminError> for Error {
+    fn from(AdminError::NotInitialized: AdminError) -> Self {
+        Self::NotInitialized
+    }
 }
 
 /// ASP Membership contract
@@ -121,8 +129,7 @@ impl ASPMembership {
     /// stored.
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
         bump_instance(&env);
-        soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin)
-            .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
+        soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin).map_err(Error::from)
     }
 
     /// Get the current Merkle root
@@ -184,9 +191,7 @@ impl ASPMembership {
     pub fn insert_leaf(env: Env, leaf: U256) -> Result<(), Error> {
         bump_instance(&env);
         let store = env.storage().persistent();
-        let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
-        bump_entry(&env, &DataKey::Admin);
-        admin.require_auth();
+        get_admin(&env, &DataKey::Admin)?.require_auth();
 
         let levels: u32 = store.get(&DataKey::Levels).ok_or(Error::NotInitialized)?;
         bump_entry(&env, &DataKey::Levels);

--- a/contracts/asp-membership/src/test.rs
+++ b/contracts/asp-membership/src/test.rs
@@ -13,7 +13,10 @@ use soroban_sdk::{
     },
     vec,
 };
-use soroban_utils::ttl::{EXTEND_TO, THRESHOLD};
+use soroban_utils::{
+    AdminUpdated,
+    ttl::{EXTEND_TO, THRESHOLD},
+};
 use taceo_poseidon2::bn254::t2;
 
 /// Create a test environment that disables snapshot writing under Miri.
@@ -265,6 +268,51 @@ fn test_update_admin() {
             .expect("Admin updated")
     });
     assert_eq!(stored_admin_after, new_admin);
+}
+
+#[test]
+fn test_update_admin_emits_admin_updated() {
+    use soroban_sdk::{events::Event, testutils::Events};
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin.clone(), 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    client.update_admin(&new_admin);
+
+    let events = env.events().all();
+    assert_eq!(events.events().len(), 1);
+    let expected = AdminUpdated {
+        old_admin: admin,
+        new_admin,
+    }
+    .to_xdr(&env, &contract_id);
+    assert_eq!(events.events()[0], expected);
+}
+
+/// Rotating to the address already stored is a permitted no-op rotation, and it
+/// is recorded so an operator reading the log sees the attempt.
+#[test]
+fn test_update_admin_to_self_emits_with_equal_fields() {
+    use soroban_sdk::{events::Event, testutils::Events};
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin.clone(), 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    client.update_admin(&admin);
+
+    let events = env.events().all();
+    assert_eq!(events.events().len(), 1);
+    let expected = AdminUpdated {
+        old_admin: admin.clone(),
+        new_admin: admin,
+    }
+    .to_xdr(&env, &contract_id);
+    assert_eq!(events.events()[0], expected);
 }
 
 #[test]

--- a/contracts/asp-non-membership/src/lib.rs
+++ b/contracts/asp-non-membership/src/lib.rs
@@ -27,7 +27,9 @@ use soroban_sdk::{
     Address, Env, U256, Vec, contract, contracterror, contractevent, contractimpl, contracttype,
     vec,
 };
-use soroban_utils::{bump_entry, bump_instance, poseidon2_compress, poseidon2_hash2};
+use soroban_utils::{
+    AdminError, bump_entry, bump_instance, get_admin, poseidon2_compress, poseidon2_hash2,
+};
 #[contracttype]
 #[derive(Clone, Debug)]
 enum DataKey {
@@ -82,6 +84,12 @@ struct LeafDeletedEvent {
     root: U256,
 }
 
+impl From<AdminError> for Error {
+    fn from(AdminError::NotInitialized: AdminError) -> Self {
+        Self::NotInitialized
+    }
+}
+
 #[contract]
 pub struct ASPNonMembership;
 
@@ -126,8 +134,7 @@ impl ASPNonMembership {
     /// stored.
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
         bump_instance(&env);
-        soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin)
-            .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
+        soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin).map_err(Error::from)
     }
 
     /// Hash a leaf node using Poseidon2
@@ -371,9 +378,7 @@ impl ASPNonMembership {
     pub fn insert_leaf(env: Env, key: U256, value: U256) -> Result<(), Error> {
         bump_instance(&env);
         let store = env.storage().persistent();
-        let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
-        bump_entry(&env, &DataKey::Admin);
-        admin.require_auth();
+        get_admin(&env, &DataKey::Admin)?.require_auth();
 
         let root: U256 = store
             .get(&DataKey::Root)
@@ -535,9 +540,7 @@ impl ASPNonMembership {
     pub fn delete_leaf(env: Env, key: U256) -> Result<(), Error> {
         bump_instance(&env);
         let store = env.storage().persistent();
-        let admin: Address = store.get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
-        bump_entry(&env, &DataKey::Admin);
-        admin.require_auth();
+        get_admin(&env, &DataKey::Admin)?.require_auth();
         let root: U256 = store.get(&DataKey::Root).ok_or(Error::NotInitialized)?;
         bump_entry(&env, &DataKey::Root);
 

--- a/contracts/pool-gvk/src/pool_gvk.rs
+++ b/contracts/pool-gvk/src/pool_gvk.rs
@@ -24,7 +24,9 @@ use soroban_sdk::{
     Address, Bytes, BytesN, Env, I256, U256, Vec, contract, contracterror, contractevent,
     contractimpl, contracttype, crypto::bn254::Bn254Fr, token::TokenClient,
 };
-use soroban_utils::{bump_dependency, bump_entry, bump_instance, constants::bn256_modulus};
+use soroban_utils::{
+    AdminError, bump_dependency, bump_entry, bump_instance, constants::bn256_modulus,
+};
 
 // Re-exported rather than merely imported so `pool_gvk::ExtData` and
 // `pool_gvk::hash_ext_data` stay part of this crate's surface, mirroring
@@ -194,6 +196,12 @@ pub struct NewNullifierEvent {
     pub gvk_ciphertext: Option<GvkCiphertext>,
 }
 
+impl From<AdminError> for Error {
+    fn from(AdminError::NotInitialized: AdminError) -> Self {
+        Self::NotInitialized
+    }
+}
+
 /// Privacy Pool Contract with Global View Key support.
 #[contract]
 pub struct PoolGvkContract;
@@ -346,8 +354,7 @@ impl PoolGvkContract {
     /// stored.
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
         Self::touch(&env);
-        soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin)
-            .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
+        soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin).map_err(Error::from)
     }
 
     // ========== ASP Contract Functions ==========

--- a/contracts/pool/src/pool.rs
+++ b/contracts/pool/src/pool.rs
@@ -23,7 +23,9 @@ use soroban_sdk::{
     Address, Bytes, BytesN, Env, I256, U256, Vec, contract, contracterror, contractevent,
     contractimpl, contracttype, crypto::bn254::Bn254Fr, token::TokenClient,
 };
-use soroban_utils::{bump_dependency, bump_entry, bump_instance, constants::bn256_modulus};
+use soroban_utils::{
+    AdminError, bump_dependency, bump_entry, bump_instance, constants::bn256_modulus, get_admin,
+};
 
 // Re-exported rather than merely imported so `pool::ExtData` and
 // `pool::hash_ext_data` keep resolving for existing consumers (`e2e-tests`,
@@ -153,6 +155,12 @@ pub struct NewNullifierEvent {
     /// The nullifier that was spent
     #[topic]
     pub nullifier: U256,
+}
+
+impl From<AdminError> for Error {
+    fn from(AdminError::NotInitialized: AdminError) -> Self {
+        Self::NotInitialized
+    }
 }
 
 /// Privacy Pool Contract
@@ -611,15 +619,6 @@ impl PoolContract {
             .ok_or(Error::NotInitialized)
     }
 
-    /// Get the admin address
-    fn get_admin(env: &Env) -> Result<Address, Error> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Admin)
-            .inspect(|_| bump_entry(env, &DataKey::Admin))
-            .ok_or(Error::NotInitialized)
-    }
-
     /// Get the pool's ASP policy flags.
     pub fn get_policy_flags(env: &Env) -> Result<u32, Error> {
         Self::touch(env);
@@ -689,8 +688,7 @@ impl PoolContract {
     /// stored.
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
         Self::touch(&env);
-        soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin)
-            .map_err(|soroban_utils::AdminError::NotInitialized| Error::NotInitialized)
+        soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin).map_err(Error::from)
     }
 
     // ========== ASP Contract Functions ==========
@@ -724,8 +722,7 @@ impl PoolContract {
     /// * `new_asp_membership` - New ASP Membership contract address
     pub fn update_asp_membership(env: &Env, new_asp_membership: Address) -> Result<(), Error> {
         Self::touch(env);
-        let admin = Self::get_admin(env)?;
-        admin.require_auth();
+        get_admin(env, &DataKey::Admin)?.require_auth();
         env.storage()
             .persistent()
             .set(&DataKey::ASPMembership, &new_asp_membership);
@@ -747,8 +744,7 @@ impl PoolContract {
         new_asp_non_membership: Address,
     ) -> Result<(), Error> {
         Self::touch(env);
-        let admin = Self::get_admin(env)?;
-        admin.require_auth();
+        get_admin(env, &DataKey::Admin)?.require_auth();
         env.storage()
             .persistent()
             .set(&DataKey::ASPNonMembership, &new_asp_non_membership);

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -1287,6 +1287,27 @@ fn update_admin_errors_when_admin_unset() {
     ));
 }
 
+/// The refusal is driven from inside a host frame that goes on to succeed,
+/// because a frame that fails discards its events whatever the contract did.
+#[test]
+fn update_admin_errors_when_admin_unset_emits_nothing() {
+    use soroban_sdk::testutils::Events;
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 3, 0u32);
+    let new_admin = Address::generate(&env);
+
+    env.as_contract(&pool_id, || {
+        env.storage().persistent().remove(&DataKey::Admin);
+        assert_eq!(
+            soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin),
+            Err(soroban_utils::AdminError::NotInitialized)
+        );
+    });
+
+    assert!(env.events().all().events().is_empty());
+}
+
 /// This test is skipped under Miri because the panic formatting path triggers
 /// undefined behavior in the `ethnum` crate's unsafe formatting code.
 /// See: https://github.com/nlordell/ethnum-rs/issues/34

--- a/contracts/soroban-utils/src/lib.rs
+++ b/contracts/soroban-utils/src/lib.rs
@@ -5,6 +5,7 @@
 //! across multiple Soroban contracts
 
 pub mod constants;
+pub mod pausable;
 pub mod poseidon2;
 pub mod ttl;
 pub mod utils;

--- a/contracts/soroban-utils/src/pausable.rs
+++ b/contracts/soroban-utils/src/pausable.rs
@@ -1,0 +1,603 @@
+//! Pause bits that stop a contract from accepting some of its calls.
+//!
+//! A contract keeps one persistent entry holding a bit set, so a gated call
+//! reads a single entry to learn whether it may proceed. The bits belong to the
+//! contract: pools recognize [`DEPOSITS`], [`TRANSFERS`], and [`WITHDRAWALS`],
+//! and the ASP contracts recognize [`MUTATIONS`]. Every caller passes the mask
+//! of bits it honors, so a mistyped flag is refused rather than setting a bit
+//! nothing ever reads.
+//!
+//! A timed pause names the ledger at which every set bit stops being honored,
+//! so an operator can shut a contract for a known span and let it reopen on
+//! its own. That ledger is a promise to users. A second timed pause during the
+//! window adds its bits and keeps the recorded ledger, even when it asks for a
+//! later one, and a timed pause after an [`unpause`] of every bit is refused
+//! until the ledger arrives, so a caller that can only pause with a deadline
+//! can neither move the ledger later nor reopen a window the administrator
+//! has cleared. Only an untimed [`pause`] clears the ledger, and a timed pause
+//! that joins an untimed one records none, so bits paused with no deadline
+//! stay paused.
+//!
+//! None of these functions authorizes anyone. A contract that exposes a pause
+//! or an unpause is responsible for requiring its administrator's
+//! authorization first.
+
+use soroban_sdk::{Env, I256, contractevent, contracttype};
+
+use crate::ttl::bump_entry;
+
+/// Pool bit gating deposits.
+pub const DEPOSITS: u32 = 1;
+
+/// Pool bit gating transfers.
+pub const TRANSFERS: u32 = 2;
+
+/// Pool bit gating withdrawals.
+pub const WITHDRAWALS: u32 = 4;
+
+/// The one bit for ASP contracts, gating inserts and deletes.
+pub const MUTATIONS: u32 = 1;
+
+/// Every bit a pool honors.
+pub const POOL_MASK: u32 = DEPOSITS | TRANSFERS | WITHDRAWALS;
+
+/// The pause bits a contract has set.
+#[contracttype]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct PauseState {
+    /// Bits set by the last pause or unpause. A timed pause stops honoring
+    /// them at the ledger in `until` without clearing them, so read the answer
+    /// from [`is_paused`] rather than testing this field.
+    pub flags: u32,
+    /// Ledger at which every set bit stops being honored, and before which a
+    /// timed pause cannot reopen a window the administrator has cleared.
+    pub until: Option<u32>,
+}
+
+#[contracttype]
+#[derive(Clone)]
+enum PausableKey {
+    Pause,
+}
+
+/// Emitted whenever the pause bits change.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PauseChanged {
+    /// Bits set after the change.
+    pub flags: u32,
+    /// Ledger at which the bits stop being honored, when the pause is timed.
+    pub until: Option<u32>,
+}
+
+/// Reason a pause or an unpause was refused.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum PauseError {
+    /// The flags were zero, or held a bit outside the caller's mask.
+    InvalidFlags,
+    /// A timed pause was asked for after every bit was cleared, while the
+    /// earlier deadline is still ahead. No timed pause reopens that window
+    /// before the deadline.
+    TimedPauseArmed,
+}
+
+/// Returns the stored pause state, or an all-clear state when none is stored.
+///
+/// Extends the entry's lifetime when it exists, so a contract that is called
+/// keeps its own pause state alive.
+pub fn get_state(env: &Env) -> PauseState {
+    env.storage()
+        .persistent()
+        .get(&PausableKey::Pause)
+        .inspect(|_| bump_entry(env, &PausableKey::Pause))
+        .unwrap_or_default()
+}
+
+/// Sets `flags` in the stored pause state, timed by `until`.
+///
+/// `mask` is the set of bits the calling contract honors. Passing `Some(until)`
+/// promises that every set bit stops being honored at that ledger. A pause
+/// already in force keeps its own deadline, or its absence: the new bits join
+/// it and `until` is ignored. A timed pause on a contract whose bits have all
+/// been cleared is refused while the stored deadline is still ahead, so a
+/// caller that can only pause with a deadline can neither move a promised
+/// ledger later nor reopen a window the administrator has cleared. Once the
+/// stored deadline has passed, a timed pause records the new deadline for
+/// every bit still set, including the bits the earlier deadline released.
+/// Passing `None` clears the stored deadline.
+///
+/// # Errors
+///
+/// Returns [`PauseError::InvalidFlags`] if `flags` is zero or holds a bit
+/// outside `mask`, and [`PauseError::TimedPauseArmed`] if `until` is `Some`
+/// while no bit is set and the stored deadline is still ahead of the current
+/// ledger.
+///
+/// # Events
+///
+/// Publishes [`PauseChanged`] from the calling contract on success.
+pub fn pause(env: &Env, flags: u32, until: Option<u32>, mask: u32) -> Result<(), PauseError> {
+    check_flags(flags, mask)?;
+    let mut state = get_state(env);
+    match (until, state.until) {
+        (None, _) => state.until = None,
+        // A pause with no deadline keeps none; the bits join it.
+        (Some(_), None) if state.flags != 0 => {}
+        (Some(_), Some(stored)) if env.ledger().sequence() < stored => {
+            if state.flags == 0 {
+                return Err(PauseError::TimedPauseArmed);
+            }
+        }
+        (Some(deadline), _) => state.until = Some(deadline),
+    }
+
+    state.flags |= flags;
+    store(env, &state);
+    Ok(())
+}
+
+/// Clears `flags` from the stored pause state.
+///
+/// `mask` is the set of bits the calling contract honors. Clearing bits that
+/// are not set is accepted. The stored deadline is left in place, so clearing
+/// every bit does not let a timed pause reopen the window before it.
+///
+/// # Errors
+///
+/// Returns [`PauseError::InvalidFlags`] if `flags` is zero or holds a bit
+/// outside `mask`.
+///
+/// # Events
+///
+/// Publishes [`PauseChanged`] from the calling contract on success.
+pub fn unpause(env: &Env, flags: u32, mask: u32) -> Result<(), PauseError> {
+    check_flags(flags, mask)?;
+    let mut state = get_state(env);
+
+    state.flags &= !flags;
+    store(env, &state);
+    Ok(())
+}
+
+/// Reports whether `bit` is paused at the current ledger.
+///
+/// Every bit stops being honored from the timed pause's ledger onwards, while
+/// [`PauseState::flags`] still reads it as set.
+pub fn is_paused(env: &Env, bit: u32) -> bool {
+    let state = get_state(env);
+    let expired = state
+        .until
+        .is_some_and(|until| env.ledger().sequence() >= until);
+
+    state.flags & bit != 0 && !expired
+}
+
+/// Returns the pool bit that governs a transaction moving `ext_amount`.
+///
+/// A positive amount is a deposit, a negative one a withdrawal, and zero a
+/// transfer between notes already inside the pool.
+pub fn shape_bit(env: &Env, ext_amount: &I256) -> u32 {
+    let zero = I256::from_i32(env, 0);
+    if *ext_amount > zero {
+        DEPOSITS
+    } else if *ext_amount < zero {
+        WITHDRAWALS
+    } else {
+        TRANSFERS
+    }
+}
+
+fn check_flags(flags: u32, mask: u32) -> Result<(), PauseError> {
+    if flags == 0 || flags & !mask != 0 {
+        Err(PauseError::InvalidFlags)
+    } else {
+        Ok(())
+    }
+}
+
+fn store(env: &Env, state: &PauseState) {
+    env.storage().persistent().set(&PausableKey::Pause, state);
+    bump_entry(env, &PausableKey::Pause);
+    PauseChanged {
+        flags: state.flags,
+        until: state.until,
+    }
+    .publish(env);
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ttl::{EXTEND_TO, THRESHOLD};
+    use soroban_sdk::{
+        Address, contract, contracterror, contractimpl,
+        events::Event,
+        testutils::{Events, Ledger as _, storage::Persistent as _},
+    };
+
+    /// Contract-facing form of [`PauseError`], so the probe's failures cross
+    /// the host boundary the way a real target's do.
+    #[contracterror]
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+    #[repr(u32)]
+    enum ProbeError {
+        InvalidFlags = 1,
+        TimedPauseArmed = 2,
+    }
+
+    impl From<PauseError> for ProbeError {
+        fn from(error: PauseError) -> Self {
+            match error {
+                PauseError::InvalidFlags => Self::InvalidFlags,
+                PauseError::TimedPauseArmed => Self::TimedPauseArmed,
+            }
+        }
+    }
+
+    #[contract]
+    struct PauseProbe;
+
+    #[contractimpl]
+    impl PauseProbe {
+        pub fn pause(
+            env: Env,
+            flags: u32,
+            until: Option<u32>,
+            mask: u32,
+        ) -> Result<(), ProbeError> {
+            super::pause(&env, flags, until, mask).map_err(ProbeError::from)
+        }
+
+        pub fn unpause(env: Env, flags: u32, mask: u32) -> Result<(), ProbeError> {
+            super::unpause(&env, flags, mask).map_err(ProbeError::from)
+        }
+
+        pub fn state(env: Env) -> PauseState {
+            get_state(&env)
+        }
+
+        pub fn paused(env: Env, bit: u32) -> bool {
+            is_paused(&env, bit)
+        }
+    }
+
+    fn probe(env: &Env) -> (Address, PauseProbeClient<'_>) {
+        let id = env.register(PauseProbe, ());
+        let client = PauseProbeClient::new(env, &id);
+        (id, client)
+    }
+
+    #[test]
+    fn shape_bit_reads_the_sign_of_the_external_amount() {
+        let env = Env::default();
+
+        assert_eq!(shape_bit(&env, &I256::from_i32(&env, 500)), DEPOSITS);
+        assert_eq!(shape_bit(&env, &I256::from_i32(&env, 0)), TRANSFERS);
+        assert_eq!(shape_bit(&env, &I256::from_i32(&env, -300)), WITHDRAWALS);
+    }
+
+    #[test]
+    fn pause_rejects_flags_outside_the_mask() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+
+        assert_eq!(
+            client.try_pause(&8u32, &None, &POOL_MASK),
+            Err(Ok(ProbeError::InvalidFlags))
+        );
+    }
+
+    #[test]
+    fn pause_rejects_zero_flags() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+
+        assert_eq!(
+            client.try_pause(&0u32, &None, &POOL_MASK),
+            Err(Ok(ProbeError::InvalidFlags))
+        );
+        assert_eq!(
+            client.try_unpause(&0u32, &POOL_MASK),
+            Err(Ok(ProbeError::InvalidFlags))
+        );
+    }
+
+    #[test]
+    fn the_mutations_mask_accepts_only_its_own_bit() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+
+        client.pause(&MUTATIONS, &None, &MUTATIONS);
+
+        assert_eq!(client.state().flags, MUTATIONS);
+        assert_eq!(
+            client.try_pause(&TRANSFERS, &None, &MUTATIONS),
+            Err(Ok(ProbeError::InvalidFlags))
+        );
+    }
+
+    #[test]
+    fn a_fresh_state_pauses_nothing() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+
+        assert_eq!(
+            client.state(),
+            PauseState {
+                flags: 0,
+                until: None,
+            }
+        );
+        for bit in [DEPOSITS, TRANSFERS, WITHDRAWALS] {
+            assert!(!client.paused(&bit));
+        }
+    }
+
+    #[test]
+    fn a_timed_pause_records_the_ledger() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+
+        client.pause(&WITHDRAWALS, &Some(500), &POOL_MASK);
+
+        assert_eq!(
+            client.state(),
+            PauseState {
+                flags: WITHDRAWALS,
+                until: Some(500),
+            }
+        );
+        assert!(client.paused(&WITHDRAWALS));
+    }
+
+    #[test]
+    fn a_second_timed_pause_adds_bits_and_keeps_the_deadline() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+        client.pause(&WITHDRAWALS, &Some(500), &POOL_MASK);
+
+        env.ledger().set_sequence_number(499);
+        client.pause(&DEPOSITS, &Some(900), &POOL_MASK);
+
+        assert_eq!(
+            client.state(),
+            PauseState {
+                flags: DEPOSITS | WITHDRAWALS,
+                until: Some(500),
+            }
+        );
+        assert!(client.paused(&DEPOSITS));
+        env.ledger().set_sequence_number(500);
+        assert!(!client.paused(&DEPOSITS));
+    }
+
+    #[test]
+    fn a_timed_pause_joins_an_untimed_pause_and_records_no_deadline() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+        client.pause(&DEPOSITS, &None, &POOL_MASK);
+
+        client.pause(&WITHDRAWALS, &Some(500), &POOL_MASK);
+
+        assert_eq!(
+            client.state(),
+            PauseState {
+                flags: DEPOSITS | WITHDRAWALS,
+                until: None,
+            }
+        );
+        env.ledger().set_sequence_number(500);
+        assert!(client.paused(&WITHDRAWALS));
+    }
+
+    #[test]
+    fn an_untimed_pause_keeps_the_flags_and_clears_until() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+        client.pause(&WITHDRAWALS, &Some(500), &POOL_MASK);
+
+        client.pause(&DEPOSITS, &None, &POOL_MASK);
+
+        assert_eq!(
+            client.state(),
+            PauseState {
+                flags: DEPOSITS | WITHDRAWALS,
+                until: None,
+            }
+        );
+    }
+
+    #[test]
+    fn unpause_clears_only_the_named_bits() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+        client.pause(&POOL_MASK, &None, &POOL_MASK);
+
+        client.unpause(&DEPOSITS, &POOL_MASK);
+
+        assert_eq!(client.state().flags, TRANSFERS | WITHDRAWALS);
+    }
+
+    #[test]
+    fn unpause_of_unset_bits_is_accepted_and_leaves_until() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+        client.pause(&WITHDRAWALS, &Some(500), &POOL_MASK);
+
+        client.unpause(&DEPOSITS, &POOL_MASK);
+
+        assert_eq!(
+            client.state(),
+            PauseState {
+                flags: WITHDRAWALS,
+                until: Some(500),
+            }
+        );
+    }
+
+    #[test]
+    fn unpause_of_some_bits_leaves_a_window_the_next_pause_adds_to() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+        client.pause(&(DEPOSITS | WITHDRAWALS), &Some(500), &POOL_MASK);
+        client.unpause(&DEPOSITS, &POOL_MASK);
+
+        client.pause(&TRANSFERS, &Some(900), &POOL_MASK);
+
+        assert_eq!(
+            client.state(),
+            PauseState {
+                flags: TRANSFERS | WITHDRAWALS,
+                until: Some(500),
+            }
+        );
+    }
+
+    #[test]
+    fn unpause_leaves_until_so_a_timed_pause_is_still_refused() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+        client.pause(&WITHDRAWALS, &Some(500), &POOL_MASK);
+
+        client.unpause(&WITHDRAWALS, &POOL_MASK);
+
+        env.ledger().set_sequence_number(499);
+        assert_eq!(
+            client.try_pause(&WITHDRAWALS, &Some(900), &POOL_MASK),
+            Err(Ok(ProbeError::TimedPauseArmed))
+        );
+        assert_eq!(
+            client.state(),
+            PauseState {
+                flags: 0,
+                until: Some(500),
+            }
+        );
+
+        env.ledger().set_sequence_number(500);
+        client.pause(&WITHDRAWALS, &Some(900), &POOL_MASK);
+
+        assert_eq!(
+            client.state(),
+            PauseState {
+                flags: WITHDRAWALS,
+                until: Some(900),
+            }
+        );
+    }
+
+    #[test]
+    fn every_bit_stops_being_honored_at_the_deadline() {
+        let env = Env::default();
+        let (_, pool) = probe(&env);
+        let (_, asp) = probe(&env);
+        let until = env.ledger().sequence().saturating_add(10);
+        pool.pause(&POOL_MASK, &Some(until), &POOL_MASK);
+        asp.pause(&MUTATIONS, &Some(until), &MUTATIONS);
+
+        env.ledger().set_sequence_number(until.saturating_sub(1));
+        for bit in [DEPOSITS, TRANSFERS, WITHDRAWALS] {
+            assert!(pool.paused(&bit));
+        }
+        assert!(asp.paused(&MUTATIONS));
+
+        env.ledger().set_sequence_number(until);
+        for bit in [DEPOSITS, TRANSFERS, WITHDRAWALS] {
+            assert!(!pool.paused(&bit));
+        }
+        assert!(!asp.paused(&MUTATIONS));
+        assert_eq!(pool.state().flags, POOL_MASK);
+        assert_eq!(asp.state().flags, MUTATIONS);
+    }
+
+    /// The one sequence in which a user who watched a contract reopen finds it
+    /// shut again, and with no deadline the second time.
+    #[test]
+    fn an_untimed_pause_reshuts_bits_the_deadline_released() {
+        let env = Env::default();
+        let (_, client) = probe(&env);
+        let until = env.ledger().sequence().saturating_add(10);
+        client.pause(&WITHDRAWALS, &Some(until), &POOL_MASK);
+        env.ledger().set_sequence_number(until);
+        assert!(!client.paused(&WITHDRAWALS));
+
+        client.pause(&DEPOSITS, &None, &POOL_MASK);
+
+        assert!(client.paused(&WITHDRAWALS));
+        assert!(client.paused(&DEPOSITS));
+        assert_eq!(client.state().until, None);
+    }
+
+    #[test]
+    fn a_ledger_already_past_honors_nothing_and_does_not_block_the_next() {
+        let env = Env::default();
+        env.ledger().set_sequence_number(1_000);
+        let (_, client) = probe(&env);
+
+        client.pause(&POOL_MASK, &Some(500), &POOL_MASK);
+
+        for bit in [DEPOSITS, TRANSFERS, WITHDRAWALS] {
+            assert!(!client.paused(&bit));
+        }
+
+        client.pause(&WITHDRAWALS, &Some(1_500), &POOL_MASK);
+
+        assert_eq!(client.state().until, Some(1_500));
+        assert!(client.paused(&WITHDRAWALS));
+        assert!(client.paused(&DEPOSITS));
+    }
+
+    #[test]
+    fn pause_emits_pause_changed() {
+        let env = Env::default();
+        let (id, client) = probe(&env);
+
+        client.pause(&DEPOSITS, &Some(500), &POOL_MASK);
+
+        let events = env.events().all();
+        assert_eq!(events.events().len(), 1);
+        let expected = PauseChanged {
+            flags: DEPOSITS,
+            until: Some(500),
+        }
+        .to_xdr(&env, &id);
+        assert_eq!(events.events()[0], expected);
+    }
+
+    #[test]
+    fn unpause_emits_pause_changed() {
+        let env = Env::default();
+        let (id, client) = probe(&env);
+        client.pause(&(DEPOSITS | TRANSFERS), &None, &POOL_MASK);
+
+        client.unpause(&DEPOSITS, &POOL_MASK);
+
+        let events = env.events().all();
+        assert_eq!(events.events().len(), 1);
+        let expected = PauseChanged {
+            flags: TRANSFERS,
+            until: None,
+        }
+        .to_xdr(&env, &id);
+        assert_eq!(events.events()[0], expected);
+    }
+
+    #[test]
+    fn get_state_extends_the_entry() {
+        let env = Env::default();
+        let (id, client) = probe(&env);
+        client.pause(&DEPOSITS, &None, &POOL_MASK);
+        let decayed = env
+            .ledger()
+            .sequence()
+            .saturating_add(EXTEND_TO.saturating_sub(THRESHOLD).saturating_add(1));
+        env.ledger().set_sequence_number(decayed);
+
+        client.state();
+
+        let ttl = env.as_contract(&id, || {
+            env.storage().persistent().get_ttl(&PausableKey::Pause)
+        });
+        assert_eq!(ttl, EXTEND_TO);
+    }
+}

--- a/contracts/soroban-utils/src/utils.rs
+++ b/contracts/soroban-utils/src/utils.rs
@@ -1,9 +1,11 @@
 use ark_bn254::{G1Affine as ArkG1Affine, G2Affine as ArkG2Affine};
 use ark_ff::{BigInteger, fields::PrimeField};
 use contract_types::VerificationKeyBytes;
-use soroban_sdk::{Address, BytesN, Env, IntoVal, TryFromVal, Val, Vec};
+use soroban_sdk::{Address, BytesN, Env, IntoVal, TryFromVal, Val, Vec, contractevent};
 #[cfg(any(test, feature = "testutils"))]
 use soroban_sdk::{contract, contractimpl};
+
+use crate::ttl::bump_entry;
 
 /// Error returned by the shared admin helpers.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -12,11 +14,22 @@ pub enum AdminError {
     NotInitialized,
 }
 
+/// Emitted when a contract's administrator changes.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminUpdated {
+    /// Address that held the role before the call.
+    pub old_admin: Address,
+    /// Address that holds it afterwards.
+    pub new_admin: Address,
+}
+
 /// Replaces the administrator stored under `admin_key` with `new_admin`.
 ///
 /// The address already stored under `admin_key` must authorize the call. Each
 /// contract passes its own storage key, so contracts sharing this helper keep
-/// separate admin entries.
+/// separate admin entries. Rotating to the address already stored is allowed
+/// and is recorded like any other rotation.
 ///
 /// # Errors
 ///
@@ -27,15 +40,26 @@ pub enum AdminError {
 ///
 /// Panics if the address stored under `admin_key` does not authorize the call,
 /// because `require_auth` raises a host error rather than returning.
+///
+/// # Events
+///
+/// Publishes [`AdminUpdated`] from the calling contract once the new address is
+/// stored. A call that fails publishes nothing.
 pub fn update_admin<K>(env: &Env, admin_key: &K, new_admin: &Address) -> Result<(), AdminError>
 where
     K: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
 {
     let store = env.storage().persistent();
     let admin: Address = store.get(admin_key).ok_or(AdminError::NotInitialized)?;
+    bump_entry(env, admin_key);
     admin.require_auth();
 
     store.set(admin_key, new_admin);
+    AdminUpdated {
+        old_admin: admin,
+        new_admin: new_admin.clone(),
+    }
+    .publish(env);
     Ok(())
 }
 

--- a/contracts/soroban-utils/src/utils.rs
+++ b/contracts/soroban-utils/src/utils.rs
@@ -24,6 +24,24 @@ pub struct AdminUpdated {
     pub new_admin: Address,
 }
 
+/// Returns the administrator stored under `admin_key` and extends the entry's
+/// lifetime.
+///
+/// # Errors
+///
+/// Returns [`AdminError::NotInitialized`] if no address is stored under
+/// `admin_key`.
+pub fn get_admin<K>(env: &Env, admin_key: &K) -> Result<Address, AdminError>
+where
+    K: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
+{
+    env.storage()
+        .persistent()
+        .get(admin_key)
+        .inspect(|_| bump_entry(env, admin_key))
+        .ok_or(AdminError::NotInitialized)
+}
+
 /// Replaces the administrator stored under `admin_key` with `new_admin`.
 ///
 /// The address already stored under `admin_key` must authorize the call. Each
@@ -49,12 +67,10 @@ pub fn update_admin<K>(env: &Env, admin_key: &K, new_admin: &Address) -> Result<
 where
     K: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
 {
-    let store = env.storage().persistent();
-    let admin: Address = store.get(admin_key).ok_or(AdminError::NotInitialized)?;
-    bump_entry(env, admin_key);
+    let admin = get_admin(env, admin_key)?;
     admin.require_auth();
 
-    store.set(admin_key, new_admin);
+    env.storage().persistent().set(admin_key, new_admin);
     AdminUpdated {
         old_admin: admin,
         new_admin: new_admin.clone(),


### PR DESCRIPTION
Library groundwork for pausing contracts during an incident, plus one accessor for the admin
key. No contract changes behavior here, which is deliberate: the pause semantics are easier to
argue about before four contracts depend on them.

## The pausable module

`soroban_utils::pausable` keeps one persistent entry per contract, a struct under the key
`Pause` holding `flags: u32` and `until: Option<u32>`.

One entry rather than a key per bit. A gated call reads a single entry, so the check costs one
storage read no matter how many bits a contract recognizes, and a client reads pause state the
way it reads any other contract key.

Every caller passes the set of bits it recognizes as `mask`. Pools pass
`DEPOSITS | TRANSFERS | WITHDRAWALS`, the ASP contracts pass `MUTATIONS`. Flags of zero, or any
flag outside the caller's mask, are refused with `InvalidFlags`. Without that check a mistyped
constant would set a bit no code ever reads, and the operator would believe something was
paused when it was not.

## What a deadline does

`pause` takes `until: Option<u32>`. `Some(ledger)` promises that **every** bit set on the
contract stops being honored at that ledger, not just one of them. `is_paused` returns false
for every bit once the ledger arrives, while `PauseState::flags` still reads them as set, so a
client that wants the honored answer must call `is_paused` rather than read the flags.

The rest of the state machine, in the order `pause` evaluates it:

- `None` clears the stored deadline, which leaves the bits set with no expiry at all. That is
  the honest reading of "we do not know yet", and it is reserved for the caller trusted to say
  so.
- `Some(_)` while bits are already set and the stored deadline is absent leaves it absent. The
  new bits join the untimed pause instead of acquiring an expiry.
- `Some(_)` while the stored deadline is still ahead keeps that deadline. A caller who can only
  pause with a deadline cannot push a promised ledger later.
- `Some(_)` while the stored deadline is still ahead and no bit is set is refused with
  `TimedPauseArmed`. Otherwise clearing every bit would reopen a window the administrator just
  closed.
- Once the stored deadline has passed, a timed pause records a new one for every bit still set,
  including bits the earlier deadline had already released.

`unpause` clears the bits it names and leaves the deadline where it is, which is what makes the
fourth rule above hold.

## Authorization

The module authorizes nobody. Every function assumes the caller has established the right to
change pause state. A contract exposing a pause entry point requires its administrator first.

## Reading the admin through one helper

`soroban_utils::get_admin` reads a contract's `Admin` key, extends the entry's lifetime, and
maps a missing entry to the contract's own `NotInitialized`. Each of the four contracts had
that read open-coded once or twice; `pause` and `unpause` would have taken it to twelve copies.
Each contract converts `AdminError` with a `From` impl, so a call site is one line.

`update_admin` now publishes `AdminUpdated` carrying the old and the new address. It previously
rotated the administrator silently, which left an operator no way to see a rotation without
diffing state. Rotating to the address already stored is still permitted and is recorded like
any other rotation, so an attempted no-op is visible too.

## Compatibility

No entry point signatures change and no storage layout moves. The refactor commit changes which
function performs the admin read, not what it reads or what it returns on failure.

Part of #372.
