### PR TITLE
Read governance state and restore archived entries in the SDK

### DIFF
--- a/sdk/native/src/account.rs
+++ b/sdk/native/src/account.rs
@@ -8,6 +8,7 @@ use crate::chain::{Limits, ReadXdr, StateFetcher, TransactionEnvelope, submit_tx
 use crate::{
     Error, Handle, PrivatePool, Prover, Signer, Storage,
     chain::RpcClient,
+    pool::{refuse_second_restore, restore_archived_entries},
     sync::{SyncHandle, catch_up, confirm_tx},
     types::{PrivatePoolConfig, TransactionResult},
 };
@@ -163,13 +164,23 @@ impl<S: Storage> Account<S> {
 
         let fetcher = StateFetcher::new(self.rpc.clone(), self.contract_config.clone())
             .map_err(|e| Error::Other(format!("state fetcher: {e:#}")))?;
-        let prepared = fetcher
+        let mut prepared = fetcher
             // Registration uses the note-owner address, which is both the
             // registry key and the transaction source. Which it should be when
             // the two identities differ is unsettled.
             .prepare_register(self.user_address.as_str(), note_pk.0, enc_pk.0)
             .await
             .map_err(|e| Error::Other(format!("prepare register: {e:#}")))?;
+
+        if let Some(restore_tx_xdr) = prepared.restore_tx_xdr.take() {
+            restore_archived_entries(&self.rpc, &self.signer, restore_tx_xdr).await?;
+            prepared = fetcher
+                .prepare_register(self.user_address.as_str(), note_pk.0, enc_pk.0)
+                .await
+                .map_err(|e| Error::Other(format!("prepare register after restore: {e:#}")))?;
+            refuse_second_restore(&prepared)?;
+        }
+
         let signed = self.signer.sign_soroban_transaction(&prepared).await?;
         let envelope = TransactionEnvelope::from_xdr_base64(&signed.signed_xdr, Limits::none())
             .map_err(|e| Error::Other(format!("invalid signed transaction xdr: {e}")))?;

--- a/sdk/native/src/blocking/pool.rs
+++ b/sdk/native/src/blocking/pool.rs
@@ -114,6 +114,17 @@ impl PrivatePool {
         block_on(self.inner.balance())
     }
 
+    /// Simulates the prepared transaction and fills in the fee, the footprint,
+    /// and the authorization entries it needs.
+    ///
+    /// A simulation whose footprint reaches an archived entry submits a
+    /// footprint restore through the signer first, which asks for a signature
+    /// and spends a fee on chain.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Other`] if the simulation fails, or if a restore cannot
+    /// be signed, submitted, or confirmed.
     pub fn simulate(&self, prepared: &mut PreparedTransaction) -> Result<(), Error> {
         block_on(self.inner.simulate(prepared))
     }

--- a/sdk/native/src/chain/contract_state.rs
+++ b/sdk/native/src/chain/contract_state.rs
@@ -64,6 +64,11 @@ pub struct PreparedSorobanTx {
     /// Ledger number from `simulateTransaction` (`latestLedger`), for auth
     /// expiration.
     pub latest_ledger: u32,
+    /// Base64-encoded XDR of a `RestoreFootprint` transaction the caller must
+    /// submit before this invocation can succeed. `None` when every entry the
+    /// invocation touches is live.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub restore_tx_xdr: Option<String>,
 }
 
 impl StateFetcher {

--- a/sdk/native/src/chain/contract_state.rs
+++ b/sdk/native/src/chain/contract_state.rs
@@ -1,7 +1,7 @@
 use super::{
     conversions::{
         field_to_scval_u256, scval_to_address_string, scval_to_baby_jub_jub_point, scval_to_bool,
-        scval_to_policy_flags, scval_to_u32, scval_to_u64, scval_to_u256,
+        scval_to_pause_state, scval_to_policy_flags, scval_to_u32, scval_to_u64, scval_to_u256,
     },
     rpc::{Client, ContractDataBulkRequest},
     soroban_encode::BASE_FEE,
@@ -15,7 +15,7 @@ use stellar_xdr::{self as xdr, ReadXdr};
 use crate::types::{
     AspMembership, AspNonMembership, AspNonMembershipProof, BabyJubJubPoint, ContractConfig,
     ContractsStateData, ExtAmount, Field, GlobalViewKeyCiphertext, GvkMode, NotePublicKey,
-    PoolInfo, SMT_DEPTH, TransactChainContext, U256, transact_chain_context_from_state,
+    PauseState, PoolInfo, SMT_DEPTH, TransactChainContext, U256, transact_chain_context_from_state,
 };
 
 macro_rules! get_state {
@@ -99,6 +99,12 @@ impl StateFetcher {
             .transpose()?;
         let gvk_mode = pool_state.get("GvkMode").map(scval_to_u32).transpose()?;
         Ok((admin_view_key, gvk_mode))
+    }
+
+    /// Reads a contract's pause bits, absent on a contract deployed before the
+    /// key existed.
+    fn pause_from_state(state: &HashMap<String, xdr::ScVal>) -> Result<Option<PauseState>> {
+        Ok(state.get("Pause").map(scval_to_pause_state).transpose()?)
     }
 
     /// Cross-checks a pool's configured GVK settings against what the chain
@@ -223,10 +229,12 @@ impl StateFetcher {
                     "MaximumDepositAmount",
                     "PolicyFlags",
                 ],
-                // Only written by `contracts/pool-gvk`, never by
-                // `contracts/pool`, so a missing entry is expected rather
-                // than an error. Read below with `.get(...)`, not `get_state!`.
-                optional_enum_keys: vec!["AdminViewKey", "GvkMode"],
+                // `AdminViewKey` and `GvkMode` are written only by
+                // `contracts/pool-gvk`; `Pause` is absent until the first
+                // pause on either pool. A missing entry is expected rather
+                // than an error for all three, so read them below with
+                // `.get(...)`, not `get_state!`.
+                optional_enum_keys: vec!["AdminViewKey", "GvkMode", "Pause"],
                 valued_keys: vec![],
             });
         }
@@ -234,14 +242,14 @@ impl StateFetcher {
         requests.push(ContractDataBulkRequest {
             contract_id: self.config.asp_membership.as_str(),
             enum_keys: vec!["Root", "Levels", "NextIndex", "Admin"],
-            optional_enum_keys: vec![],
+            optional_enum_keys: vec!["Pause"],
             valued_keys: vec![],
         });
 
         requests.push(ContractDataBulkRequest {
             contract_id: self.config.asp_non_membership.as_str(),
             enum_keys: vec!["Root", "Admin"],
-            optional_enum_keys: vec![],
+            optional_enum_keys: vec!["Pause"],
             valued_keys: vec![],
         });
 
@@ -402,6 +410,7 @@ impl StateFetcher {
                     )?)?,
                     admin_view_key: gvk_admin_view_key,
                     gvk_mode,
+                    pause: Self::pause_from_state(pool_state)?,
                 };
 
                 out.push(pool_info);
@@ -438,6 +447,7 @@ impl StateFetcher {
                 )?)?,
                 capacity: asp_mem_capacity,
                 used_slots: asp_mem_next_index.to_string(),
+                pause: Self::pause_from_state(asp_membership_state)?,
             };
 
             let asp_non_membership_id = &self.config.asp_non_membership;
@@ -462,6 +472,7 @@ impl StateFetcher {
                     "Admin",
                     asp_non_membership_id
                 )?)?,
+                pause: Self::pause_from_state(asp_non_membership_state)?,
             };
 
             return Ok(ContractsStateData {
@@ -918,6 +929,117 @@ mod tests {
 
         assert!(admin_view_key.is_none());
         assert!(gvk_mode.is_none());
+    }
+
+    fn pause_scval(entries: Vec<(&str, xdr::ScVal)>) -> xdr::ScVal {
+        let mut entries: Vec<xdr::ScMapEntry> = entries
+            .into_iter()
+            .map(|(name, val)| xdr::ScMapEntry {
+                key: xdr::ScVal::Symbol(xdr::ScSymbol(name.try_into().expect("symbol"))),
+                val,
+            })
+            .collect();
+        entries.sort_by(|a, b| a.key.cmp(&b.key));
+        xdr::ScVal::Map(Some(xdr::ScMap(entries.try_into().expect("pause map"))))
+    }
+
+    fn pause_state_with(key: &str, val: xdr::ScVal) -> HashMap<String, xdr::ScVal> {
+        HashMap::from([(key.to_string(), val)])
+    }
+
+    #[test]
+    fn pause_is_none_for_a_contract_deployed_before_the_key_existed() {
+        let state: HashMap<String, xdr::ScVal> = HashMap::new();
+
+        let pause = StateFetcher::pause_from_state(&state).expect("no Pause key present");
+
+        assert!(pause.is_none());
+    }
+
+    #[test]
+    fn pause_is_read_from_a_contract_that_stores_it() {
+        let state = pause_state_with(
+            "Pause",
+            pause_scval(vec![
+                ("flags", xdr::ScVal::U32(5)),
+                ("until", xdr::ScVal::U32(900)),
+            ]),
+        );
+
+        let pause = StateFetcher::pause_from_state(&state).expect("Pause key present");
+
+        assert_eq!(
+            pause,
+            Some(PauseState {
+                flags: 5,
+                until: Some(900),
+            })
+        );
+    }
+
+    /// An untimed pause stores `until` as `Void`, which is a present field
+    /// holding `None`, not a missing one.
+    #[test]
+    fn an_untimed_pause_reads_until_as_none() {
+        let state = pause_state_with(
+            "Pause",
+            pause_scval(vec![
+                ("flags", xdr::ScVal::U32(1)),
+                ("until", xdr::ScVal::Void),
+            ]),
+        );
+
+        let pause = StateFetcher::pause_from_state(&state).expect("Pause key present");
+
+        assert_eq!(
+            pause,
+            Some(PauseState {
+                flags: 1,
+                until: None,
+            })
+        );
+    }
+
+    #[test]
+    fn a_pause_entry_missing_a_field_names_it() {
+        let full = [("flags", xdr::ScVal::U32(5)), ("until", xdr::ScVal::Void)];
+        for missing in ["flags", "until"] {
+            let entries = full
+                .iter()
+                .filter(|(name, _)| *name != missing)
+                .map(|(name, val)| (*name, val.clone()))
+                .collect();
+            let state = pause_state_with("Pause", pause_scval(entries));
+
+            let err = StateFetcher::pause_from_state(&state)
+                .expect_err("every PauseState field is required");
+
+            assert!(err.to_string().contains(missing), "{err}");
+        }
+    }
+
+    #[test]
+    fn a_pause_entry_with_a_non_u32_flags_is_rejected() {
+        let state = pause_state_with(
+            "Pause",
+            pause_scval(vec![
+                ("flags", xdr::ScVal::Bool(true)),
+                ("until", xdr::ScVal::Void),
+            ]),
+        );
+
+        let err = StateFetcher::pause_from_state(&state).expect_err("flags must be a u32");
+
+        assert!(err.to_string().contains("flags"), "{err}");
+    }
+
+    #[test]
+    fn a_pause_entry_that_is_not_a_map_is_rejected() {
+        let state = pause_state_with("Pause", xdr::ScVal::U32(1));
+
+        let err = StateFetcher::pause_from_state(&state).expect_err("PauseState must be a map");
+
+        assert!(err.to_string().contains("expected ScVal::Map"), "{err}");
     }
 
     #[test]

--- a/sdk/native/src/chain/conversions.rs
+++ b/sdk/native/src/chain/conversions.rs
@@ -1,6 +1,6 @@
 use crate::{
     chain::rpc::Error,
-    types::{BabyJubJubPoint, ContractEvent, Field, GlobalViewKeyCiphertext, U256},
+    types::{BabyJubJubPoint, ContractEvent, Field, GlobalViewKeyCiphertext, PauseState, U256},
 };
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use core::ops::Shl;
@@ -219,6 +219,46 @@ pub(crate) fn scval_to_baby_jub_jub_point(val: &xdr::ScVal) -> Result<BabyJubJub
             .map_err(|e| Error::UnexpectedScVal(format!("BabyJubJubPoint.x: {e}")))?,
         y: Field::try_from_u256(y)
             .map_err(|e| Error::UnexpectedScVal(format!("BabyJubJubPoint.y: {e}")))?,
+    })
+}
+
+/// Prefixes a decode failure with the `PauseState` field that produced it.
+fn field<T>(decoded: Result<T, Error>, name: &str) -> Result<T, Error> {
+    decoded.map_err(|e| Error::UnexpectedScVal(format!("PauseState.{name}: {e}")))
+}
+
+/// Decode a `soroban_utils::pausable::PauseState`
+/// (`{ flags: u32, until: Option<u32> }`) from contract storage.
+pub(crate) fn scval_to_pause_state(val: &xdr::ScVal) -> Result<PauseState, Error> {
+    let xdr::ScVal::Map(Some(map)) = val else {
+        return Err(Error::UnexpectedScVal(format!(
+            "PauseState: expected ScVal::Map, found: {val:?}"
+        )));
+    };
+
+    let mut flags = None;
+    let mut until = None;
+    for xdr::ScMapEntry { key, val } in map.iter() {
+        let xdr::ScVal::Symbol(name) = key else {
+            continue;
+        };
+        match name.to_utf8_string_lossy().as_str() {
+            "flags" => flags = Some(field(scval_to_u32(val), "flags")?),
+            "until" => {
+                until = Some(match val {
+                    xdr::ScVal::Void => None,
+                    other => Some(field(scval_to_u32(other), "until")?),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    Ok(PauseState {
+        flags: flags
+            .ok_or_else(|| Error::UnexpectedScVal("PauseState missing field: flags".into()))?,
+        until: until
+            .ok_or_else(|| Error::UnexpectedScVal("PauseState missing field: until".into()))?,
     })
 }
 

--- a/sdk/native/src/chain/rpc.rs
+++ b/sdk/native/src/chain/rpc.rs
@@ -238,8 +238,21 @@ pub struct SimulateTransactionResponse {
     pub transaction_data: Option<String>,
     #[serde(rename = "minResourceFee", default)]
     pub min_resource_fee: Option<String>,
+    /// Present when the simulation's footprint touches an archived entry.
+    /// The entry must be restored before the invocation can succeed.
+    #[serde(rename = "restorePreamble", default)]
+    pub restore_preamble: Option<RestorePreamble>,
     #[serde(default)]
     pub error: Option<String>,
+}
+
+/// The footprint restore a simulation asks for before its invocation can run.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct RestorePreamble {
+    #[serde(rename = "minResourceFee")]
+    pub min_resource_fee: String,
+    #[serde(rename = "transactionData")]
+    pub transaction_data: String,
 }
 
 /// Response from Soroban RPC `sendTransaction`.

--- a/sdk/native/src/chain/signer.rs
+++ b/sdk/native/src/chain/signer.rs
@@ -469,6 +469,7 @@ mod tests {
                 .expect("tx xdr"),
             auth_entries: vec![entry.to_xdr_base64(Limits::none()).expect("auth entry xdr")],
             latest_ledger: 100,
+            restore_tx_xdr: None,
         }
     }
 

--- a/sdk/native/src/chain/tx_assemble.rs
+++ b/sdk/native/src/chain/tx_assemble.rs
@@ -5,7 +5,11 @@ use stellar_xdr::{
     self as xdr, Limits, ReadXdr, SorobanAuthorizationEntry, SorobanTransactionData, WriteXdr,
 };
 
-use super::{contract_state::PreparedSorobanTx, rpc::SimulateTransactionResponse};
+use super::{
+    contract_state::PreparedSorobanTx,
+    rpc::{RestorePreamble, SimulateTransactionResponse},
+    soroban_encode::BASE_FEE,
+};
 
 impl SimulateTransactionResponse {
     /// Returns the first host-function simulation result.
@@ -125,6 +129,56 @@ fn assemble_soroban_transaction(
     }))
 }
 
+/// Builds the `RestoreFootprint` transaction a simulation's restore preamble
+/// asks for.
+///
+/// The restore reuses the invocation's source account and sequence number, so
+/// it takes the sequence the invocation would have used and the retried
+/// invocation takes the one after it.
+///
+/// # Errors
+///
+/// Returns an error if `raw` is not a V1 transaction envelope, if the
+/// preamble's `transactionData` is not valid XDR, if its `minResourceFee` is
+/// not a number, or if the total fee does not fit into `u32`.
+fn restore_footprint_envelope(
+    raw: &xdr::TransactionEnvelope,
+    preamble: &RestorePreamble,
+) -> Result<xdr::TransactionEnvelope> {
+    let xdr::TransactionEnvelope::Tx(v1) = raw else {
+        return Err(anyhow!("expected TransactionEnvelope::Tx"));
+    };
+
+    let soroban_data =
+        SorobanTransactionData::from_xdr_base64(&preamble.transaction_data, Limits::none())
+            .map_err(|e| anyhow!("invalid restorePreamble transactionData xdr: {e}"))?;
+    let resource_fee = preamble.min_resource_fee.parse::<u64>().map_err(|_| {
+        anyhow!(
+            "invalid restorePreamble minResourceFee: {}",
+            preamble.min_resource_fee
+        )
+    })?;
+    let fee: u32 = u64::from(BASE_FEE)
+        .saturating_add(resource_fee)
+        .try_into()
+        .map_err(|_| anyhow!("restore fee does not fit into u32"))?;
+
+    let mut tx = v1.tx.clone();
+    tx.fee = fee;
+    tx.operations = xdr::VecM::try_from(vec![xdr::Operation {
+        source_account: None,
+        body: xdr::OperationBody::RestoreFootprint(xdr::RestoreFootprintOp {
+            ext: xdr::ExtensionPoint::V0,
+        }),
+    }])?;
+    tx.ext = xdr::TransactionExt::V1(soroban_data);
+
+    Ok(xdr::TransactionEnvelope::Tx(xdr::TransactionV1Envelope {
+        tx,
+        signatures: xdr::VecM::default(),
+    }))
+}
+
 impl PreparedSorobanTx {
     /// Builds a wallet-ready prepared tx from an unsigned envelope and
     /// simulation.
@@ -135,10 +189,19 @@ impl PreparedSorobanTx {
         let assembled = assemble_soroban_transaction(raw, sim)?;
         let latest_ledger = u32::try_from(sim.latest_ledger)
             .map_err(|_| anyhow!("latestLedger does not fit into u32"))?;
+        let restore_tx_xdr = sim
+            .restore_preamble
+            .as_ref()
+            .map(|preamble| -> Result<String> {
+                let envelope = restore_footprint_envelope(raw, preamble)?;
+                Ok(envelope.to_xdr_base64(Limits::none())?)
+            })
+            .transpose()?;
         Ok(Self {
             tx_xdr: assembled.to_xdr_base64(Limits::none())?,
             auth_entries: sim.auth_entries_base64()?,
             latest_ledger,
+            restore_tx_xdr,
         })
     }
 }
@@ -242,6 +305,7 @@ mod tests {
                     .expect("xdr base64"),
             ),
             min_resource_fee: Some("500".to_string()),
+            restore_preamble: None,
             error: None,
         };
         sim.results
@@ -273,6 +337,7 @@ mod tests {
                     .expect("xdr base64"),
             ),
             min_resource_fee: Some("0".to_string()),
+            restore_preamble: None,
             error: None,
         };
         sim.results
@@ -307,8 +372,140 @@ mod tests {
             results: vec![],
             transaction_data: None,
             min_resource_fee: None,
+            restore_preamble: None,
             error: Some("boom".to_string()),
         };
         assert!(assemble_soroban_transaction(&raw, &sim).is_err());
+    }
+
+    fn preamble(resource_fee: &str) -> RestorePreamble {
+        RestorePreamble {
+            min_resource_fee: resource_fee.to_string(),
+            transaction_data: empty_soroban_data()
+                .to_xdr_base64(Limits::none())
+                .expect("xdr"),
+        }
+    }
+
+    fn sim_with_preamble(preamble: Option<RestorePreamble>) -> SimulateTransactionResponse {
+        let mut sim = SimulateTransactionResponse {
+            latest_ledger: 1,
+            result: None,
+            results: vec![],
+            transaction_data: Some(
+                empty_soroban_data()
+                    .to_xdr_base64(Limits::none())
+                    .expect("xdr"),
+            ),
+            min_resource_fee: Some("500".to_string()),
+            restore_preamble: preamble,
+            error: None,
+        };
+        sim.results
+            .push(crate::chain::rpc::SimulateHostFunctionResult {
+                auth: vec![],
+                retval: None,
+                ..Default::default()
+            });
+        sim
+    }
+
+    #[test]
+    fn a_restore_preamble_yields_a_restore_footprint_transaction() {
+        let raw = empty_envelope();
+
+        let envelope = restore_footprint_envelope(&raw, &preamble("700")).expect("restore tx");
+
+        let xdr::TransactionEnvelope::Tx(v1) = envelope else {
+            panic!("expected v1 envelope");
+        };
+        assert_eq!(v1.tx.operations.len(), 1);
+        assert!(matches!(
+            v1.tx.operations[0].body,
+            xdr::OperationBody::RestoreFootprint(_)
+        ));
+        let TransactionExt::V1(data) = &v1.tx.ext else {
+            panic!("expected soroban transaction data on the restore");
+        };
+        assert_eq!(*data, empty_soroban_data());
+        assert_eq!(v1.tx.fee, BASE_FEE + 700);
+    }
+
+    /// The restore takes the sequence the invocation would have used, so the
+    /// invocation retried after it takes the one following.
+    #[test]
+    fn a_restore_reuses_the_source_and_sequence_of_the_invocation() {
+        let raw = empty_envelope();
+        let xdr::TransactionEnvelope::Tx(original) = &raw else {
+            panic!("expected v1 envelope");
+        };
+
+        let envelope = restore_footprint_envelope(&raw, &preamble("0")).expect("restore tx");
+
+        let xdr::TransactionEnvelope::Tx(v1) = &envelope else {
+            panic!("expected v1 envelope");
+        };
+        assert_eq!(v1.tx.source_account, original.tx.source_account);
+        assert_eq!(v1.tx.seq_num, original.tx.seq_num);
+    }
+
+    #[test]
+    fn a_restore_preamble_with_invalid_transaction_data_is_rejected() {
+        let raw = empty_envelope();
+        let preamble = RestorePreamble {
+            min_resource_fee: "1".to_string(),
+            transaction_data: "not base64 xdr".to_string(),
+        };
+
+        let err = restore_footprint_envelope(&raw, &preamble)
+            .expect_err("a preamble with unreadable transaction data must not assemble");
+
+        assert!(err.to_string().contains("transactionData"), "{err}");
+    }
+
+    #[test]
+    fn a_restore_preamble_with_a_non_numeric_fee_is_rejected() {
+        let raw = empty_envelope();
+        let preamble = RestorePreamble {
+            min_resource_fee: "lots".to_string(),
+            transaction_data: empty_soroban_data()
+                .to_xdr_base64(Limits::none())
+                .expect("xdr"),
+        };
+
+        let err = restore_footprint_envelope(&raw, &preamble)
+            .expect_err("a preamble with a non-numeric fee must not assemble");
+
+        assert!(err.to_string().contains("minResourceFee"), "{err}");
+    }
+
+    #[test]
+    fn a_simulation_with_a_preamble_carries_the_restore_xdr() {
+        let raw = empty_envelope();
+
+        let prepared =
+            PreparedSorobanTx::from_simulation(&raw, &sim_with_preamble(Some(preamble("300"))))
+                .expect("prepare");
+
+        let restore = prepared.restore_tx_xdr.expect("restore xdr");
+        let envelope =
+            xdr::TransactionEnvelope::from_xdr_base64(&restore, Limits::none()).expect("xdr");
+        let xdr::TransactionEnvelope::Tx(v1) = envelope else {
+            panic!("expected v1 envelope");
+        };
+        assert!(matches!(
+            v1.tx.operations[0].body,
+            xdr::OperationBody::RestoreFootprint(_)
+        ));
+    }
+
+    #[test]
+    fn a_simulation_without_a_preamble_leaves_the_restore_xdr_unset() {
+        let raw = empty_envelope();
+
+        let prepared =
+            PreparedSorobanTx::from_simulation(&raw, &sim_with_preamble(None)).expect("prepare");
+
+        assert!(prepared.restore_tx_xdr.is_none());
     }
 }

--- a/sdk/native/src/chain/tx_prepare.rs
+++ b/sdk/native/src/chain/tx_prepare.rs
@@ -176,15 +176,21 @@ mod tests {
 
     struct MockRpc {
         seq: xdr::SequenceNumber,
-        sim: SimulateTransactionResponse,
+        sims: Vec<SimulateTransactionResponse>,
         simulate_calls: AtomicUsize,
     }
 
     impl MockRpc {
         fn new(seq: i64, sim: SimulateTransactionResponse) -> Self {
+            Self::with_sims(seq, vec![sim])
+        }
+
+        /// Answers the nth call with the nth response, repeating the last one
+        /// once the list runs out.
+        fn with_sims(seq: i64, sims: Vec<SimulateTransactionResponse>) -> Self {
             Self {
                 seq: xdr::SequenceNumber(seq),
-                sim,
+                sims,
                 simulate_calls: AtomicUsize::new(0),
             }
         }
@@ -193,8 +199,13 @@ mod tests {
             &self,
             _tx: &xdr::TransactionEnvelope,
         ) -> Result<SimulateTransactionResponse, RpcError> {
-            self.simulate_calls.fetch_add(1, Ordering::SeqCst);
-            Ok(self.sim.clone())
+            let call = self.simulate_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self
+                .sims
+                .get(call)
+                .or_else(|| self.sims.last())
+                .expect("a simulation fixture")
+                .clone())
         }
     }
 
@@ -209,6 +220,7 @@ mod tests {
                     .expect("xdr"),
             ),
             min_resource_fee: Some(resource_fee.to_string()),
+            restore_preamble: None,
             error: None,
         };
         sim.results.push(SimulateHostFunctionResult {
@@ -384,5 +396,46 @@ mod tests {
     #[test]
     fn next_sequence_rejects_overflow() {
         assert!(next_sequence(xdr::SequenceNumber(i64::MAX)).is_err());
+    }
+
+    fn fixture_sim_with_preamble(resource_fee: &str) -> SimulateTransactionResponse {
+        let mut sim = fixture_sim(resource_fee);
+        sim.restore_preamble = Some(crate::chain::rpc::RestorePreamble {
+            min_resource_fee: "400".to_string(),
+            transaction_data: empty_soroban_data()
+                .to_xdr_base64(Limits::none())
+                .expect("xdr"),
+        });
+        sim
+    }
+
+    /// A first simulation that asks for a restore is answered by submitting it
+    /// and preparing again; the second simulation asks for nothing, which is
+    /// what lets the caller stop rather than loop.
+    #[test]
+    fn a_register_simulation_asking_for_a_restore_prepares_twice() {
+        let pk = ed25519::PublicKey([9u8; 32]);
+        let source = pk.to_string();
+        let mock = MockRpc::with_sims(
+            4,
+            vec![fixture_sim_with_preamble("250"), fixture_sim("250")],
+        );
+
+        let first = block_on(prepare_register_with_mock(
+            &mock, &source, [0xAB; 32], [0xEE; 32],
+        ))
+        .expect("prepare register");
+        assert!(
+            first.restore_tx_xdr.is_some(),
+            "first pass asks for a restore"
+        );
+
+        let second = block_on(prepare_register_with_mock(
+            &mock, &source, [0xAB; 32], [0xEE; 32],
+        ))
+        .expect("prepare register after restore");
+
+        assert!(second.restore_tx_xdr.is_none());
+        assert_eq!(mock.simulate_calls.load(Ordering::SeqCst), 2);
     }
 }

--- a/sdk/native/src/pool.rs
+++ b/sdk/native/src/pool.rs
@@ -5,7 +5,9 @@ use crate::{
     types::{EncryptionPublicKey, NoteAmount, NotePublicKey, Sensitive, UserNoteSummary},
 };
 
-use crate::chain::{Limits, ReadXdr, StateFetcher, TransactionEnvelope, submit_tx};
+use crate::chain::{
+    Limits, PreparedSorobanTx, ReadXdr, StateFetcher, TransactionEnvelope, submit_tx,
+};
 
 use crate::{
     PreparedTransaction,
@@ -34,6 +36,50 @@ use crate::{
 };
 
 const POLL_INTERVAL_MS: u32 = 200;
+
+/// Submits the footprint restore a simulation asked for and waits for it to
+/// land, so the caller can prepare the same invocation again against
+/// unarchived entries.
+///
+/// # Errors
+///
+/// Returns [`Error::Other`] if the restore cannot be signed, submitted, or
+/// confirmed. A restore that fails on chain surfaces its result XDR.
+pub(crate) async fn restore_archived_entries(
+    rpc: &RpcClient,
+    signer: &Handle<dyn Signer>,
+    restore_tx_xdr: String,
+) -> Result<(), Error> {
+    let prepared = PreparedSorobanTx {
+        tx_xdr: restore_tx_xdr,
+        ..Default::default()
+    };
+    let signed = signer.sign_soroban_transaction(&prepared).await?;
+    let envelope = TransactionEnvelope::from_xdr_base64(&signed.signed_xdr, Limits::none())
+        .map_err(|e| Error::Other(format!("invalid signed restore transaction xdr: {e}")))?;
+    let hash = submit_tx(rpc, &envelope)
+        .await
+        .map_err(|e| Error::Other(format!("submit restore: {e:#}")))?;
+    confirm_tx(rpc, hash).await?;
+    Ok(())
+}
+
+/// Refuses a preparation that still asks for a footprint restore once one has
+/// been submitted, which is what stops a caller from restoring in a loop and
+/// paying a fee on every pass.
+///
+/// # Errors
+///
+/// Returns [`Error::Other`] if `prepared` carries a second restore request.
+pub(crate) fn refuse_second_restore(prepared: &PreparedSorobanTx) -> Result<(), Error> {
+    if prepared.restore_tx_xdr.is_some() {
+        return Err(Error::Other(
+            "preparation still asks for a footprint restore after one was submitted".into(),
+        ));
+    }
+    Ok(())
+}
+
 const SYNC_MAX_RETRIES: u32 = 50;
 const DISCLOSE_MAX_RETRIES: u32 = 50;
 
@@ -247,13 +293,28 @@ impl<S: Storage> PrivatePool<S> {
         .await
     }
 
+    /// Simulates the prepared transaction and fills in the fee, the footprint,
+    /// and the authorization entries it needs.
+    ///
+    /// A simulation whose footprint reaches an archived entry cannot price the
+    /// call, so this submits a footprint restore through the signer, waits for
+    /// it to confirm, and simulates again. That path asks the signer for a
+    /// signature and spends a fee on chain, which is the one way this call
+    /// changes ledger state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Other`] if the simulation fails, if a restore cannot be
+    /// signed, submitted, or confirmed, or if the second simulation still asks
+    /// for one.
     pub async fn simulate(&self, prepared: &mut PreparedTransaction) -> Result<(), Error> {
         let chain_config = self.core.config();
-        prepared.soroban_tx = self
+        let input = pool_transact_input(prepared);
+        let mut soroban_tx = self
             .fetcher
             .prepare_pool_transact(
                 &chain_config.pool_contract_id,
-                &pool_transact_input(prepared),
+                &input,
                 // The signing address becomes the contract's `sender`, the
                 // sequence-number lookup and the envelope source.
                 &chain_config.signer_address,
@@ -261,6 +322,21 @@ impl<S: Storage> PrivatePool<S> {
             .await
             .map_err(|e| Error::Other(format!("simulate transaction: {e:#}")))?;
 
+        if let Some(restore_tx_xdr) = soroban_tx.restore_tx_xdr.take() {
+            restore_archived_entries(&self.rpc, &self.signer, restore_tx_xdr).await?;
+            soroban_tx = self
+                .fetcher
+                .prepare_pool_transact(
+                    &chain_config.pool_contract_id,
+                    &input,
+                    &chain_config.signer_address,
+                )
+                .await
+                .map_err(|e| Error::Other(format!("simulate transaction after restore: {e:#}")))?;
+            refuse_second_restore(&soroban_tx)?;
+        }
+
+        prepared.soroban_tx = soroban_tx;
         Ok(())
     }
 
@@ -491,5 +567,24 @@ impl<S: Storage> PrivatePool<S> {
             .user_public_keys(self.config.user_address.as_str())
             .await?;
         self.core.deposit_transact_step(note_pub, enc_pub, amount)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// The guard is the only thing between an RPC that keeps answering with a
+    /// preamble and a caller that submits a restore on every pass, so both
+    /// call sites route their refusal through it.
+    #[test]
+    fn a_second_restore_request_is_refused() {
+        let prepared = PreparedSorobanTx {
+            restore_tx_xdr: Some("AAAA".to_string()),
+            ..Default::default()
+        };
+
+        assert!(refuse_second_restore(&prepared).is_err());
+        assert!(refuse_second_restore(&PreparedSorobanTx::default()).is_ok());
     }
 }

--- a/sdk/native/src/state/events_parsers.rs
+++ b/sdk/native/src/state/events_parsers.rs
@@ -5,11 +5,13 @@ use crate::{
         scval_to_u32, scval_to_u64, scval_to_u256,
     },
     types::{
-        ContractEvent, Field, LeafAddedEvent, LeafDeletedEvent, LeafInsertedEvent,
-        LeafUpdatedEvent, NewCommitmentEvent, NewNullifierEvent, ProcessedEvent, PublicKeyEvent,
+        AdminUpdatedEvent, ContractEvent, Field, LeafAddedEvent, LeafDeletedEvent,
+        LeafInsertedEvent, LeafUpdatedEvent, NewCommitmentEvent, NewNullifierEvent,
+        PauseChangedEvent, ProcessedEvent, PublicKeyEvent,
     },
 };
 use anyhow::{Result, anyhow};
+use stellar_xdr as xdr;
 
 /// Field name emitted by `contracts/pool-gvk`'s pool events, carrying the
 /// admin-decryptable ciphertext of the note.
@@ -41,6 +43,14 @@ pub fn parse_event(event: ContractEvent) -> Result<ProcessedEvent> {
         }
         "leaf_updated" | "LeafUpdated" => ProcessedEvent::LeafUpdated(parse_leaf_updated(parsed)?),
         "leaf_deleted" | "LeafDeleted" => ProcessedEvent::LeafDeleted(parse_leaf_deleted(parsed)?),
+        // Governance events contracts/soroban-utils/src/{utils,pausable}.rs, emitted by
+        // every contract that exposes an admin rotation or a pause
+        "admin_updated" | "AdminUpdated" => {
+            ProcessedEvent::AdminUpdated(parse_admin_updated(parsed)?)
+        }
+        "pause_changed" | "PauseChanged" => {
+            ProcessedEvent::PauseChanged(parse_pause_changed(parsed)?)
+        }
         _ => return Err(anyhow!("unhandled event {}", parsed.name)),
     };
     Ok(ev)
@@ -289,18 +299,72 @@ fn parse_leaf_deleted(parsed: ParsedContractEvent) -> Result<LeafDeletedEvent> {
     Ok(LeafDeletedEvent { id, key, root })
 }
 
+// #[contractevent]
+// #[derive(Clone, Debug, Eq, PartialEq)]
+// pub struct AdminUpdated {
+//     pub old_admin: Address,
+//     pub new_admin: Address,
+// }
+fn parse_admin_updated(parsed: ParsedContractEvent) -> Result<AdminUpdatedEvent> {
+    let ParsedContractEvent {
+        id, name, values, ..
+    } = parsed;
+    let old_admin_scval = values
+        .get("old_admin")
+        .ok_or_else(|| anyhow!("event `{name}` id {id} should have an old_admin value"))?;
+    let old_admin = scval_to_address_string(old_admin_scval)?;
+    let new_admin_scval = values
+        .get("new_admin")
+        .ok_or_else(|| anyhow!("event `{name}` id {id} should have an new_admin value"))?;
+    let new_admin = scval_to_address_string(new_admin_scval)?;
+    Ok(AdminUpdatedEvent {
+        id,
+        old_admin,
+        new_admin,
+    })
+}
+
+// #[contractevent]
+// #[derive(Clone, Debug, Eq, PartialEq)]
+// pub struct PauseChanged {
+//     pub flags: u32,
+//     pub until: Option<u32>,
+// }
+fn parse_pause_changed(parsed: ParsedContractEvent) -> Result<PauseChangedEvent> {
+    let ParsedContractEvent {
+        id, name, values, ..
+    } = parsed;
+    let flags_scval = values
+        .get("flags")
+        .ok_or_else(|| anyhow!("event `{name}` id {id} should have an flags value"))?;
+    let flags = scval_to_u32(flags_scval)?;
+    let until_scval = values
+        .get("until")
+        .ok_or_else(|| anyhow!("event `{name}` id {id} should have an until value"))?;
+    let until = match until_scval {
+        xdr::ScVal::Void => None,
+        xdr::ScVal::U32(ledger) => Some(*ledger),
+        other => {
+            return Err(anyhow!(
+                "event `{name}` id {id} has an until value that is neither void nor u32: {other:?}"
+            ));
+        }
+    };
+    Ok(PauseChangedEvent { id, flags, until })
+}
+
 #[cfg(test)]
 mod gvk_passthrough_tests {
     use super::*;
     use crate::types::{Field, U256};
     use stellar_xdr::{self as xdr, WriteXdr};
 
-    fn b64(val: &xdr::ScVal) -> String {
+    pub(super) fn b64(val: &xdr::ScVal) -> String {
         val.to_xdr_base64(xdr::Limits::none())
             .expect("encode scval")
     }
 
-    fn symbol(s: &str) -> xdr::ScVal {
+    pub(super) fn symbol(s: &str) -> xdr::ScVal {
         xdr::ScVal::Symbol(xdr::ScSymbol(s.try_into().expect("symbol")))
     }
 
@@ -469,5 +533,129 @@ mod gvk_passthrough_tests {
         assert!(without.gvk_ciphertext.is_none());
         let ct = with.gvk_ciphertext.expect("gvk ciphertext");
         assert_eq!(ct.c2, Field(U256::from(2)));
+    }
+}
+
+#[cfg(test)]
+mod governance_event_tests {
+    use super::{
+        gvk_passthrough_tests::{b64, symbol},
+        *,
+    };
+    use stellar_xdr as xdr;
+
+    fn address(byte: u8) -> xdr::ScVal {
+        xdr::ScVal::Address(xdr::ScAddress::Contract(xdr::ContractId(xdr::Hash(
+            [byte; 32],
+        ))))
+    }
+
+    fn event(name: &str, entries: Vec<xdr::ScMapEntry>) -> ContractEvent {
+        let mut entries = entries;
+        // Soroban emits map entries in key order.
+        entries.sort_by(|a, b| a.key.cmp(&b.key));
+        ContractEvent {
+            id: "0000000000000000003-0000000000".to_string(),
+            ledger: 1,
+            contract_id: "CPOOL".to_string(),
+            topics: vec![b64(&symbol(name))],
+            value: b64(&xdr::ScVal::Map(Some(xdr::ScMap(
+                entries.try_into().expect("data map"),
+            )))),
+        }
+    }
+
+    fn admin_updated_event(with_new_admin: bool) -> ContractEvent {
+        let mut entries = vec![xdr::ScMapEntry {
+            key: symbol("old_admin"),
+            val: address(1),
+        }];
+        if with_new_admin {
+            entries.push(xdr::ScMapEntry {
+                key: symbol("new_admin"),
+                val: address(2),
+            });
+        }
+        event("admin_updated", entries)
+    }
+
+    fn pause_changed_event(until: xdr::ScVal) -> ContractEvent {
+        event(
+            "pause_changed",
+            vec![
+                xdr::ScMapEntry {
+                    key: symbol("flags"),
+                    val: xdr::ScVal::U32(5),
+                },
+                xdr::ScMapEntry {
+                    key: symbol("until"),
+                    val: until,
+                },
+            ],
+        )
+    }
+
+    #[test]
+    fn admin_updated_parses_both_addresses() {
+        let ProcessedEvent::AdminUpdated(ev) =
+            parse_event(admin_updated_event(true)).expect("parse admin_updated")
+        else {
+            panic!("expected an admin updated event");
+        };
+
+        assert_eq!(ev.id, "0000000000000000003-0000000000");
+        assert_eq!(
+            ev.old_admin,
+            "CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC526"
+        );
+        assert_eq!(
+            ev.new_admin,
+            "CABAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAFNSZ"
+        );
+    }
+
+    #[test]
+    fn admin_updated_without_new_admin_fails() {
+        let err = parse_event(admin_updated_event(false))
+            .expect_err("an admin_updated event without new_admin must not parse");
+
+        assert!(err.to_string().contains("new_admin"), "{err}");
+    }
+
+    #[test]
+    fn pause_changed_reads_an_untimed_pause_as_none() {
+        let ProcessedEvent::PauseChanged(ev) =
+            parse_event(pause_changed_event(xdr::ScVal::Void)).expect("parse pause_changed")
+        else {
+            panic!("expected a pause changed event");
+        };
+
+        assert_eq!(ev.flags, 5);
+        assert_eq!(ev.until, None);
+    }
+
+    #[test]
+    fn pause_changed_reads_a_timed_pause_as_some() {
+        let ProcessedEvent::PauseChanged(ev) =
+            parse_event(pause_changed_event(xdr::ScVal::U32(42))).expect("parse pause_changed")
+        else {
+            panic!("expected a pause changed event");
+        };
+
+        assert_eq!(ev.flags, 5);
+        assert_eq!(ev.until, Some(42));
+    }
+
+    #[test]
+    fn pause_changed_with_a_non_ledger_until_names_the_event_id() {
+        let err = parse_event(pause_changed_event(xdr::ScVal::Bool(true)))
+            .expect_err("an until that is neither void nor u32 must not parse");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("0000000000000000003-0000000000"),
+            "{message}"
+        );
+        assert!(message.contains("until"), "{message}");
     }
 }

--- a/sdk/native/src/state/processor.rs
+++ b/sdk/native/src/state/processor.rs
@@ -11,6 +11,7 @@ pub(crate) fn process_events(storage: &mut SqliteStorage, limit: u32) -> Result<
     let mut commitments = vec![];
     let mut pubkeys = vec![];
     let mut leaves = vec![];
+    let mut processed_ids = vec![];
     while let Some(event) = unprocessed.pop() {
         let parsed = match parse_event(event) {
             Ok(parsed) => parsed,
@@ -27,6 +28,8 @@ pub(crate) fn process_events(storage: &mut SqliteStorage, limit: u32) -> Result<
             ProcessedEvent::Commitment(ev) => commitments.push(ev),
             ProcessedEvent::PublicKey(ev) => pubkeys.push(ev),
             ProcessedEvent::LeafAdded(ev) => leaves.push(ev),
+            ProcessedEvent::AdminUpdated(ev) => processed_ids.push(ev.id),
+            ProcessedEvent::PauseChanged(ev) => processed_ids.push(ev.id),
             _ => tracing::warn!("event won't be saved to the storage: {parsed:?}"),
         }
     }
@@ -34,6 +37,7 @@ pub(crate) fn process_events(storage: &mut SqliteStorage, limit: u32) -> Result<
     storage.save_commitment_events_batch(&commitments)?;
     storage.save_public_key_events_batch(&pubkeys)?;
     storage.save_leaf_added_events_batch(&leaves)?;
+    storage.save_processed_event_ids(&processed_ids)?;
     Ok(true)
 }
 
@@ -51,4 +55,60 @@ pub(crate) fn process_notes(
     did_work |= storage.scan_commitments_for_user_notes(limit, derive)?;
     did_work |= storage.reconcile_nullifiers(limit)?;
     Ok(did_work)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ContractEvent, ContractsEventData};
+    use stellar_xdr::{self as xdr, WriteXdr};
+
+    fn b64(val: &xdr::ScVal) -> String {
+        val.to_xdr_base64(xdr::Limits::none())
+            .expect("encode scval")
+    }
+
+    fn symbol(s: &str) -> xdr::ScVal {
+        xdr::ScVal::Symbol(xdr::ScSymbol(s.try_into().expect("symbol")))
+    }
+
+    fn pause_changed_event() -> ContractEvent {
+        let entries = vec![
+            xdr::ScMapEntry {
+                key: symbol("flags"),
+                val: xdr::ScVal::U32(1),
+            },
+            xdr::ScMapEntry {
+                key: symbol("until"),
+                val: xdr::ScVal::Void,
+            },
+        ];
+        ContractEvent {
+            id: "0000000000000000004-0000000000".to_string(),
+            ledger: 1,
+            contract_id: "CPOOL".to_string(),
+            topics: vec![b64(&symbol("pause_changed"))],
+            value: b64(&xdr::ScVal::Map(Some(xdr::ScMap(
+                entries.try_into().expect("data map"),
+            )))),
+        }
+    }
+
+    /// A pause event saves no row of its own, so only the `processed_events`
+    /// table stops it from being read again on the next pass.
+    #[test]
+    fn a_pause_changed_event_is_read_once() -> Result<()> {
+        let mut storage = SqliteStorage::connect_in_memory()?;
+        storage.save_events_batch(&ContractsEventData {
+            events: vec![pause_changed_event()],
+            cursor: "cur".to_string(),
+            latest_ledger: 1,
+        })?;
+        assert_eq!(storage.get_unprocessed_events(10)?.len(), 1);
+
+        assert!(process_events(&mut storage, 10)?);
+
+        assert!(storage.get_unprocessed_events(10)?.is_empty());
+        Ok(())
+    }
 }

--- a/sdk/native/src/state/schema_v3_processed_events.sql
+++ b/sdk/native/src/state/schema_v3_processed_events.sql
@@ -1,0 +1,3 @@
+-- Events that parse but leave no row in a saved-event table. Without this,
+-- get_unprocessed_events re-reads them on every pass forever.
+CREATE TABLE processed_events (event_id TEXT PRIMARY KEY);

--- a/sdk/native/src/state/storage.rs
+++ b/sdk/native/src/state/storage.rs
@@ -21,6 +21,7 @@ pub const DEFAULT_BOOTNODE_URL: &str = "https://bootnode.dev-nethermind.xyz";
 const MIGRATION_ARRAY: &[M] = &[
     M::up(include_str!("schema.sql")),
     M::up(include_str!("schema_v2_gvk_ciphertext.sql")),
+    M::up(include_str!("schema_v3_processed_events.sql")),
 ];
 const MIGRATIONS: Migrations = Migrations::from_slice(MIGRATION_ARRAY);
 
@@ -1272,6 +1273,30 @@ impl Storage {
         Ok(leaves)
     }
 
+    /// Records event ids that parsed but produced no row of their own, so
+    /// [`Self::get_unprocessed_events`] stops returning them.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the transaction cannot be opened or an insert
+    /// fails.
+    pub fn save_processed_event_ids(&mut self, ids: &[String]) -> Result<()> {
+        let tx = self.conn.transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO processed_events (event_id)
+                    VALUES (?1)
+                    ON CONFLICT(event_id) DO NOTHING",
+            )?;
+
+            for id in ids {
+                stmt.execute(params![id])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
     /// Unprocessed raw events fetch
     pub fn get_unprocessed_events(&self, limit: u32) -> Result<Vec<ContractEvent>> {
         let mut stmt = self.conn.prepare(
@@ -1282,10 +1307,12 @@ impl Storage {
                 LEFT JOIN public_keys p ON r.id = p.event_id
                 LEFT JOIN asp_membership_leaves l ON r.id = l.event_id
                 LEFT JOIN pool_nullifiers n ON r.id = n.event_id
+                LEFT JOIN processed_events pe ON r.id = pe.event_id
                 WHERE pc.event_id IS NULL
                 AND p.event_id IS NULL
                 AND n.event_id IS NULL
                 AND l.event_id IS NULL
+                AND pe.event_id IS NULL
                 ORDER BY r.ledger ASC, r.id ASC
                 LIMIT ?1",
         )?;
@@ -2969,5 +2996,49 @@ mod tests {
 
         let _ = std::fs::remove_file(path);
         Ok(())
+    }
+
+    #[test]
+    fn processed_event_ids_are_not_returned_as_unprocessed() -> Result<()> {
+        let mut storage = Storage::connect_in_memory()?;
+        storage.save_events_batch(&ContractsEventData {
+            events: vec![dummy_event("evt-pause"), dummy_event("evt-other")],
+            cursor: "cur".to_string(),
+            latest_ledger: 1,
+        })?;
+
+        storage.save_processed_event_ids(&["evt-pause".to_string()])?;
+
+        let ids: Vec<String> = storage
+            .get_unprocessed_events(10)?
+            .into_iter()
+            .map(|e| e.id)
+            .collect();
+        assert_eq!(ids, vec!["evt-other".to_string()]);
+        Ok(())
+    }
+
+    #[test]
+    fn opening_a_v2_database_applies_the_processed_events_migration() -> Result<()> {
+        let mut conn = Connection::open_in_memory()?;
+        MIGRATIONS.to_version(&mut conn, 2)?;
+        assert!(
+            !table_exists(&conn, "processed_events")?,
+            "v2 must predate the table"
+        );
+
+        let storage = Storage::connect_with_connection(conn)?;
+
+        assert!(table_exists(&storage.conn, "processed_events")?);
+        Ok(())
+    }
+
+    fn table_exists(conn: &Connection, name: &str) -> Result<bool> {
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            params![name],
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
     }
 }

--- a/sdk/native/src/types/chain_data.rs
+++ b/sdk/native/src/types/chain_data.rs
@@ -335,6 +335,35 @@ pub struct LeafDeletedEvent {
     pub root: Field,
 }
 
+/// Event emitted when a contract's administrator is replaced
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminUpdatedEvent {
+    // Unique identifier for this event, based on the TOID format.
+    // It combines a 19-character TOID and a 10-character, zero-padded event index, separated by a
+    // hyphen.
+    pub id: String,
+    /// Address that held the administrator role before the call.
+    pub old_admin: String,
+    /// Address that holds it afterwards.
+    pub new_admin: String,
+}
+
+/// Event emitted when a contract's pause bits change
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PauseChangedEvent {
+    // Unique identifier for this event, based on the TOID format.
+    // It combines a 19-character TOID and a 10-character, zero-padded event index, separated by a
+    // hyphen.
+    pub id: String,
+    /// Bits set after the change.
+    pub flags: u32,
+    /// Ledger from which the withdrawals bit is no longer honored, absent when
+    /// the pause is untimed.
+    pub until: Option<u32>,
+}
+
 /// A contract event after full parsing
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -346,6 +375,8 @@ pub enum ProcessedEvent {
     LeafInserted(LeafInsertedEvent),
     LeafUpdated(LeafUpdatedEvent),
     LeafDeleted(LeafDeletedEvent),
+    AdminUpdated(AdminUpdatedEvent),
+    PauseChanged(PauseChangedEvent),
 }
 
 #[cfg(test)]

--- a/sdk/native/src/types/chain_data.rs
+++ b/sdk/native/src/types/chain_data.rs
@@ -37,6 +37,23 @@ pub struct ContractsStateData {
     pub asp_non_membership: AspNonMembership,
 }
 
+/// The pause bits a contract has set, as `soroban_utils::pausable` stores
+/// them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PauseState {
+    /// Bits set by the last pause or unpause. Which bits mean what depends on
+    /// the contract: pools recognize deposits, transfers, and withdrawals, and
+    /// the ASP contracts recognize mutations.
+    pub flags: u32,
+    /// Ledger from which every set bit is no longer honored, absent when the
+    /// pause is untimed.
+    ///
+    /// A deadline that has passed leaves [`Self::flags`] unchanged, so a bit
+    /// can read as set on a contract that no longer honors it.
+    pub until: Option<u32>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PoolInfo {
@@ -70,6 +87,13 @@ pub struct PoolInfo {
     /// Omitted from serialized output when absent, as for `admin_view_key`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gvk_mode: Option<u32>,
+    /// Pause bits read from the contract. `None` when the contract has never
+    /// been paused or unpaused, which includes contracts deployed before the
+    /// pause entry existed. Treat it as all bits clear.
+    ///
+    /// Omitted from serialized output when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pause: Option<PauseState>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -86,6 +110,13 @@ pub struct AspMembership {
     pub admin: String,
     pub capacity: u64,
     pub used_slots: String, //num_bigint::BigUint,
+    /// Pause bits read from the contract. `None` when the contract has never
+    /// been paused or unpaused, which includes contracts deployed before the
+    /// pause entry existed. Treat it as all bits clear.
+    ///
+    /// Omitted from serialized output when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pause: Option<PauseState>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -99,6 +130,13 @@ pub struct AspNonMembership {
     pub root: Field,
     pub is_empty: bool,
     pub admin: String,
+    /// Pause bits read from the contract. `None` when the contract has never
+    /// been paused or unpaused, which includes contracts deployed before the
+    /// pause entry existed. Treat it as all bits clear.
+    ///
+    /// Omitted from serialized output when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pause: Option<PauseState>,
 }
 
 /// ASP non-membership (blocklist) proof data needed by the circuit.
@@ -359,8 +397,11 @@ pub struct PauseChangedEvent {
     pub id: String,
     /// Bits set after the change.
     pub flags: u32,
-    /// Ledger from which the withdrawals bit is no longer honored, absent when
-    /// the pause is untimed.
+    /// Ledger from which every set bit is no longer honored, absent when the
+    /// pause is untimed.
+    ///
+    /// A deadline that has passed leaves [`Self::flags`] unchanged, so a bit
+    /// can read as set on a contract that no longer honors it.
     pub until: Option<u32>,
 }
 
@@ -407,6 +448,7 @@ mod pool_info_gvk_tests {
                 y: Field(U256::from(2)),
             }),
             gvk_mode: Some(2),
+            pause: None,
         }
     }
 
@@ -450,6 +492,7 @@ mod pool_info_gvk_tests {
         let pool = PoolInfo {
             admin_view_key: None,
             gvk_mode: None,
+            pause: None,
             ..pool_info_with_gvk()
         };
 
@@ -458,6 +501,7 @@ mod pool_info_gvk_tests {
 
         assert!(!object.contains_key("adminViewKey"));
         assert!(!object.contains_key("gvkMode"));
+        assert!(!object.contains_key("pause"));
         // Unrelated optional fields keep their existing null-emitting shape.
         assert!(object.contains_key("merkleRoot"));
         assert!(object.contains_key("merkleCurrentRootIndex"));
@@ -465,5 +509,81 @@ mod pool_info_gvk_tests {
         let decoded: PoolInfo = serde_json::from_value(value).expect("decode non-GVK PoolInfo");
         assert!(decoded.admin_view_key.is_none());
         assert!(decoded.gvk_mode.is_none());
+    }
+
+    fn pause_state() -> PauseState {
+        PauseState {
+            flags: 5,
+            until: Some(900),
+        }
+    }
+
+    /// State serialized before the pause key existed must still decode, for
+    /// every contract that gained the field.
+    #[test]
+    fn contract_state_without_pause_still_decodes() {
+        let pool = PoolInfo {
+            pause: Some(pause_state()),
+            ..pool_info_with_gvk()
+        };
+        assert!(decode_without_pause::<PoolInfo>(&pool).pause.is_none());
+
+        let membership = AspMembership {
+            ledger: 1,
+            contract_id: "CASPM".to_string(),
+            contract_type: "ASP Membership".to_string(),
+            root: Field(U256::from(7)),
+            levels: 20,
+            next_index: "0".to_string(),
+            admin: "GADMIN".to_string(),
+            capacity: 1_048_576,
+            used_slots: "0".to_string(),
+            pause: Some(pause_state()),
+        };
+        assert!(
+            decode_without_pause::<AspMembership>(&membership)
+                .pause
+                .is_none()
+        );
+
+        let non_membership = AspNonMembership {
+            ledger: 1,
+            contract_id: "CASPN".to_string(),
+            contract_type: "ASP Non-Membership".to_string(),
+            root: Field(U256::from(0)),
+            is_empty: true,
+            admin: "GADMIN".to_string(),
+            pause: Some(pause_state()),
+        };
+        assert!(
+            decode_without_pause::<AspNonMembership>(&non_membership)
+                .pause
+                .is_none()
+        );
+    }
+
+    /// Serializes `value`, drops the `pause` key, and decodes what an older
+    /// deployment would have produced.
+    fn decode_without_pause<T>(value: &impl Serialize) -> T
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let mut encoded = serde_json::to_value(value).expect("serialize to value");
+        let object = encoded.as_object_mut().expect("serializes as object");
+        assert!(object.remove("pause").is_some(), "field was present");
+        serde_json::from_value(encoded).expect("decode state written without pause")
+    }
+
+    #[test]
+    fn pool_info_round_trips_with_pause_set() {
+        let pool = PoolInfo {
+            pause: Some(pause_state()),
+            ..pool_info_with_gvk()
+        };
+
+        let encoded = serde_json::to_string(&pool).expect("serialize PoolInfo");
+        let decoded: PoolInfo = serde_json::from_str(&encoded).expect("decode PoolInfo");
+
+        assert_eq!(decoded.pause, Some(pause_state()));
     }
 }

--- a/sdk/web/src/models/chain.rs
+++ b/sdk/web/src/models/chain.rs
@@ -1,8 +1,9 @@
 use stellar_private_payments::types::{
     AspMembership as NativeAspMembership, AspNonMembership as NativeAspNonMembership,
     ContractsStateData as NativeContractsStateData,
-    OperationalFeedItem as NativeOperationalFeedItem, PoolInfo as NativePoolInfo,
-    PublicKeyEntry as NativePublicKeyEntry, RecipientLookup as NativeRecipientLookup,
+    OperationalFeedItem as NativeOperationalFeedItem, PauseState as NativePauseState,
+    PoolInfo as NativePoolInfo, PublicKeyEntry as NativePublicKeyEntry,
+    RecipientLookup as NativeRecipientLookup,
 };
 use wasm_bindgen::prelude::*;
 
@@ -134,6 +135,33 @@ pub(crate) fn operational_feed_items(
     values.into_iter().map(OperationalFeedItem::from).collect()
 }
 
+/// The pause bits a contract has set and the ledger a timed pause ends at.
+#[wasm_bindgen]
+pub struct PauseState {
+    inner: NativePauseState,
+}
+
+#[wasm_bindgen]
+impl PauseState {
+    #[wasm_bindgen(getter)]
+    pub fn flags(&self) -> u32 {
+        self.inner.flags
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn until(&self) -> Option<u32> {
+        self.inner.until
+    }
+}
+
+impl From<&NativePauseState> for PauseState {
+    fn from(inner: &NativePauseState) -> Self {
+        Self {
+            inner: inner.clone(),
+        }
+    }
+}
+
 #[wasm_bindgen]
 pub struct AspMembership {
     inner: NativeAspMembership,
@@ -185,6 +213,11 @@ impl AspMembership {
     pub fn used_slots(&self) -> String {
         self.inner.used_slots.clone()
     }
+
+    #[wasm_bindgen(getter)]
+    pub fn pause(&self) -> Option<PauseState> {
+        self.inner.pause.as_ref().map(PauseState::from)
+    }
 }
 
 impl From<NativeAspMembership> for AspMembership {
@@ -228,6 +261,11 @@ impl AspNonMembership {
     #[wasm_bindgen(getter)]
     pub fn admin(&self) -> String {
         self.inner.admin.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn pause(&self) -> Option<PauseState> {
+        self.inner.pause.as_ref().map(PauseState::from)
     }
 }
 
@@ -335,6 +373,11 @@ impl PoolInfo {
             .admin_view_key
             .as_ref()
             .map(BabyJubJubPoint::from)
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn pause(&self) -> Option<PauseState> {
+        self.inner.pause.as_ref().map(PauseState::from)
     }
 }
 


### PR DESCRIPTION
Client-side work in three parts: the indexer learns the two new governance events, the contract
state types carry pause state, and an invocation whose footprint touches an archived entry
restores it instead of failing. Includes a SQLite migration.

## Event parsing

`AdminUpdated` and `PauseChanged` now parse into typed events. `PauseChanged` carries an
optional expiry: an absent value decodes as `None`, a ledger number as `Some`. Anything else is
an error naming the event id, so a malformed event is traceable rather than dropped in silence.

## The `processed_events` table, migration v3

`get_unprocessed_events` finds work by selecting every raw event that has no row in one of the
saved-event tables. That works because every event the indexer handles produces a row
somewhere.

These two events produce no row of their own. They are read, parsed, and acted on, and they
leave nothing behind for that query to find, so without a record of having handled them they
would be selected again on every pass, forever. The new table stores their ids and the query
excludes anything listed in it.

A test opens a database at the v2 schema, applies v3, and confirms the table exists, so an
existing local database upgrades rather than needing to be rebuilt.

## Pause state on contract state types

`PoolInfo`, `AspMembership`, and `AspNonMembership` gain a `pause` field, an
`Option<PauseState>` read from the contract's `Pause` key, holding `flags` and `until`.

`None` means the contract has never been paused or unpaused. That covers a contract deployed
before the entry existed and a contract that has simply never been touched, and consumers
should treat both as all bits clear rather than as an unknown state.

The field carries `#[serde(default, skip_serializing_if = "Option::is_none")]`, so state
written before it existed still decodes, and a contract that was never paused serializes no new
key. Existing consumers see no change.

The browser SDK exposes the same field as a `pause` getter on its `PoolInfo`, `AspMembership`,
and `AspNonMembership` classes, returning a `PauseState` with `flags` and `until`, or
`undefined` when the contract has never been paused. Each `#[wasm_bindgen]` wrapper names its
getters by hand, so a field added under `sdk/native` stays invisible to JavaScript until a
getter names it.

## Restoring archived entries

When a simulation's footprint touches an archived ledger entry, Soroban RPC returns no usable
transaction. It returns a `restorePreamble` describing a `RestoreFootprint` transaction that
has to be submitted and land before the real invocation can run. The SDK ignored that field, so
the caller saw an unexplained failure with no path forward.

On a preamble the SDK now assembles the transaction the preamble describes, signs and submits it
through the existing signer, waits for it to land, and prepares the original invocation again
against the restored entries. The user sees one extra on-chain transaction and their original
call succeeding.

Details worth checking in review:

- The restore reuses the invocation's source account and sequence number, taking the sequence
  the invocation would have used. The invocation retried after it takes the next one, which
  keeps both valid without a separate sequence lookup.
- Its fee is the base fee plus the preamble's `minResourceFee`.
- A second preamble after a restore is an error, not a reason to try again. Retrying would be an
  unbounded loop against an RPC that keeps asking for the same thing, and it almost certainly
  means something other than archival is wrong.
- A restore that fails on chain surfaces its result XDR in the error, so the failure is
  diagnosable rather than reported as a generic submission failure.

Both paths that submit an invocation handle a preamble: pool `simulate` and account
registration.

This closes the story #562 opens. Commits 1 to 6 there stop entries being archived; this
recovers the ones that already were.

## Breaking change

`PreparedSorobanTx` gains `restore_tx_xdr`, under
`#[serde(default, skip_serializing_if = "Option::is_none")]`, so values serialized before this
change still decode and an invocation needing no restore serializes no new key.

The wallet flow is unchanged. The restore is signed through the same
`sign_soroban_transaction` as any other transaction, so no signer learns a new shape.

Part of #372.
