### PR TITLE
Gate pool and ASP writes on pause bits

### DIFF
--- a/contracts/asp-membership/src/lib.rs
+++ b/contracts/asp-membership/src/lib.rs
@@ -9,7 +9,9 @@ use soroban_sdk::{
     Address, Env, U256, Vec, contract, contracterror, contractevent, contractimpl, contracttype,
 };
 use soroban_utils::{
-    AdminError, bump_entry, bump_instance, get_admin, get_zeroes, poseidon2_compress,
+    AdminError, bump_entry, bump_instance, get_admin, get_zeroes,
+    pausable::{self, PauseError, PauseState},
+    poseidon2_compress,
 };
 
 /// Storage keys for contract persistent data
@@ -45,6 +47,22 @@ pub enum Error {
     NotInitialized = 4,
     /// Arithmetic overflow occurred
     Overflow = 5,
+    /// Tree mutations are paused.
+    Paused = 6,
+    /// Pause flags were zero, or held a bit the contract does not recognize.
+    InvalidPauseFlags = 7,
+    /// A timed pause was asked for after every bit was cleared, while the
+    /// earlier deadline is still ahead.
+    TimedPauseArmed = 8,
+}
+
+impl From<PauseError> for Error {
+    fn from(e: PauseError) -> Self {
+        match e {
+            PauseError::InvalidFlags => Error::InvalidPauseFlags,
+            PauseError::TimedPauseArmed => Error::TimedPauseArmed,
+        }
+    }
 }
 
 /// Event emitted when a new leaf is added to the Merkle tree
@@ -132,6 +150,62 @@ impl ASPMembership {
         soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin).map_err(Error::from)
     }
 
+    /// Pauses tree mutations.
+    ///
+    /// The only bit the contract honors is `MUTATIONS` from
+    /// [`soroban_utils::pausable`]. Passing `Some(until)` promises that it
+    /// stops being honored at that ledger. A second timed pause during the
+    /// window keeps the stored `until`, and a timed pause is refused on a
+    /// contract whose bit was cleared while `until` is still ahead. Requires
+    /// admin authorization.
+    ///
+    /// A pause stops `insert_leaf` and nothing else. `update_admin`,
+    /// `unpause`, `get_root`, and `hash_pair` answer while the contract is
+    /// paused, so an operator can hand over a paused contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the contract has no admin address
+    /// stored, [`Error::InvalidPauseFlags`] if `flags` is zero or holds a bit
+    /// other than `MUTATIONS`, and [`Error::TimedPauseArmed`] if `until` is
+    /// `Some` while the bit is clear and an earlier `until` is still in the
+    /// future.
+    ///
+    /// # Events
+    ///
+    /// Publishes [`soroban_utils::pausable::PauseChanged`] from the contract.
+    pub fn pause(env: Env, flags: u32, until: Option<u32>) -> Result<(), Error> {
+        bump_instance(&env);
+        get_admin(&env, &DataKey::Admin)?.require_auth();
+        Ok(pausable::pause(&env, flags, until, pausable::MUTATIONS)?)
+    }
+
+    /// Clears the pause bits named by `flags`.
+    ///
+    /// Clearing bits that are not set is accepted, and a timed pause's `until`
+    /// stays in place. Requires admin authorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the contract has no admin address
+    /// stored, and [`Error::InvalidPauseFlags`] if `flags` is zero or holds a
+    /// bit other than `MUTATIONS`.
+    ///
+    /// # Events
+    ///
+    /// Publishes [`soroban_utils::pausable::PauseChanged`] from the contract.
+    pub fn unpause(env: Env, flags: u32) -> Result<(), Error> {
+        bump_instance(&env);
+        get_admin(&env, &DataKey::Admin)?.require_auth();
+        Ok(pausable::unpause(&env, flags, pausable::MUTATIONS)?)
+    }
+
+    /// Returns the contract's pause bits.
+    pub fn get_pause_state(env: Env) -> PauseState {
+        bump_instance(&env);
+        pausable::get_state(&env)
+    }
+
     /// Get the current Merkle root
     ///
     /// Returns the current root hash of the Merkle tree.
@@ -185,14 +259,18 @@ impl ASPMembership {
     /// # Errors
     ///
     /// Returns [`Error::NotInitialized`] if the contract is missing the admin
-    /// address or any tree state the insertion reads,
-    /// [`Error::MerkleTreeFull`] if the tree is at capacity, and
-    /// [`Error::Overflow`] if the next leaf index would exceed `u64::MAX`.
+    /// address or any tree state the insertion reads, [`Error::Paused`] if
+    /// mutations are paused, [`Error::MerkleTreeFull`] if the tree is at
+    /// capacity, and [`Error::Overflow`] if the next leaf index would exceed
+    /// `u64::MAX`.
     pub fn insert_leaf(env: Env, leaf: U256) -> Result<(), Error> {
         bump_instance(&env);
-        let store = env.storage().persistent();
         get_admin(&env, &DataKey::Admin)?.require_auth();
+        if pausable::is_paused(&env, pausable::MUTATIONS) {
+            return Err(Error::Paused);
+        }
 
+        let store = env.storage().persistent();
         let levels: u32 = store.get(&DataKey::Levels).ok_or(Error::NotInitialized)?;
         bump_entry(&env, &DataKey::Levels);
         let actual_index: u64 = store

--- a/contracts/asp-membership/src/test.rs
+++ b/contracts/asp-membership/src/test.rs
@@ -802,3 +802,241 @@ fn test_full_tree_insert_fails_without_extending() {
     assert_ne!(before, EXTEND_TO);
     assert_eq!(entry_ttl(&env, &contract_id, &DataKey::NextIndex), before);
 }
+
+fn next_index(env: &Env, contract: &Address) -> u64 {
+    env.as_contract(contract, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::NextIndex)
+            .expect("NextIndex set in constructor")
+    })
+}
+
+/// Registers a paused contract and returns its address and client.
+fn paused_contract(env: &Env) -> (Address, ASPMembershipClient<'_>) {
+    let admin = Address::generate(env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(env, &contract_id);
+
+    env.mock_all_auths();
+    client.pause(&pausable::MUTATIONS, &None);
+    (contract_id, client)
+}
+
+#[test]
+fn test_insert_leaf_rejected_while_paused() {
+    use soroban_sdk::testutils::Events;
+    let env = test_env();
+    let (contract_id, client) = paused_contract(&env);
+    let root_before = client.get_root();
+    let events_before = env.events().all().events().len();
+
+    let err = client
+        .try_insert_leaf(&U256::from_u32(&env, 100))
+        .expect_err("an insert must be refused while mutations are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+    assert_eq!(client.get_root(), root_before);
+    assert_eq!(next_index(&env, &contract_id), 0);
+    assert_eq!(env.events().all().events().len(), events_before);
+}
+
+#[test]
+fn test_insert_leaf_allowed_after_unpause() {
+    let env = test_env();
+    let (contract_id, client) = paused_contract(&env);
+
+    client.unpause(&pausable::MUTATIONS);
+    client.insert_leaf(&U256::from_u32(&env, 100));
+
+    assert_eq!(next_index(&env, &contract_id), 1);
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_pause_requires_admin() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+
+    ASPMembershipClient::new(&env, &contract_id).pause(&pausable::MUTATIONS, &None);
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_unpause_requires_admin() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+
+    ASPMembershipClient::new(&env, &contract_id).unpause(&pausable::MUTATIONS);
+}
+
+#[test]
+fn test_pause_rejects_bits_outside_mutations() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+
+    let err = client
+        .try_pause(&2u32, &None)
+        .expect_err("a pause naming a bit the contract does not honor must be refused");
+
+    assert_eq!(err, Ok(Error::InvalidPauseFlags));
+}
+
+#[test]
+fn test_pause_errors_when_admin_unset() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().remove(&DataKey::Admin);
+    });
+
+    assert_eq!(
+        client.try_pause(&pausable::MUTATIONS, &None),
+        Err(Ok(Error::NotInitialized))
+    );
+    assert_eq!(
+        client.try_unpause(&pausable::MUTATIONS),
+        Err(Ok(Error::NotInitialized))
+    );
+}
+
+#[test]
+fn test_second_timed_pause_keeps_the_deadline() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+    client.pause(&pausable::MUTATIONS, &Some(500));
+
+    env.ledger().set_sequence_number(499);
+    client.pause(&pausable::MUTATIONS, &Some(900));
+
+    assert_eq!(client.get_pause_state().until, Some(500));
+}
+
+#[test]
+fn test_unpause_leaves_until_so_a_second_timed_pause_is_still_refused() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+    client.pause(&pausable::MUTATIONS, &Some(500));
+
+    client.unpause(&pausable::MUTATIONS);
+    let err = client
+        .try_pause(&pausable::MUTATIONS, &Some(900))
+        .expect_err("an unpause must not reopen the window before the promised ledger");
+
+    assert_eq!(err, Ok(Error::TimedPauseArmed));
+    assert_eq!(client.get_pause_state().until, Some(500));
+
+    env.ledger().set_sequence_number(500);
+    client.pause(&pausable::MUTATIONS, &Some(900));
+
+    assert_eq!(client.get_pause_state().until, Some(900));
+}
+
+#[test]
+fn test_update_admin_and_get_root_work_while_paused() {
+    let env = test_env();
+    let (contract_id, client) = paused_contract(&env);
+    let new_admin = Address::generate(&env);
+    let root = client.get_root();
+
+    client.update_admin(&new_admin);
+
+    let stored_admin: Address = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Admin set in constructor")
+    });
+    assert_eq!(stored_admin, new_admin);
+    assert_eq!(client.get_root(), root);
+}
+
+#[test]
+fn test_new_admin_can_unpause_after_rotation() {
+    let env = test_env();
+    let (contract_id, client) = paused_contract(&env);
+    let new_admin = Address::generate(&env);
+    client.update_admin(&new_admin);
+
+    env.mock_auths(&[MockAuth {
+        address: &new_admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "unpause",
+            args: (pausable::MUTATIONS,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.unpause(&pausable::MUTATIONS);
+
+    assert_eq!(client.get_pause_state().flags, 0);
+}
+
+/// `mock_all_auths` approves any signer, so the tests above cannot tell an
+/// admin signature from anyone else's. This one pins the address.
+///
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_pause_from_a_non_admin_is_refused() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+    let stranger = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &stranger,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "pause",
+            args: (pausable::MUTATIONS, None::<u32>).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.pause(&pausable::MUTATIONS, &None);
+}
+
+#[test]
+fn test_insert_is_allowed_again_after_the_deadline() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPMembership, (admin, 3u32));
+    let client = ASPMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+    let until = env.ledger().sequence().saturating_add(10);
+    client.pause(&pausable::MUTATIONS, &Some(until));
+
+    env.ledger().set_sequence_number(until);
+    client.insert_leaf(&U256::from_u32(&env, 100));
+
+    assert_eq!(next_index(&env, &contract_id), 1);
+    let state = client.get_pause_state();
+    assert_eq!(state.flags, pausable::MUTATIONS);
+    assert_eq!(state.until, Some(until));
+}

--- a/contracts/asp-non-membership/src/lib.rs
+++ b/contracts/asp-non-membership/src/lib.rs
@@ -28,7 +28,9 @@ use soroban_sdk::{
     vec,
 };
 use soroban_utils::{
-    AdminError, bump_entry, bump_instance, get_admin, poseidon2_compress, poseidon2_hash2,
+    AdminError, bump_entry, bump_instance, get_admin,
+    pausable::{self, PauseError, PauseState},
+    poseidon2_compress, poseidon2_hash2,
 };
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -68,6 +70,22 @@ pub enum Error {
     InvalidProof = 4,
     NotInitialized = 5,
     Overflow = 6,
+    /// Tree mutations are paused.
+    Paused = 7,
+    /// Pause flags were zero, or held a bit the contract does not recognize.
+    InvalidPauseFlags = 8,
+    /// A timed pause was asked for after every bit was cleared, while the
+    /// earlier deadline is still ahead.
+    TimedPauseArmed = 9,
+}
+
+impl From<PauseError> for Error {
+    fn from(e: PauseError) -> Self {
+        match e {
+            PauseError::InvalidFlags => Error::InvalidPauseFlags,
+            PauseError::TimedPauseArmed => Error::TimedPauseArmed,
+        }
+    }
 }
 
 // Events
@@ -135,6 +153,63 @@ impl ASPNonMembership {
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
         bump_instance(&env);
         soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin).map_err(Error::from)
+    }
+
+    /// Pauses tree mutations.
+    ///
+    /// The only bit the contract honors is `MUTATIONS` from
+    /// [`soroban_utils::pausable`]. Passing `Some(until)` promises that it
+    /// stops being honored at that ledger. A second timed pause during the
+    /// window keeps the stored `until`, and a timed pause is refused on a
+    /// contract whose bit was cleared while `until` is still ahead. Requires
+    /// admin authorization.
+    ///
+    /// A pause stops `insert_leaf` and `delete_leaf`, and nothing else.
+    /// `update_admin`, `unpause`, `find_key`, `verify_non_membership`, and
+    /// `get_root` answer while the contract is paused, so pools keep proving
+    /// non-membership against a frozen tree.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the contract has no admin address
+    /// stored, [`Error::InvalidPauseFlags`] if `flags` is zero or holds a bit
+    /// other than `MUTATIONS`, and [`Error::TimedPauseArmed`] if `until` is
+    /// `Some` while the bit is clear and an earlier `until` is still in the
+    /// future.
+    ///
+    /// # Events
+    ///
+    /// Publishes [`soroban_utils::pausable::PauseChanged`] from the contract.
+    pub fn pause(env: Env, flags: u32, until: Option<u32>) -> Result<(), Error> {
+        bump_instance(&env);
+        get_admin(&env, &DataKey::Admin)?.require_auth();
+        Ok(pausable::pause(&env, flags, until, pausable::MUTATIONS)?)
+    }
+
+    /// Clears the pause bits named by `flags`.
+    ///
+    /// Clearing bits that are not set is accepted, and a timed pause's `until`
+    /// stays in place. Requires admin authorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the contract has no admin address
+    /// stored, and [`Error::InvalidPauseFlags`] if `flags` is zero or holds a
+    /// bit other than `MUTATIONS`.
+    ///
+    /// # Events
+    ///
+    /// Publishes [`soroban_utils::pausable::PauseChanged`] from the contract.
+    pub fn unpause(env: Env, flags: u32) -> Result<(), Error> {
+        bump_instance(&env);
+        get_admin(&env, &DataKey::Admin)?.require_auth();
+        Ok(pausable::unpause(&env, flags, pausable::MUTATIONS)?)
+    }
+
+    /// Returns the contract's pause bits.
+    pub fn get_pause_state(env: Env) -> PauseState {
+        bump_instance(&env);
+        pausable::get_state(&env)
     }
 
     /// Hash a leaf node using Poseidon2
@@ -372,14 +447,18 @@ impl ASPNonMembership {
     ///
     /// # Errors
     ///
+    /// * `Error::Paused` - Tree mutations are paused
     /// * `Error::KeyAlreadyExists` - Key already exists in the tree
     /// * `Error::KeyNotFound` - Database operations failed
     #[allow(clippy::cast_possible_truncation)]
     pub fn insert_leaf(env: Env, key: U256, value: U256) -> Result<(), Error> {
         bump_instance(&env);
-        let store = env.storage().persistent();
         get_admin(&env, &DataKey::Admin)?.require_auth();
+        if pausable::is_paused(&env, pausable::MUTATIONS) {
+            return Err(Error::Paused);
+        }
 
+        let store = env.storage().persistent();
         let root: U256 = store
             .get(&DataKey::Root)
             .inspect(|_| bump_entry(&env, &DataKey::Root))
@@ -535,12 +614,17 @@ impl ASPNonMembership {
     ///
     /// # Errors
     ///
+    /// * `Error::Paused` - Tree mutations are paused
     /// * `Error::KeyNotFound` - Key does not exist in the tree or database
     ///   operations failed
     pub fn delete_leaf(env: Env, key: U256) -> Result<(), Error> {
         bump_instance(&env);
-        let store = env.storage().persistent();
         get_admin(&env, &DataKey::Admin)?.require_auth();
+        if pausable::is_paused(&env, pausable::MUTATIONS) {
+            return Err(Error::Paused);
+        }
+
+        let store = env.storage().persistent();
         let root: U256 = store.get(&DataKey::Root).ok_or(Error::NotInitialized)?;
         bump_entry(&env, &DataKey::Root);
 

--- a/contracts/asp-non-membership/src/test.rs
+++ b/contracts/asp-non-membership/src/test.rs
@@ -1209,3 +1209,217 @@ fn test_find_key_extends_the_path_it_reads() {
         EXTEND_TO
     );
 }
+
+/// Registers a contract holding one leaf, then pauses mutations. Returns the
+/// client, the key it holds, and that key's value.
+fn paused_with_one_leaf(env: &Env) -> (ASPNonMembershipClient<'_>, U256, U256) {
+    let admin = Address::generate(env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(env, &contract_id);
+    let key = U256::from_u32(env, 1u32);
+    let value = U256::from_u32(env, 42u32);
+
+    env.mock_all_auths();
+    client.insert_leaf(&key, &value);
+    client.pause(&pausable::MUTATIONS, &None);
+    (client, key, value)
+}
+
+#[test]
+fn test_insert_leaf_rejected_while_paused() {
+    let env = test_env();
+    let (client, ..) = paused_with_one_leaf(&env);
+    let root_before = client.get_root();
+
+    let err = client
+        .try_insert_leaf(&U256::from_u32(&env, 7u32), &U256::from_u32(&env, 99u32))
+        .expect_err("an insert must be refused while mutations are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+    assert_eq!(client.get_root(), root_before);
+}
+
+#[test]
+fn test_delete_leaf_rejected_while_paused() {
+    let env = test_env();
+    let (client, key, value) = paused_with_one_leaf(&env);
+    let root_before = client.get_root();
+
+    let err = client
+        .try_delete_leaf(&key)
+        .expect_err("a delete must be refused while mutations are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+    assert_eq!(client.get_root(), root_before);
+    let find_result = client.find_key(&key);
+    assert!(find_result.found);
+    assert_eq!(find_result.found_value, value);
+}
+
+#[test]
+fn test_find_key_and_verify_work_while_paused() {
+    let env = test_env();
+    let (client, key, value) = paused_with_one_leaf(&env);
+    let absent_key = U256::from_u32(&env, 99u32);
+
+    let find_result = client.find_key(&absent_key);
+
+    assert!(!find_result.found);
+    assert_eq!(find_result.not_found_key, key);
+    assert_eq!(find_result.not_found_value, value);
+    assert!(client.verify_non_membership(
+        &absent_key,
+        &find_result.siblings,
+        &find_result.not_found_key,
+        &find_result.not_found_value,
+    ));
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_pause_requires_admin() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+
+    ASPNonMembershipClient::new(&env, &contract_id).pause(&pausable::MUTATIONS, &None);
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_unpause_requires_admin() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+
+    ASPNonMembershipClient::new(&env, &contract_id).unpause(&pausable::MUTATIONS);
+}
+
+#[test]
+fn test_pause_errors_when_admin_unset() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().remove(&DataKey::Admin);
+    });
+
+    assert_eq!(
+        client.try_pause(&pausable::MUTATIONS, &None),
+        Err(Ok(Error::NotInitialized))
+    );
+    assert_eq!(
+        client.try_unpause(&pausable::MUTATIONS),
+        Err(Ok(Error::NotInitialized))
+    );
+}
+
+#[test]
+fn test_writes_resume_after_unpause() {
+    let env = test_env();
+    let (client, key, _) = paused_with_one_leaf(&env);
+
+    client.unpause(&pausable::MUTATIONS);
+    client.insert_leaf(&U256::from_u32(&env, 7u32), &U256::from_u32(&env, 99u32));
+    client.delete_leaf(&key);
+
+    assert!(!client.find_key(&key).found);
+}
+
+#[test]
+fn test_second_timed_pause_keeps_the_deadline() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+    client.pause(&pausable::MUTATIONS, &Some(500));
+
+    env.ledger().set_sequence_number(499);
+    client.pause(&pausable::MUTATIONS, &Some(900));
+
+    assert_eq!(client.get_pause_state().until, Some(500));
+}
+
+#[test]
+fn test_unpause_leaves_until_so_a_second_timed_pause_is_still_refused() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+    env.mock_all_auths();
+    client.pause(&pausable::MUTATIONS, &Some(500));
+
+    client.unpause(&pausable::MUTATIONS);
+    let err = client
+        .try_pause(&pausable::MUTATIONS, &Some(900))
+        .expect_err("an unpause must not reopen the window before the promised ledger");
+
+    assert_eq!(err, Ok(Error::TimedPauseArmed));
+    assert_eq!(client.get_pause_state().until, Some(500));
+
+    env.ledger().set_sequence_number(500);
+    client.pause(&pausable::MUTATIONS, &Some(900));
+
+    assert_eq!(client.get_pause_state().until, Some(900));
+}
+
+/// `mock_all_auths` approves any signer, so the tests above cannot tell an
+/// admin signature from anyone else's. This one pins the address.
+///
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_pause_from_a_non_admin_is_refused() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+    let stranger = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &stranger,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "pause",
+            args: (pausable::MUTATIONS, None::<u32>).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.pause(&pausable::MUTATIONS, &None);
+}
+
+#[test]
+fn test_writes_are_allowed_again_after_the_deadline() {
+    let env = test_env();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ASPNonMembership, (admin,));
+    let client = ASPNonMembershipClient::new(&env, &contract_id);
+    let key = U256::from_u32(&env, 1u32);
+    env.mock_all_auths();
+    client.insert_leaf(&key, &U256::from_u32(&env, 42u32));
+    let until = env.ledger().sequence().saturating_add(10);
+    client.pause(&pausable::MUTATIONS, &Some(until));
+
+    env.ledger().set_sequence_number(until);
+    client.insert_leaf(&U256::from_u32(&env, 7u32), &U256::from_u32(&env, 99u32));
+    client.delete_leaf(&key);
+
+    assert!(!client.find_key(&key).found);
+    let state = client.get_pause_state();
+    assert_eq!(state.flags, pausable::MUTATIONS);
+    assert_eq!(state.until, Some(until));
+}

--- a/contracts/pool-gvk/src/pool_gvk.rs
+++ b/contracts/pool-gvk/src/pool_gvk.rs
@@ -25,7 +25,10 @@ use soroban_sdk::{
     contractimpl, contracttype, crypto::bn254::Bn254Fr, token::TokenClient,
 };
 use soroban_utils::{
-    AdminError, bump_dependency, bump_entry, bump_instance, constants::bn256_modulus,
+    AdminError, bump_dependency, bump_entry, bump_instance,
+    constants::bn256_modulus,
+    get_admin,
+    pausable::{self, PauseError, PauseState},
 };
 
 // Re-exported rather than merely imported so `pool_gvk::ExtData` and
@@ -74,6 +77,22 @@ pub enum Error {
     WrongGvkCiphertextCount = 16,
     /// Admin view key `D` is unusable as a circuit public input.
     InvalidAdminViewKey = 17,
+    /// Transactions of this shape are paused.
+    Paused = 18,
+    /// Pause flags were zero, or held a bit the pool does not recognize.
+    InvalidPauseFlags = 19,
+    /// A timed pause was asked for after every bit was cleared, while the
+    /// earlier deadline is still ahead.
+    TimedPauseArmed = 20,
+}
+
+impl From<PauseError> for Error {
+    fn from(e: PauseError) -> Self {
+        match e {
+            PauseError::InvalidFlags => Error::InvalidPauseFlags,
+            PauseError::TimedPauseArmed => Error::TimedPauseArmed,
+        }
+    }
 }
 
 impl From<MerkleError> for Error {
@@ -355,6 +374,70 @@ impl PoolGvkContract {
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
         Self::touch(&env);
         soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin).map_err(Error::from)
+    }
+
+    /// Pauses the transaction shapes named by `flags`.
+    ///
+    /// The bits are `DEPOSITS`, `TRANSFERS`, and `WITHDRAWALS` from
+    /// [`soroban_utils::pausable`]. Passing `Some(until)` promises that every
+    /// set bit stops being honored at that ledger. `Some(until)` joins a pause
+    /// already in force without moving its deadline, and is refused on a pool
+    /// whose bits were all cleared while an earlier `until` is still in the
+    /// future. Requires admin authorization.
+    ///
+    /// Once an earlier `until` has passed, `Some(until)` records the new
+    /// deadline for every bit still set, including the bits that deadline
+    /// released, because a lapsed deadline stops a bit being honored without
+    /// clearing it. Read [`PoolGvkContract::get_pause_state`] and clear stale
+    /// bits with [`PoolGvkContract::unpause`] before pausing one shape, or
+    /// the call freezes the other shapes an earlier pause left set.
+    ///
+    /// A pause stops `transact` and nothing else. `update_admin`, `unpause`,
+    /// and every getter answer while the pool is fully paused, so an operator
+    /// can hand over a paused pool.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the pool has no admin address
+    /// stored, [`Error::InvalidPauseFlags`] if `flags` is zero or holds a bit
+    /// outside the three above, and [`Error::TimedPauseArmed`] if `until` is
+    /// `Some` while no bit is set and an earlier `until` is still in the
+    /// future.
+    ///
+    /// # Events
+    ///
+    /// Publishes [`soroban_utils::pausable::PauseChanged`] from the pool.
+    pub fn pause(env: &Env, flags: u32, until: Option<u32>) -> Result<(), Error> {
+        Self::touch(env);
+        get_admin(env, &DataKey::Admin)?.require_auth();
+        Ok(pausable::pause(env, flags, until, pausable::POOL_MASK)?)
+    }
+
+    /// Clears the pause bits named by `flags`.
+    ///
+    /// Clearing bits that are not set is accepted, and a timed pause's `until`
+    /// stays in place. Requires admin authorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the pool has no admin address
+    /// stored, and [`Error::InvalidPauseFlags`] if `flags` is zero or holds a
+    /// bit the pool does not recognize.
+    ///
+    /// # Events
+    ///
+    /// Publishes [`soroban_utils::pausable::PauseChanged`] from the pool.
+    pub fn unpause(env: &Env, flags: u32) -> Result<(), Error> {
+        Self::touch(env);
+        get_admin(env, &DataKey::Admin)?.require_auth();
+        Ok(pausable::unpause(env, flags, pausable::POOL_MASK)?)
+    }
+
+    /// Returns the pool's pause bits and the ledger at which they stop being
+    /// honored.
+    pub fn get_pause_state(env: &Env) -> PauseState {
+        Self::touch(env);
+        pausable::get_state(env)
     }
 
     // ========== ASP Contract Functions ==========
@@ -643,7 +726,23 @@ impl PoolGvkContract {
     /// Execute a shielded transaction with deposit handling.
     ///
     /// If `ext_amount > 0`, tokens are transferred from the sender to the
-    /// pool before processing the transaction.
+    /// pool before processing the transaction. The shape of the transaction,
+    /// read from the sign of `ext_data.ext_amount`, must not be paused.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Paused`] if the transaction's shape is paused,
+    /// [`Error::NotInitialized`] if the token, the verifier, the policy flags,
+    /// the maximum deposit, or an ASP address the policy needs is not stored,
+    /// [`Error::UnknownRoot`] if `proof.root` is not in the root history,
+    /// [`Error::AlreadySpentNullifier`] if an input nullifier is spent,
+    /// [`Error::WrongExtHash`] if `ext_data` does not hash to
+    /// `proof.ext_data_hash`, [`Error::WrongExtAmount`] if
+    /// `proof.public_amount` does not match `ext_data.ext_amount`,
+    /// [`Error::InvalidProof`] if an ASP root in the proof differs from
+    /// that ASP's current root or the verifier rejects the proof, and
+    /// [`Error::MerkleTreeFull`], [`Error::NextIndexNotEven`], or
+    /// [`Error::Overflow`] if the output commitments cannot be inserted.
     pub fn transact(
         env: &Env,
         proof: Proof,
@@ -652,6 +751,11 @@ impl PoolGvkContract {
     ) -> Result<(), Error> {
         Self::touch(env);
         sender.require_auth();
+
+        if pausable::is_paused(env, pausable::shape_bit(env, &ext_data.ext_amount)) {
+            return Err(Error::Paused);
+        }
+
         bump_dependency(env, &Self::get_verifier(env)?);
         let policy_flags = Self::load_policy_flags(env)?;
         if policy::requires_membership_proofs(policy_flags) {

--- a/contracts/pool-gvk/src/test.rs
+++ b/contracts/pool-gvk/src/test.rs
@@ -30,6 +30,7 @@ use soroban_sdk::{
 };
 use soroban_utils::{
     constants::bn256_modulus,
+    pausable::{self, PauseChanged},
     ttl::{EXTEND_TO, THRESHOLD},
     utils::MockToken,
 };
@@ -2004,4 +2005,303 @@ fn getters_extend_the_instance() {
     pool.get_root();
 
     assert_eq!(instance_ttl(&env, &pool_id), EXTEND_TO);
+}
+
+/// A GVK pool with no ASP policy in view-only mode, for paths that never reach
+/// a proof.
+fn default_gvk_pool(env: &Env) -> Address {
+    let setup = setup_test_contracts(env);
+    register_pool_gvk(
+        env,
+        &setup,
+        U256::from_u32(env, 1000),
+        3,
+        0,
+        mk_point(env, 1, 2),
+        VIEW_ONLY,
+    )
+}
+
+/// [`default_gvk_pool`] with every authorization mocked.
+fn pausable_pool_gvk(env: &Env) -> PoolGvkContractClient<'static> {
+    env.mock_all_auths();
+    PoolGvkContractClient::new(env, &default_gvk_pool(env))
+}
+
+#[test]
+fn transact_rejects_deposit_while_deposits_paused() {
+    let nullifier = 0xF1;
+    let (env, pool, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, nullifier, 500, 1000);
+    pool.pause(&pausable::DEPOSITS, &None);
+
+    let err = pool
+        .try_transact(&proof, &ext, &sender)
+        .expect_err("a deposit must be refused while deposits are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+    assert!(!pool.is_spent(&U256::from_u32(&env, nullifier)));
+}
+
+#[test]
+fn transact_allows_withdrawal_and_transfer_while_only_deposits_paused() {
+    let (_, withdrawing, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, 0xF2, -300, 1000);
+    withdrawing.pause(&pausable::DEPOSITS, &None);
+    withdrawing.transact(&proof, &ext, &sender);
+
+    let (_, transferring, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, 0xF3, 0, 1000);
+    transferring.pause(&pausable::DEPOSITS, &None);
+    transferring.transact(&proof, &ext, &sender);
+}
+
+#[test]
+fn transact_rejects_transfer_while_transfers_paused() {
+    let (_, pool, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, 0xF4, 0, 1000);
+    pool.pause(&pausable::TRANSFERS, &None);
+
+    let err = pool
+        .try_transact(&proof, &ext, &sender)
+        .expect_err("a transfer must be refused while transfers are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+}
+
+#[test]
+fn transact_rejects_withdrawal_while_withdrawals_paused() {
+    let (_, pool, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, 0xF5, -300, 1000);
+    pool.pause(&pausable::WITHDRAWALS, &None);
+
+    let err = pool
+        .try_transact(&proof, &ext, &sender)
+        .expect_err("a withdrawal must be refused while withdrawals are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+}
+
+#[test]
+fn full_pause_blocks_all_three_shapes() {
+    for ext_amount in [500i32, 0, -300] {
+        let (_, pool, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, 0xF6, ext_amount, 1000);
+        pool.pause(&pausable::POOL_MASK, &None);
+
+        let err = pool
+            .try_transact(&proof, &ext, &sender)
+            .expect_err("a fully paused pool must refuse every shape");
+
+        assert_eq!(
+            err,
+            Ok(Error::Paused),
+            "ext_amount {ext_amount} was allowed"
+        );
+    }
+}
+
+#[test]
+fn every_shape_reopens_when_the_timed_pause_expires() {
+    for ext_amount in [500i32, 0, -300] {
+        let (env, pool, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, 0xF7, ext_amount, 1000);
+        let until = env.ledger().sequence().saturating_add(10);
+        pool.pause(&pausable::POOL_MASK, &Some(until));
+
+        env.ledger().set_sequence_number(until);
+        pool.transact(&proof, &ext, &sender);
+
+        let state = pool.get_pause_state();
+        assert_eq!(state.flags, pausable::POOL_MASK);
+        assert_eq!(state.until, Some(until));
+    }
+}
+
+#[test]
+fn transact_succeeds_again_after_unpause() {
+    let (_, pool, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, 0xF8, 0, 1000);
+    pool.pause(&pausable::TRANSFERS, &None);
+    assert_eq!(
+        pool.try_transact(&proof, &ext, &sender),
+        Err(Ok(Error::Paused))
+    );
+
+    pool.unpause(&pausable::TRANSFERS);
+
+    pool.transact(&proof, &ext, &sender);
+}
+
+#[test]
+fn update_admin_works_while_fully_paused() {
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+    pool.pause(&pausable::POOL_MASK, &None);
+    let new_admin = Address::generate(&env);
+
+    pool.update_admin(&new_admin);
+
+    let stored: Address = env.as_contract(&pool.address, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Admin updated")
+    });
+    assert_eq!(stored, new_admin);
+}
+
+#[test]
+fn getters_work_while_fully_paused() {
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+    pool.pause(&pausable::POOL_MASK, &None);
+
+    let root = pool.get_root();
+
+    assert!(pool.is_known_root(&root));
+    assert_eq!(pool.get_gvk_mode(), VIEW_ONLY);
+}
+
+#[test]
+fn get_admin_view_key_works_while_fully_paused() {
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+    pool.pause(&pausable::POOL_MASK, &None);
+
+    assert_eq!(pool.get_admin_view_key(), mk_point(&env, 1, 2));
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn pause_requires_admin() {
+    let env = test_env();
+    PoolGvkContractClient::new(&env, &default_gvk_pool(&env)).pause(&pausable::DEPOSITS, &None);
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn unpause_requires_admin() {
+    let env = test_env();
+    PoolGvkContractClient::new(&env, &default_gvk_pool(&env)).unpause(&pausable::DEPOSITS);
+}
+
+#[test]
+fn pause_errors_when_admin_unset() {
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+    env.as_contract(&pool.address, || {
+        env.storage().persistent().remove(&DataKey::Admin);
+    });
+
+    assert_eq!(
+        pool.try_pause(&pausable::DEPOSITS, &None)
+            .expect_err("a pool with no admin cannot be paused"),
+        Ok(Error::NotInitialized)
+    );
+    assert_eq!(
+        pool.try_unpause(&pausable::DEPOSITS)
+            .expect_err("a pool with no admin cannot be unpaused"),
+        Ok(Error::NotInitialized)
+    );
+}
+
+#[test]
+fn pause_rejects_zero_flags() {
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+
+    let err = pool
+        .try_pause(&0u32, &None)
+        .expect_err("a pause that names no bit must be refused");
+
+    assert_eq!(err, Ok(Error::InvalidPauseFlags));
+}
+
+#[test]
+fn pause_rejects_unknown_bits() {
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+
+    let err = pool
+        .try_pause(&8u32, &None)
+        .expect_err("a pause naming a bit the pool does not honor must be refused");
+
+    assert_eq!(err, Ok(Error::InvalidPauseFlags));
+}
+
+#[test]
+fn second_timed_pause_adds_bits_and_keeps_the_deadline() {
+    let (env, pool, proof, ext, sender) = build_gvk_transact(VIEW_ONLY, 0xF9, 500, 1000);
+    let until = env.ledger().sequence().saturating_add(10);
+    pool.pause(&pausable::DEPOSITS, &Some(until));
+
+    pool.pause(&pausable::WITHDRAWALS, &Some(until.saturating_add(40)));
+
+    let err = pool
+        .try_transact(&proof, &ext, &sender)
+        .expect_err("deposits stay paused after a second timed pause");
+    assert_eq!(err, Ok(Error::Paused));
+    // The pause check reads only the sign of `ext_amount`, and it runs before
+    // the proof is looked at, so a withdrawal-shaped call needs no proof of
+    // its own to prove that withdrawals are shut too.
+    let withdrawal = mk_ext_data(&env, Address::generate(&env), -300);
+    let err = pool
+        .try_transact(&proof, &withdrawal, &sender)
+        .expect_err("a second timed pause adds its bits");
+    assert_eq!(err, Ok(Error::Paused));
+    assert_eq!(pool.get_pause_state().until, Some(until));
+}
+
+#[test]
+fn unpause_leaves_until_so_a_second_timed_pause_is_still_refused() {
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+    pool.pause(&pausable::WITHDRAWALS, &Some(500));
+
+    pool.unpause(&pausable::POOL_MASK);
+    let err = pool
+        .try_pause(&pausable::DEPOSITS, &Some(900))
+        .expect_err("an unpause must not reopen the window before the promised ledger");
+
+    assert_eq!(err, Ok(Error::TimedPauseArmed));
+    assert_eq!(pool.get_pause_state().until, Some(500));
+
+    env.ledger().set_sequence_number(500);
+    pool.pause(&pausable::DEPOSITS, &Some(900));
+
+    assert_eq!(pool.get_pause_state().until, Some(900));
+}
+
+#[test]
+fn untimed_pause_clears_until_so_a_timed_pause_is_accepted_again() {
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+    pool.pause(&pausable::WITHDRAWALS, &Some(500));
+
+    pool.pause(&pausable::DEPOSITS, &None);
+    pool.unpause(&pausable::POOL_MASK);
+    pool.pause(&pausable::TRANSFERS, &Some(900));
+
+    let state = pool.get_pause_state();
+    assert_eq!(state.flags, pausable::TRANSFERS);
+    assert_eq!(state.until, Some(900));
+}
+
+#[test]
+fn pause_emits_pause_changed_from_the_pool_address() {
+    use soroban_sdk::events::Event;
+    let env = test_env();
+    let pool = pausable_pool_gvk(&env);
+
+    pool.pause(&pausable::DEPOSITS, &Some(500));
+
+    let events = env.events().all();
+    assert_eq!(events.events().len(), 1);
+    let expected = PauseChanged {
+        flags: pausable::DEPOSITS,
+        until: Some(500),
+    }
+    .to_xdr(&env, &pool.address);
+    assert_eq!(events.events()[0], expected);
 }

--- a/contracts/pool/src/pool.rs
+++ b/contracts/pool/src/pool.rs
@@ -24,7 +24,10 @@ use soroban_sdk::{
     contractimpl, contracttype, crypto::bn254::Bn254Fr, token::TokenClient,
 };
 use soroban_utils::{
-    AdminError, bump_dependency, bump_entry, bump_instance, constants::bn256_modulus, get_admin,
+    AdminError, bump_dependency, bump_entry, bump_instance,
+    constants::bn256_modulus,
+    get_admin,
+    pausable::{self, PauseError, PauseState},
 };
 
 // Re-exported rather than merely imported so `pool::ExtData` and
@@ -65,6 +68,22 @@ pub enum Error {
     NonCanonicalPublicInput = 13,
     /// Unsupported policy flag bits.
     InvalidPolicyFlags = 14,
+    /// Transactions of this shape are paused.
+    Paused = 15,
+    /// Pause flags were zero, or held a bit the pool does not recognize.
+    InvalidPauseFlags = 16,
+    /// A timed pause was asked for after every bit was cleared, while the
+    /// earlier deadline is still ahead.
+    TimedPauseArmed = 17,
+}
+
+impl From<PauseError> for Error {
+    fn from(e: PauseError) -> Self {
+        match e {
+            PauseError::InvalidFlags => Error::InvalidPauseFlags,
+            PauseError::TimedPauseArmed => Error::TimedPauseArmed,
+        }
+    }
 }
 
 /// Conversion from MerkleTreeWithHistory errors to pool contract errors
@@ -429,7 +448,8 @@ impl PoolContract {
     ///
     /// This is the main entry point for users to interact with the pool.
     /// If `ext_amount > 0`, tokens are transferred from the sender to the pool
-    /// before processing the transaction.
+    /// before processing the transaction. The shape of the transaction, read
+    /// from the sign of `ext_data.ext_amount`, must not be paused.
     ///
     /// # Arguments
     ///
@@ -439,9 +459,20 @@ impl PoolContract {
     /// * `sender` - Address of the transaction sender (must authorize funding
     ///   transaction)
     ///
-    /// # Returns
+    /// # Errors
     ///
-    /// Returns `Ok(())` on success, or an error if validation fails
+    /// Returns [`Error::Paused`] if the transaction's shape is paused,
+    /// [`Error::NotInitialized`] if the token, the verifier, the policy flags,
+    /// the maximum deposit, or an ASP address the policy needs is not stored,
+    /// [`Error::UnknownRoot`] if `proof.root` is not in the root history,
+    /// [`Error::AlreadySpentNullifier`] if an input nullifier is spent,
+    /// [`Error::WrongExtHash`] if `ext_data` does not hash to
+    /// `proof.ext_data_hash`, [`Error::WrongExtAmount`] if
+    /// `proof.public_amount` does not match `ext_data.ext_amount`,
+    /// [`Error::InvalidProof`] if an ASP root in the proof differs from
+    /// that ASP's current root or the verifier rejects the proof, and
+    /// [`Error::MerkleTreeFull`], [`Error::NextIndexNotEven`], or
+    /// [`Error::Overflow`] if the output commitments cannot be inserted.
     pub fn transact(
         env: &Env,
         proof: Proof,
@@ -450,6 +481,11 @@ impl PoolContract {
     ) -> Result<(), Error> {
         Self::touch(env);
         sender.require_auth();
+
+        if pausable::is_paused(env, pausable::shape_bit(env, &ext_data.ext_amount)) {
+            return Err(Error::Paused);
+        }
+
         bump_dependency(env, &Self::get_verifier(env)?);
         let policy_flags = Self::load_policy_flags(env)?;
         if policy::requires_membership_proofs(policy_flags) {
@@ -689,6 +725,72 @@ impl PoolContract {
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
         Self::touch(&env);
         soroban_utils::update_admin(&env, &DataKey::Admin, &new_admin).map_err(Error::from)
+    }
+
+    /// Pauses the transaction shapes named by `flags`.
+    ///
+    /// The bits are `DEPOSITS`, `TRANSFERS`, and `WITHDRAWALS` from
+    /// [`soroban_utils::pausable`]. Passing `Some(until)` promises that every
+    /// set bit stops being honored at that ledger. `Some(until)` joins a pause
+    /// already in force without moving its deadline, and is refused on a pool
+    /// whose bits were all cleared while an earlier `until` is still in the
+    /// future. Requires admin authorization.
+    ///
+    /// Once an earlier `until` has passed, `Some(until)` records the new
+    /// deadline for every bit still set, including the bits that deadline
+    /// released, because a lapsed deadline stops a bit being honored without
+    /// clearing it. Read [`PoolContract::get_pause_state`] and clear stale bits
+    /// with [`PoolContract::unpause`] before pausing one shape, or the call
+    /// freezes the other shapes an earlier pause left set.
+    ///
+    /// A pause stops `transact` and nothing else. Administration keeps working
+    /// throughout: `update_admin`, `update_asp_membership`,
+    /// `update_asp_non_membership`, `unpause`, and every getter answer while
+    /// the pool is fully paused, so an operator can repoint or hand over a
+    /// paused pool.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the pool has no admin address
+    /// stored, [`Error::InvalidPauseFlags`] if `flags` is zero or holds a bit
+    /// outside the three above, and [`Error::TimedPauseArmed`] if `until` is
+    /// `Some` while no bit is set and an earlier `until` is still in the
+    /// future.
+    ///
+    /// # Events
+    ///
+    /// Publishes [`soroban_utils::pausable::PauseChanged`] from the pool.
+    pub fn pause(env: &Env, flags: u32, until: Option<u32>) -> Result<(), Error> {
+        Self::touch(env);
+        get_admin(env, &DataKey::Admin)?.require_auth();
+        Ok(pausable::pause(env, flags, until, pausable::POOL_MASK)?)
+    }
+
+    /// Clears the pause bits named by `flags`.
+    ///
+    /// Clearing bits that are not set is accepted, and a timed pause's `until`
+    /// stays in place. Requires admin authorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotInitialized`] if the pool has no admin address
+    /// stored, and [`Error::InvalidPauseFlags`] if `flags` is zero or holds a
+    /// bit the pool does not recognize.
+    ///
+    /// # Events
+    ///
+    /// Publishes [`soroban_utils::pausable::PauseChanged`] from the pool.
+    pub fn unpause(env: &Env, flags: u32) -> Result<(), Error> {
+        Self::touch(env);
+        get_admin(env, &DataKey::Admin)?.require_auth();
+        Ok(pausable::unpause(env, flags, pausable::POOL_MASK)?)
+    }
+
+    /// Returns the pool's pause bits and the ledger at which they stop being
+    /// honored.
+    pub fn get_pause_state(env: &Env) -> PauseState {
+        Self::touch(env);
+        pausable::get_state(env)
     }
 
     // ========== ASP Contract Functions ==========

--- a/contracts/pool/src/test.rs
+++ b/contracts/pool/src/test.rs
@@ -19,6 +19,7 @@ use soroban_sdk::{
 };
 use soroban_utils::{
     constants::bn256_modulus,
+    pausable::{self, PauseChanged},
     ttl::{EXTEND_TO, THRESHOLD},
     utils::MockToken,
 };
@@ -1984,4 +1985,377 @@ fn transact_rejects_deposit_with_invalid_proof_without_moving_funds() {
         0,
         "a refused deposit must not credit the pool"
     );
+}
+
+/// Tokens minted to the sender and to the pool by [`pausable_pool`], enough for
+/// any single deposit or withdrawal the pause tests make.
+const PAUSE_FIXTURE_FUNDS: i128 = 10_000;
+
+/// A pool on a verifier that accepts every proof, holding a real asset so that
+/// a deposit or a withdrawal shows up in balances. Authorizations are mocked,
+/// and the pool carries no ASP policy, so only the pause check stands between a
+/// well-formed transaction and success.
+fn pausable_pool(env: &Env, sender: &Address) -> (TestSetup, PoolContractClient<'static>) {
+    env.mock_all_auths();
+    let mut setup = setup_test_contracts(env);
+    setup.token = register_funded_token(env, sender, PAUSE_FIXTURE_FUNDS);
+    let verifier = env.register(AcceptingVerifier, ());
+    let pool_id = register_pool_with_verifier(env, &setup, &verifier, 3, 0);
+    StellarAssetClient::new(env, &setup.token).mint(&pool_id, &PAUSE_FIXTURE_FUNDS);
+    let pool = PoolContractClient::new(env, &pool_id);
+    (setup, pool)
+}
+
+/// The public amount a proof must carry for `ext_amount`: the value itself for
+/// a deposit or a transfer, and the field's complement for a withdrawal.
+fn expected_public_amount(env: &Env, ext_amount: i32) -> U256 {
+    let magnitude = U256::from_u32(env, ext_amount.unsigned_abs());
+    if ext_amount < 0 {
+        bn256_modulus(env).sub(&magnitude)
+    } else {
+        magnitude
+    }
+}
+
+/// A proof and external data moving `ext_amount`, consistent enough that only
+/// the pause check can refuse it.
+fn mk_transact_of(
+    env: &Env,
+    setup: &TestSetup,
+    pool: &PoolContractClient,
+    ext_amount: i32,
+    nullifier: u32,
+) -> (Proof, ExtData) {
+    let (member_root, non_member_root) = asp_roots(setup);
+    let (mut proof, _) = mk_transact_proof(env, pool, member_root, non_member_root, nullifier);
+    let ext = mk_ext_data(env, Address::generate(env), ext_amount);
+    proof.ext_data_hash = compute_ext_hash(env, &ext);
+    proof.public_amount = expected_public_amount(env, ext_amount);
+    (proof, ext)
+}
+
+#[test]
+fn transact_rejects_deposit_while_deposits_paused() {
+    use soroban_sdk::testutils::Events;
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (setup, pool) = pausable_pool(&env, &sender);
+    let token = TokenClient::new(&env, &setup.token);
+    pool.pause(&pausable::DEPOSITS, &None);
+
+    let nullifier = 0xD1;
+    let (proof, ext) = mk_transact_of(&env, &setup, &pool, 500, nullifier);
+    let err = pool
+        .try_transact(&proof, &ext, &sender)
+        .expect_err("a deposit must be refused while deposits are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+    assert_eq!(token.balance(&sender), PAUSE_FIXTURE_FUNDS);
+    assert_eq!(token.balance(&pool.address), PAUSE_FIXTURE_FUNDS);
+    assert!(!pool.is_spent(&U256::from_u32(&env, nullifier)));
+    assert!(env.events().all().events().is_empty());
+}
+
+#[test]
+fn transact_allows_withdrawal_and_transfer_while_only_deposits_paused() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (setup, pool) = pausable_pool(&env, &sender);
+    let token = TokenClient::new(&env, &setup.token);
+    pool.pause(&pausable::DEPOSITS, &None);
+
+    let (withdrawal, withdrawal_ext) = mk_transact_of(&env, &setup, &pool, -300, 0xD2);
+    pool.transact(&withdrawal, &withdrawal_ext, &sender);
+    let (transfer, transfer_ext) = mk_transact_of(&env, &setup, &pool, 0, 0xD3);
+    pool.transact(&transfer, &transfer_ext, &sender);
+
+    assert_eq!(
+        token.balance(&pool.address),
+        PAUSE_FIXTURE_FUNDS.saturating_sub(300)
+    );
+}
+
+#[test]
+fn transact_rejects_transfer_while_transfers_paused() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (setup, pool) = pausable_pool(&env, &sender);
+    pool.pause(&pausable::TRANSFERS, &None);
+
+    let (proof, ext) = mk_transact_of(&env, &setup, &pool, 0, 0xD4);
+    let err = pool
+        .try_transact(&proof, &ext, &sender)
+        .expect_err("a transfer must be refused while transfers are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+}
+
+#[test]
+fn transact_rejects_withdrawal_while_withdrawals_paused() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (setup, pool) = pausable_pool(&env, &sender);
+    let token = TokenClient::new(&env, &setup.token);
+    pool.pause(&pausable::WITHDRAWALS, &None);
+
+    let (proof, ext) = mk_transact_of(&env, &setup, &pool, -300, 0xD5);
+    let err = pool
+        .try_transact(&proof, &ext, &sender)
+        .expect_err("a withdrawal must be refused while withdrawals are paused");
+
+    assert_eq!(err, Ok(Error::Paused));
+    assert_eq!(token.balance(&pool.address), PAUSE_FIXTURE_FUNDS);
+}
+
+#[test]
+fn full_pause_blocks_all_three_shapes() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (setup, pool) = pausable_pool(&env, &sender);
+    pool.pause(&pausable::POOL_MASK, &None);
+
+    for ext_amount in [500i32, 0, -300] {
+        let (proof, ext) = mk_transact_of(&env, &setup, &pool, ext_amount, 0xD6);
+        let err = pool
+            .try_transact(&proof, &ext, &sender)
+            .expect_err("a fully paused pool must refuse every shape");
+        assert_eq!(
+            err,
+            Ok(Error::Paused),
+            "ext_amount {ext_amount} was allowed"
+        );
+    }
+}
+
+#[test]
+fn every_shape_reopens_when_the_timed_pause_expires() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (setup, pool) = pausable_pool(&env, &sender);
+    let token = TokenClient::new(&env, &setup.token);
+    let until = env.ledger().sequence().saturating_add(10);
+    pool.pause(&pausable::POOL_MASK, &Some(until));
+
+    env.ledger().set_sequence_number(until);
+
+    let (deposit, deposit_ext) = mk_transact_of(&env, &setup, &pool, 500, 0xD7);
+    pool.transact(&deposit, &deposit_ext, &sender);
+    let (transfer, transfer_ext) = mk_transact_of(&env, &setup, &pool, 0, 0xD8);
+    pool.transact(&transfer, &transfer_ext, &sender);
+    let (withdrawal, withdrawal_ext) = mk_transact_of(&env, &setup, &pool, -300, 0xDA);
+    pool.transact(&withdrawal, &withdrawal_ext, &sender);
+
+    assert_eq!(
+        token.balance(&pool.address),
+        PAUSE_FIXTURE_FUNDS.saturating_add(200)
+    );
+    let state = pool.get_pause_state();
+    assert_eq!(state.flags, pausable::POOL_MASK);
+    assert_eq!(state.until, Some(until));
+}
+
+#[test]
+fn transact_succeeds_again_after_unpause() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (setup, pool) = pausable_pool(&env, &sender);
+    pool.pause(&pausable::TRANSFERS, &None);
+    let (proof, ext) = mk_transact_of(&env, &setup, &pool, 0, 0xD9);
+    assert_eq!(
+        pool.try_transact(&proof, &ext, &sender),
+        Err(Ok(Error::Paused))
+    );
+
+    pool.unpause(&pausable::TRANSFERS);
+
+    pool.transact(&proof, &ext, &sender);
+}
+
+#[test]
+fn update_admin_works_while_fully_paused() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (_, pool) = pausable_pool(&env, &sender);
+    pool.pause(&pausable::POOL_MASK, &None);
+    let new_admin = Address::generate(&env);
+
+    pool.update_admin(&new_admin);
+
+    let stored: Address = env.as_contract(&pool.address, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Admin updated")
+    });
+    assert_eq!(stored, new_admin);
+}
+
+#[test]
+fn getters_work_while_fully_paused() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (setup, pool) = pausable_pool(&env, &sender);
+    pool.pause(&pausable::POOL_MASK, &None);
+
+    let root = pool.get_root();
+
+    assert!(pool.is_known_root(&root));
+    assert_eq!(
+        pool.get_asp_membership_root(),
+        setup.asp_membership_client.get_root()
+    );
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn pause_requires_admin() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 3, 0u32);
+
+    PoolContractClient::new(&env, &pool_id).pause(&pausable::DEPOSITS, &None);
+}
+
+/// This test is skipped under Miri because the panic formatting path triggers
+/// undefined behavior in the `ethnum` crate's unsafe formatting code.
+/// See: https://github.com/nlordell/ethnum-rs/issues/34
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn unpause_requires_admin() {
+    let env = test_env();
+    let setup = setup_test_contracts(&env);
+    let pool_id = register_pool(&env, &setup, U256::from_u32(&env, 1000), 3, 0u32);
+
+    PoolContractClient::new(&env, &pool_id).unpause(&pausable::DEPOSITS);
+}
+
+#[test]
+fn pause_errors_when_admin_unset() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (_, pool) = pausable_pool(&env, &sender);
+    env.as_contract(&pool.address, || {
+        env.storage().persistent().remove(&DataKey::Admin);
+    });
+
+    assert_eq!(
+        pool.try_pause(&pausable::DEPOSITS, &None)
+            .expect_err("a pool with no admin cannot be paused"),
+        Ok(Error::NotInitialized)
+    );
+    assert_eq!(
+        pool.try_unpause(&pausable::DEPOSITS)
+            .expect_err("a pool with no admin cannot be unpaused"),
+        Ok(Error::NotInitialized)
+    );
+}
+
+#[test]
+fn pause_rejects_zero_flags() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (_, pool) = pausable_pool(&env, &sender);
+
+    let err = pool
+        .try_pause(&0u32, &None)
+        .expect_err("a pause that names no bit must be refused");
+
+    assert_eq!(err, Ok(Error::InvalidPauseFlags));
+}
+
+#[test]
+fn pause_rejects_unknown_bits() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (_, pool) = pausable_pool(&env, &sender);
+
+    let err = pool
+        .try_pause(&8u32, &None)
+        .expect_err("a pause naming a bit the pool does not honor must be refused");
+
+    assert_eq!(err, Ok(Error::InvalidPauseFlags));
+}
+
+#[test]
+fn second_timed_pause_adds_bits_and_keeps_the_deadline() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (setup, pool) = pausable_pool(&env, &sender);
+    let until = env.ledger().sequence().saturating_add(10);
+    pool.pause(&pausable::DEPOSITS, &Some(until));
+
+    pool.pause(&pausable::WITHDRAWALS, &Some(until.saturating_add(40)));
+
+    let (deposit, deposit_ext) = mk_transact_of(&env, &setup, &pool, 500, 0xDB);
+    let err = pool
+        .try_transact(&deposit, &deposit_ext, &sender)
+        .expect_err("deposits stay paused after a second timed pause");
+    assert_eq!(err, Ok(Error::Paused));
+    let (withdrawal, withdrawal_ext) = mk_transact_of(&env, &setup, &pool, -300, 0xDC);
+    let err = pool
+        .try_transact(&withdrawal, &withdrawal_ext, &sender)
+        .expect_err("a second timed pause adds its bits");
+    assert_eq!(err, Ok(Error::Paused));
+    assert_eq!(pool.get_pause_state().until, Some(until));
+}
+
+#[test]
+fn unpause_leaves_until_so_a_second_timed_pause_is_still_refused() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (_, pool) = pausable_pool(&env, &sender);
+    pool.pause(&pausable::WITHDRAWALS, &Some(500));
+
+    pool.unpause(&pausable::POOL_MASK);
+    let err = pool
+        .try_pause(&pausable::DEPOSITS, &Some(900))
+        .expect_err("an unpause must not reopen the window before the promised ledger");
+
+    assert_eq!(err, Ok(Error::TimedPauseArmed));
+    assert_eq!(pool.get_pause_state().until, Some(500));
+
+    env.ledger().set_sequence_number(500);
+    pool.pause(&pausable::DEPOSITS, &Some(900));
+
+    assert_eq!(pool.get_pause_state().until, Some(900));
+}
+
+#[test]
+fn untimed_pause_clears_until_so_a_timed_pause_is_accepted_again() {
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (_, pool) = pausable_pool(&env, &sender);
+    pool.pause(&pausable::WITHDRAWALS, &Some(500));
+
+    pool.pause(&pausable::DEPOSITS, &None);
+    pool.unpause(&pausable::POOL_MASK);
+    pool.pause(&pausable::TRANSFERS, &Some(900));
+
+    let state = pool.get_pause_state();
+    assert_eq!(state.flags, pausable::TRANSFERS);
+    assert_eq!(state.until, Some(900));
+}
+
+#[test]
+fn pause_emits_pause_changed_from_the_pool_address() {
+    use soroban_sdk::{events::Event, testutils::Events};
+    let env = test_env();
+    let sender = Address::generate(&env);
+    let (_, pool) = pausable_pool(&env, &sender);
+
+    pool.pause(&pausable::DEPOSITS, &Some(500));
+
+    let events = env.events().all();
+    assert_eq!(events.events().len(), 1);
+    let expected = PauseChanged {
+        flags: pausable::DEPOSITS,
+        until: Some(500),
+    }
+    .to_xdr(&env, &pool.address);
+    assert_eq!(events.events()[0], expected);
 }


### PR DESCRIPTION
Wires the `pausable` module into the four contracts that hold funds or trees: `pool`,
`pool-gvk`, `asp-membership`, and `asp-non-membership`.

## Where the check sits, and why there

`transact` picks its bit from the sign of `ext_data.ext_amount`. Positive is a deposit, zero a
transfer between notes already in the pool, negative a withdrawal. An operator can therefore
stop deposits while letting users withdraw, which is usually what an incident calls for.

The check runs immediately after `require_auth` and before the token read, so a paused
transaction touches no balances and moves no funds. Placing it later would risk a refusal after
a partial effect.

`insert_leaf` and `delete_leaf` check `MUTATIONS` immediately after the admin authorizes,
before any tree state is read or written, so a refused write leaves the root and the index
exactly as they were.

## Administration is never gated

`update_admin`, `unpause`, and every getter answer while a contract is fully paused. A pause
stops user traffic; locking the operator out of the contract they need to fix or hand over
would make an incident worse. Each of these has a test that pauses everything and then
exercises it.

## Who can pause

The three new entry points require the contract's existing `admin` key. No new key, role, or
approval mechanism arrives here. The governor takes over those keys in a later PR.

## Breaking changes

New error variants, each appended at the next free number in its contract, nothing renumbered:

| Contract | Paused | InvalidPauseFlags | TimedPauseArmed |
| --- | --- | --- | --- |
| `pool` | 15 | 16 | 17 |
| `pool-gvk` | 18 | 19 | 20 |
| `asp-membership` | 6 | 7 | 8 |
| `asp-non-membership` | 7 | 8 | 9 |

All four contracts gain `pause`, `unpause`, and `get_pause_state`. `transact`, `insert_leaf`,
and `delete_leaf` gain a failure mode callers did not previously have to handle, which is what
earns the breaking marker: a client that treats every error as fatal will surface a pause as a
hard failure rather than as a state that will clear.

## Reviewing the repetition

`pool` and `pool-gvk` take the same change as each other, as do the two ASP contracts. Reading
`pool` and `asp-membership` closely and then diffing their counterparts covers the substance.

Part of #372.
