### PR TITLE
Add the governor and its timelock queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,6 +2878,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+ "soroban-utils",
+ "stellar-access",
+ "stellar-governance",
+ "stellar-macros",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5971,6 +5982,32 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stellar-access"
+version = "0.7.1"
+source = "git+https://github.com/OpenZeppelin/stellar-contracts?rev=9c5e279aa7efabf94ef84fdef29497ff13656e9d#9c5e279aa7efabf94ef84fdef29497ff13656e9d"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "stellar-governance"
+version = "0.7.1"
+source = "git+https://github.com/OpenZeppelin/stellar-contracts?rev=9c5e279aa7efabf94ef84fdef29497ff13656e9d#9c5e279aa7efabf94ef84fdef29497ff13656e9d"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "stellar-macros"
+version = "0.7.1"
+source = "git+https://github.com/OpenZeppelin/stellar-contracts?rev=9c5e279aa7efabf94ef84fdef29497ff13656e9d#9c5e279aa7efabf94ef84fdef29497ff13656e9d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "stellar-private-payments"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,11 @@ soroban-sdk = { version = "27", default-features = false, features = ["hazmat"] 
 soroban-utils = { path = "contracts/soroban-utils" }
 sqlite-wasm-rs = { version = "0.5.5", default-features = false }
 sqlite-wasm-vfs = { version = "0.2.0", default-features = false }
+# The crates.io releases of these three require soroban-sdk 26; this revision targets 27.
+# Replace the git source with the first crates.io release built against soroban-sdk 27.
+stellar-access = { git = "https://github.com/OpenZeppelin/stellar-contracts", rev = "9c5e279aa7efabf94ef84fdef29497ff13656e9d", default-features = false }
+stellar-governance = { git = "https://github.com/OpenZeppelin/stellar-contracts", rev = "9c5e279aa7efabf94ef84fdef29497ff13656e9d", default-features = false }
+stellar-macros = { git = "https://github.com/OpenZeppelin/stellar-contracts", rev = "9c5e279aa7efabf94ef84fdef29497ff13656e9d", default-features = false }
 stellar-private-payments = { path = "sdk/native", version = "0.1.0" }
 taceo-poseidon2 = { version = "0.3", default-features = false, features = ["bn254", "t2", "t3", "t4"] }
 thiserror = { version = "2", default-features = false }

--- a/contracts/governor/Cargo.toml
+++ b/contracts/governor/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "governor"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+# workspace
+soroban-utils = { workspace = true }
+
+# external
+soroban-sdk = { workspace = true }
+stellar-access = { workspace = true }
+stellar-governance = { workspace = true }
+stellar-macros = { workspace = true }
+
+[dev-dependencies]
+# external
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[lints]
+workspace = true

--- a/contracts/governor/src/lib.rs
+++ b/contracts/governor/src/lib.rs
@@ -1,0 +1,614 @@
+//! Timelocked administration of the pools and the association set providers.
+//!
+//! This contract holds the privileged functions of every contract it
+//! administers. A change is queued as an operation, waits out a delay, and is
+//! then executed by anyone, so an observer has the whole delay in which to
+//! react before the change takes effect.
+//!
+//! The queue, the operation hash, and the role table come from the
+//! OpenZeppelin `stellar-governance` and `stellar-access` crates. What this
+//! contract adds is the recovery path, the grace window after which a ready
+//! operation stops being executable, an on-ledger list of what is queued, and
+//! the queue cap that keeps that list readable.
+//!
+//! Four roles divide the authority. The council queues and cancels operations,
+//! the recovery role queues role changes when the council keys are lost, the
+//! guardian stops a contract without waiting for the queue, and the operator
+//! makes the calls that the permission table opens to it.
+#![no_std]
+use soroban_sdk::{
+    Address, BytesN, Env, Symbol, Val, Vec, contract, contracterror, contractimpl, contracttype,
+    panic_with_error, symbol_short,
+};
+use soroban_utils::{bump_entry, bump_instance};
+use stellar_access::access_control as access;
+use stellar_governance::timelock;
+use stellar_macros::only_role;
+
+/// Role that queues any operation against any target and cancels queued ones.
+pub const COUNCIL: Symbol = symbol_short!("council");
+/// Role that calls a target function the permission table opens to it.
+pub const OPERATOR: Symbol = symbol_short!("operator");
+/// Role that pauses a target without waiting out the delay.
+pub const GUARDIAN: Symbol = symbol_short!("guardian");
+/// Role that queues role changes when the council keys are lost.
+pub const RECOVERY: Symbol = symbol_short!("recovery");
+
+/// Smallest `delay` the constructor accepts, one minute of ledgers.
+pub const DELAY_FLOOR: u32 = 12;
+
+/// Most operations the queue holds at once.
+///
+/// An operation left past its grace window is never removed by
+/// [`Governor::execute`], which rolls back, so without a ceiling the queue
+/// grows for as long as nobody tends it.
+pub const MAX_PENDING: u32 = 16;
+
+/// Most operations the council may leave queued.
+///
+/// The gap up to [`MAX_PENDING`] belongs to the recovery role alone, so a
+/// council whose keys are compromised cannot fill the queue and shut out the
+/// role that exists to replace it.
+pub const MAX_PENDING_COUNCIL: u32 = 12;
+
+/// A role handed to an address when the governor is constructed.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoleGrant {
+    /// One of the four roles the governor defines.
+    pub role: Symbol,
+    /// The address that receives the role.
+    pub member: Address,
+}
+
+/// The four waiting periods a governor is constructed with.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Delays {
+    /// Ledgers between a council operation being queued and becoming ready.
+    pub delay: u32,
+    /// Ledgers between a recovery operation being queued and becoming ready.
+    pub recovery_delay: u32,
+    /// Ledgers a ready operation stays executable.
+    pub grace: u32,
+    /// Ledgers a guardian pause holds before the deadline it sets.
+    pub guardian_pause: u32,
+}
+
+/// A queued operation together with the ledger at which it becomes ready.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingOperation {
+    /// The operation hash, which is also its queue key.
+    pub id: BytesN<32>,
+    /// The call the operation performs once executed.
+    pub operation: timelock::Operation,
+    /// Ledger sequence number at which the operation may be executed.
+    pub ready_ledger: u32,
+}
+
+/// Where an operation stands in the queue.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OperationStatus {
+    /// No operation with this hash has been scheduled.
+    Unset,
+    /// Scheduled, and the delay has not run out.
+    Waiting,
+    /// The delay has run out and the grace window has not.
+    Ready,
+    /// The grace window closed before anyone executed the operation.
+    Expired,
+    /// The operation has been executed.
+    Done,
+}
+
+/// Storage keys for contract data the governor owns.
+///
+/// The minimum delay, the operation ledgers, and the role table live under the
+/// OpenZeppelin crates' own keys.
+#[contracttype]
+#[derive(Clone, Debug)]
+enum DataKey {
+    /// Ledgers a recovery operation waits before it becomes ready.
+    RecoveryDelay,
+    /// Ledgers a ready operation stays executable.
+    Grace,
+    /// Ledgers a guardian pause holds before the deadline it sets.
+    GuardianPause,
+    /// Hashes of the operations that are queued and not yet executed.
+    Pending,
+    /// The queued call, stored under its hash while it is pending.
+    Operation(BytesN<32>),
+}
+
+/// The errors the governor raises.
+///
+/// The codes start at 3000 so that a failure the governor raises is
+/// distinguishable from one it forwards from a target contract, the same way
+/// OpenZeppelin reserves 2000 for access control and 4000 for the timelock.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    /// The governor's configuration is absent, or the arguments given to the
+    /// constructor break an invariant it requires.
+    InvalidConfig = 3001,
+    /// The requested delay is below the floor that applies to the call.
+    InsufficientDelay = 3002,
+    /// The grace window closed before anyone executed the operation.
+    Expired = 3003,
+    /// The caller holds no role that permits the call.
+    Unauthorized = 3004,
+    /// A ledger computation overflowed.
+    Overflow = 3005,
+    /// The permission table holds no row for the target function.
+    UnknownFunction = 3006,
+    /// The arguments do not match what the target function accepts.
+    InvalidArgs = 3007,
+    /// The change would leave the governor without a required role holder.
+    RoleInvariant = 3008,
+    /// The symbol names no role the governor defines.
+    UnknownRole = 3009,
+    /// The queue already holds as many operations as the caller's role may
+    /// leave in it.
+    QueueFull = 3010,
+}
+
+/// The timelocked administrator of the pools and the association set providers.
+#[contract]
+pub struct Governor;
+
+#[contractimpl]
+impl Governor {
+    /// Configures the waiting periods and hands out the initial roles.
+    ///
+    /// The four waiting periods are counts of ledgers: `delay` is at least
+    /// [`DELAY_FLOOR`], `recovery_delay` is at least `delay`, `grace` is at
+    /// least 1, and `guardian_pause` exceeds `delay` so that the council can
+    /// queue an unpause inside the window. `roles` covers at least one council
+    /// address, one recovery address, and one guardian, with no address under
+    /// two roles.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidConfig`] if any of those conditions fails, or
+    /// if a grant names a symbol that is not one of the four roles.
+    ///
+    /// # Events
+    ///
+    /// Publishes `RoleGranted` from the OpenZeppelin access control module for
+    /// each grant, and `MinDelayChanged` from the OpenZeppelin timelock.
+    pub fn __constructor(
+        env: Env,
+        delay: u32,
+        recovery_delay: u32,
+        grace: u32,
+        guardian_pause: u32,
+        roles: Vec<RoleGrant>,
+    ) -> Result<(), Error> {
+        if delay < DELAY_FLOOR || recovery_delay < delay || grace == 0 || guardian_pause <= delay {
+            return Err(Error::InvalidConfig);
+        }
+
+        let governor = env.current_contract_address();
+        for (index, grant) in roles.iter().enumerate() {
+            if !is_known_role(&grant.role) {
+                return Err(Error::InvalidConfig);
+            }
+            if roles
+                .iter()
+                .take(index)
+                .any(|other| other.member == grant.member)
+            {
+                return Err(Error::InvalidConfig);
+            }
+            grant_role(&env, &grant.member, &grant.role, &governor);
+        }
+        if access::get_role_member_count(&env, &COUNCIL) == 0
+            || access::get_role_member_count(&env, &RECOVERY) == 0
+            || access::get_role_member_count(&env, &GUARDIAN) == 0
+        {
+            return Err(Error::InvalidConfig);
+        }
+
+        timelock::set_min_delay(&env, delay);
+        let instance = env.storage().instance();
+        instance.set(&DataKey::RecoveryDelay, &recovery_delay);
+        instance.set(&DataKey::Grace, &grace);
+        instance.set(&DataKey::GuardianPause, &guardian_pause);
+        bump_instance(&env);
+        Ok(())
+    }
+
+    /// Queues an operation and returns its hash.
+    ///
+    /// The council may queue any call against any contract and waits the
+    /// governor's delay. A recovery address may queue only `grant_role` and
+    /// `revoke_role` on the governor itself, and waits the recovery delay
+    /// instead. Every operation whose grace window has closed is dropped from
+    /// the queue before the new one is appended. `predecessor` is the hash of
+    /// an operation that must execute first, or 32 zero bytes for none, and
+    /// `salt` distinguishes two otherwise identical operations.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Unauthorized`] if `caller` holds neither the council
+    /// nor the recovery role, or holds only recovery and the call is not a
+    /// role change on the governor; [`Error::Overflow`] if the ready ledger
+    /// would exceed `u32::MAX`; and [`Error::QueueFull`] if the queue is
+    /// already at [`MAX_PENDING_COUNCIL`] for the council, or [`MAX_PENDING`]
+    /// for a recovery address, once the dead operations have been pruned.
+    ///
+    /// # Panics
+    ///
+    /// Panics with OpenZeppelin's `OperationAlreadyScheduled` if an operation
+    /// with the same hash is already queued, and with
+    /// [`Error::InvalidConfig`] if the governor holds no configuration, which
+    /// a constructed governor always does.
+    ///
+    /// # Events
+    ///
+    /// Publishes `OperationScheduled` from the OpenZeppelin timelock.
+    pub fn schedule(
+        env: Env,
+        target: Address,
+        function: Symbol,
+        args: Vec<Val>,
+        predecessor: BytesN<32>,
+        salt: BytesN<32>,
+        caller: Address,
+    ) -> Result<BytesN<32>, Error> {
+        bump_instance(&env);
+        caller.require_auth();
+
+        let council = access::has_role(&env, &caller, &COUNCIL).is_some();
+        let required = if council {
+            timelock::get_min_delay(&env)
+        } else if access::has_role(&env, &caller, &RECOVERY).is_some() {
+            if target != env.current_contract_address() || !is_role_function(&env, &function) {
+                return Err(Error::Unauthorized);
+            }
+            setting(&env, &DataKey::RecoveryDelay)
+        } else {
+            return Err(Error::Unauthorized);
+        };
+
+        env.ledger()
+            .sequence()
+            .checked_add(required)
+            .ok_or(Error::Overflow)?;
+
+        let mut pending = prune_pending(&env);
+        let limit = if council {
+            MAX_PENDING_COUNCIL
+        } else {
+            MAX_PENDING
+        };
+        if pending.len() >= limit {
+            return Err(Error::QueueFull);
+        }
+
+        let operation = operation(target, function, args, predecessor, salt);
+        let id = timelock::schedule_operation(&env, &operation, required);
+
+        let key = DataKey::Operation(id.clone());
+        env.storage().persistent().set(&key, &operation);
+        bump_entry(&env, &key);
+        // The timelock writes the ready ledger with the network minimum
+        // lifetime, which on a delay of a week or more expires before the
+        // operation it gates becomes executable.
+        bump_entry(
+            &env,
+            &timelock::TimelockStorageKey::OperationLedger(id.clone()),
+        );
+
+        pending.push_back(id.clone());
+        env.storage().persistent().set(&DataKey::Pending, &pending);
+        bump_entry(&env, &DataKey::Pending);
+
+        Ok(id)
+    }
+
+    /// Executes a ready operation and returns what the target returned.
+    ///
+    /// Anyone may execute. The delay is what protects the call, not the
+    /// identity of whoever finally makes it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Expired`] if the grace window closed, and
+    /// [`Error::Unauthorized`] if the target is the governor itself.
+    ///
+    /// # Panics
+    ///
+    /// Panics with OpenZeppelin's `InvalidOperationState` if the operation is
+    /// not ready, `UnexecutedPredecessor` if its predecessor has not run, and
+    /// [`Error::InvalidConfig`] if the governor holds no configuration, which
+    /// a constructed governor always does.
+    ///
+    /// # Events
+    ///
+    /// Publishes `OperationExecuted` from the OpenZeppelin timelock.
+    pub fn execute(
+        env: Env,
+        target: Address,
+        function: Symbol,
+        args: Vec<Val>,
+        predecessor: BytesN<32>,
+        salt: BytesN<32>,
+    ) -> Result<Val, Error> {
+        bump_instance(&env);
+        let operation = operation(target, function, args, predecessor, salt);
+        let id = timelock::hash_operation(&env, &operation);
+
+        let ready = timelock::get_operation_ledger(&env, &id);
+        if is_scheduled(ready)
+            && env.ledger().sequence() > ready.saturating_add(setting(&env, &DataKey::Grace))
+        {
+            return Err(Error::Expired);
+        }
+
+        timelock::set_execute_operation(&env, &operation);
+        forget(&env, &id);
+
+        if operation.target == env.current_contract_address() {
+            return Err(Error::Unauthorized);
+        }
+        Ok(env.invoke_contract::<Val>(&operation.target, &operation.function, operation.args))
+    }
+
+    /// Cancels a queued operation, which is named by the call it would make.
+    ///
+    /// # Panics
+    ///
+    /// Panics with OpenZeppelin's `Unauthorized` if `caller` does not hold the
+    /// council role, and `InvalidOperationState` if the operation is neither
+    /// waiting nor ready.
+    ///
+    /// # Events
+    ///
+    /// Publishes `OperationCancelled` from the OpenZeppelin timelock.
+    #[only_role(caller, "council")]
+    pub fn cancel(
+        env: Env,
+        target: Address,
+        function: Symbol,
+        args: Vec<Val>,
+        predecessor: BytesN<32>,
+        salt: BytesN<32>,
+        caller: Address,
+    ) {
+        bump_instance(&env);
+        let id =
+            timelock::hash_operation(&env, &operation(target, function, args, predecessor, salt));
+        timelock::cancel_operation(&env, &id);
+        forget(&env, &id);
+    }
+
+    /// Returns the four waiting periods the governor was constructed with.
+    ///
+    /// # Panics
+    ///
+    /// Panics with [`Error::InvalidConfig`] if the governor has no
+    /// configuration stored, and with OpenZeppelin's `MinDelayNotSet` if it
+    /// has no minimum delay.
+    pub fn get_delays(env: Env) -> Delays {
+        bump_instance(&env);
+        Delays {
+            delay: timelock::get_min_delay(&env),
+            recovery_delay: setting(&env, &DataKey::RecoveryDelay),
+            grace: setting(&env, &DataKey::Grace),
+            guardian_pause: setting(&env, &DataKey::GuardianPause),
+        }
+    }
+
+    /// Reports whether `member` holds `role`.
+    pub fn has_role(env: Env, member: Address, role: Symbol) -> bool {
+        bump_instance(&env);
+        access::has_role(&env, &member, &role).is_some()
+    }
+
+    /// Returns the number of addresses that hold `role`.
+    pub fn get_role_member_count(env: Env, role: Symbol) -> u32 {
+        bump_instance(&env);
+        access::get_role_member_count(&env, &role)
+    }
+
+    /// Returns the address holding `role` at `index`.
+    ///
+    /// # Panics
+    ///
+    /// Panics with OpenZeppelin's `IndexOutOfBounds` if fewer than `index + 1`
+    /// addresses hold the role.
+    pub fn get_role_member(env: Env, role: Symbol, index: u32) -> Address {
+        bump_instance(&env);
+        access::get_role_member(&env, &role, index)
+    }
+
+    /// Returns the hash that identifies the operation these arguments
+    /// describe.
+    pub fn hash_operation(
+        env: Env,
+        target: Address,
+        function: Symbol,
+        args: Vec<Val>,
+        predecessor: BytesN<32>,
+        salt: BytesN<32>,
+    ) -> BytesN<32> {
+        bump_instance(&env);
+        timelock::hash_operation(&env, &operation(target, function, args, predecessor, salt))
+    }
+
+    /// Returns where the operation identified by `id` stands in the queue.
+    ///
+    /// An expired operation is still ready as far as the OpenZeppelin timelock
+    /// is concerned, so [`Governor::cancel`] accepts it while
+    /// [`Governor::execute`] refuses it.
+    ///
+    /// # Panics
+    ///
+    /// Panics with [`Error::InvalidConfig`] if the governor has no grace
+    /// window stored.
+    pub fn get_operation_state(env: Env, id: BytesN<32>) -> OperationStatus {
+        bump_instance(&env);
+        let ready = timelock::get_operation_ledger(&env, &id);
+        let now = env.ledger().sequence();
+        match ready {
+            timelock::UNSET_LEDGER => OperationStatus::Unset,
+            timelock::DONE_LEDGER => OperationStatus::Done,
+            _ if ready > now => OperationStatus::Waiting,
+            _ if now > ready.saturating_add(setting(&env, &DataKey::Grace)) => {
+                OperationStatus::Expired
+            }
+            _ => OperationStatus::Ready,
+        }
+    }
+
+    /// Returns every queued operation with the ledger at which it becomes
+    /// ready.
+    ///
+    /// Public RPC keeps events for about a week, which is shorter than the
+    /// delay a deployment may choose, so the queue is answered from ledger
+    /// state rather than from the event log.
+    pub fn get_pending(env: Env) -> Vec<PendingOperation> {
+        bump_instance(&env);
+        let mut pending = Vec::new(&env);
+        for id in pending_ids(&env).iter() {
+            let key = DataKey::Operation(id.clone());
+            let Some(operation) = env.storage().persistent().get(&key) else {
+                continue;
+            };
+            bump_entry(&env, &key);
+            let ready_ledger = timelock::get_operation_ledger(&env, &id);
+            pending.push_back(PendingOperation {
+                id,
+                operation,
+                ready_ledger,
+            });
+        }
+        pending
+    }
+}
+
+/// Assembles the operation these arguments describe.
+fn operation(
+    target: Address,
+    function: Symbol,
+    args: Vec<Val>,
+    predecessor: BytesN<32>,
+    salt: BytesN<32>,
+) -> timelock::Operation {
+    timelock::Operation {
+        target,
+        function,
+        args,
+        predecessor,
+        salt,
+    }
+}
+
+/// Reports whether `role` is one of the four roles the governor defines.
+fn is_known_role(role: &Symbol) -> bool {
+    [COUNCIL, OPERATOR, GUARDIAN, RECOVERY].contains(role)
+}
+
+/// Reports whether `function` is one of the role changes a recovery address
+/// may queue against the governor.
+fn is_role_function(env: &Env, function: &Symbol) -> bool {
+    *function == Symbol::new(env, "grant_role") || *function == Symbol::new(env, "revoke_role")
+}
+
+/// Reports whether `ready_ledger` belongs to an operation that is queued
+/// rather than one that is unset or already done.
+fn is_scheduled(ready_ledger: u32) -> bool {
+    ready_ledger != timelock::UNSET_LEDGER && ready_ledger != timelock::DONE_LEDGER
+}
+
+/// Grants `role` to `member` and extends the lifetime of the entries the grant
+/// writes.
+///
+/// The access control module writes one more entry, the role enumeration slot
+/// that [`Governor::get_role_member`] reads, under a key private to the
+/// module. Reading the member back through the module's own getter is what
+/// extends that one, because the module writes it without ever reading it.
+/// That read lands at the module's own 90-day amount rather than
+/// [`soroban_utils::ttl::EXTEND_TO`], because the key type the entry needs is
+/// private and [`bump_entry`] cannot name it.
+fn grant_role(env: &Env, member: &Address, role: &Symbol, caller: &Address) {
+    access::grant_role_no_auth(env, member, role, caller);
+    bump_entry(
+        env,
+        &access::AccessControlStorageKey::HasRole(member.clone(), role.clone()),
+    );
+    bump_entry(
+        env,
+        &access::AccessControlStorageKey::RoleAccountsCount(role.clone()),
+    );
+    bump_entry(env, &access::AccessControlStorageKey::ExistingRoles);
+    if let Some(index) = access::has_role(env, member, role) {
+        access::get_role_member(env, role, index);
+    }
+}
+
+/// Reads one of the governor's own waiting periods from instance storage.
+///
+/// # Panics
+///
+/// Panics with [`Error::InvalidConfig`] if the governor holds no value under
+/// `key`, which a constructed governor always does.
+fn setting(env: &Env, key: &DataKey) -> u32 {
+    env.storage()
+        .instance()
+        .get(key)
+        .unwrap_or_else(|| panic_with_error!(env, Error::InvalidConfig))
+}
+
+/// Reads the queued operation hashes, treating an absent list as empty.
+fn pending_ids(env: &Env) -> Vec<BytesN<32>> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Pending)
+        .inspect(|_| bump_entry(env, &DataKey::Pending))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Returns the queue with every operation that can no longer be executed
+/// dropped, and forgets the call each dropped operation held.
+///
+/// An operation left past its grace window returns [`Error::Expired`] from
+/// [`Governor::execute`], which rolls back, so nothing removes it on its own.
+/// Pruning on the way into [`Governor::schedule`] is what keeps a queue that
+/// nobody tends from growing until governance can no longer act.
+fn prune_pending(env: &Env) -> Vec<BytesN<32>> {
+    let grace = setting(env, &DataKey::Grace);
+    let now = env.ledger().sequence();
+    let mut kept = Vec::new(env);
+    for id in pending_ids(env).iter() {
+        let ready = timelock::get_operation_ledger(env, &id);
+        let scheduled = is_scheduled(ready);
+        if scheduled && now <= ready.saturating_add(grace) {
+            kept.push_back(id);
+        } else {
+            if scheduled {
+                timelock::cancel_operation(env, &id);
+            }
+            env.storage().persistent().remove(&DataKey::Operation(id));
+        }
+    }
+    kept
+}
+
+/// Drops an operation from the queue once it has executed or been cancelled.
+fn forget(env: &Env, id: &BytesN<32>) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::Operation(id.clone()));
+    let mut pending = pending_ids(env);
+    if let Some(index) = pending.first_index_of(id) {
+        pending.remove(index);
+        env.storage().persistent().set(&DataKey::Pending, &pending);
+    }
+}
+
+mod test;

--- a/contracts/governor/src/test.rs
+++ b/contracts/governor/src/test.rs
@@ -1,0 +1,1347 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    Address, BytesN, Env, IntoVal, InvokeError, Symbol, Val, Vec,
+    events::Event,
+    testutils::{
+        Address as _, Events, Ledger as _,
+        storage::{Instance as _, Persistent as _},
+    },
+    vec,
+};
+use soroban_utils::ttl::EXTEND_TO;
+use stellar_access::access_control::RoleGranted;
+use stellar_governance::timelock::{OperationCancelled, OperationExecuted, OperationScheduled};
+
+const DELAY: u32 = DELAY_FLOOR;
+const RECOVERY_DELAY: u32 = 20;
+const GRACE: u32 = 5;
+const GUARDIAN_PAUSE: u32 = 15;
+
+/// Create a test environment that disables snapshot writing under Miri.
+/// Miri's isolation mode blocks filesystem operations, which the Soroban SDK
+/// uses for test snapshots.
+fn test_env() -> Env {
+    #[cfg(miri)]
+    {
+        use soroban_sdk::testutils::EnvTestConfig;
+        Env::new_with_config(EnvTestConfig {
+            capture_snapshot_at_drop: false,
+        })
+    }
+    #[cfg(not(miri))]
+    {
+        Env::default()
+    }
+}
+
+#[contracttype]
+enum MockKey {
+    LastPoke,
+}
+
+/// A target the governor can call, recording the argument it was called with.
+#[contract]
+pub struct MockTarget;
+
+#[contractimpl]
+impl MockTarget {
+    pub fn poke(env: Env, x: u32) {
+        env.storage().instance().set(&MockKey::LastPoke, &x);
+    }
+
+    pub fn last_poke(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&MockKey::LastPoke)
+            .unwrap_or(0)
+    }
+
+    pub fn fail() {
+        panic!()
+    }
+}
+
+struct Setup {
+    mock: Address,
+    governor: Address,
+    council: Address,
+    recovery: Address,
+    guardian: Address,
+}
+
+fn roles(env: &Env, council: &Address, recovery: &Address, guardian: &Address) -> Vec<RoleGrant> {
+    vec![
+        env,
+        RoleGrant {
+            role: COUNCIL,
+            member: council.clone(),
+        },
+        RoleGrant {
+            role: RECOVERY,
+            member: recovery.clone(),
+        },
+        RoleGrant {
+            role: GUARDIAN,
+            member: guardian.clone(),
+        },
+    ]
+}
+
+fn register_governor(
+    env: &Env,
+    delay: u32,
+    recovery_delay: u32,
+    grace: u32,
+    guardian_pause: u32,
+    roles: Vec<RoleGrant>,
+) -> Address {
+    env.register(
+        Governor,
+        (delay, recovery_delay, grace, guardian_pause, roles),
+    )
+}
+
+fn setup(env: &Env) -> Setup {
+    let mock = env.register(MockTarget, ());
+    let council = Address::generate(env);
+    let recovery = Address::generate(env);
+    let guardian = Address::generate(env);
+    let governor = register_governor(
+        env,
+        DELAY,
+        RECOVERY_DELAY,
+        GRACE,
+        GUARDIAN_PAUSE,
+        roles(env, &council, &recovery, &guardian),
+    );
+    Setup {
+        mock,
+        governor,
+        council,
+        recovery,
+        guardian,
+    }
+}
+
+/// The value a `try_` client yields for a contract error raised by a function
+/// that declares no error type of its own.
+fn host_error(code: u32) -> soroban_sdk::Error {
+    soroban_sdk::Error::from_contract_error(code)
+}
+
+fn no_predecessor(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[0u8; 32])
+}
+
+fn salt(env: &Env, byte: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[byte; 32])
+}
+
+fn poke(env: &Env) -> Symbol {
+    Symbol::new(env, "poke")
+}
+
+fn poke_args(env: &Env, x: u32) -> Vec<Val> {
+    vec![env, x.into_val(env)]
+}
+
+fn grant_role_fn(env: &Env) -> Symbol {
+    Symbol::new(env, "grant_role")
+}
+
+/// Schedules `poke(7)` on the mock from the council and returns its id.
+fn schedule_poke(env: &Env, s: &Setup) -> BytesN<32> {
+    GovernorClient::new(env, &s.governor).schedule(
+        &s.mock,
+        &poke(env),
+        &poke_args(env, 7),
+        &no_predecessor(env),
+        &salt(env, 1),
+        &s.council,
+    )
+}
+
+/// Schedules `grant_role` on the governor from the recovery role and returns
+/// its id.
+fn schedule_recovery(env: &Env, s: &Setup, byte: u8) -> BytesN<32> {
+    GovernorClient::new(env, &s.governor).schedule(
+        &s.governor,
+        &grant_role_fn(env),
+        &Vec::new(env),
+        &no_predecessor(env),
+        &salt(env, byte),
+        &s.recovery,
+    )
+}
+
+// ---------------------------------------------------------------- constructor
+
+// Every test below that asserts a panic carries `#[cfg_attr(miri, ignore)]`,
+// because the panic formatting path triggers undefined behavior in the
+// `ethnum` crate's unsafe formatting code.
+// See: https://github.com/nlordell/ethnum-rs/issues/34
+
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Contract, #3001)")]
+fn constructor_rejects_delay_below_floor() {
+    let env = test_env();
+    let council = Address::generate(&env);
+    let recovery = Address::generate(&env);
+    let guardian = Address::generate(&env);
+
+    register_governor(
+        &env,
+        DELAY_FLOOR - 1,
+        RECOVERY_DELAY,
+        GRACE,
+        GUARDIAN_PAUSE,
+        roles(&env, &council, &recovery, &guardian),
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Contract, #3001)")]
+fn constructor_rejects_recovery_delay_below_delay() {
+    let env = test_env();
+    let council = Address::generate(&env);
+    let recovery = Address::generate(&env);
+    let guardian = Address::generate(&env);
+
+    register_governor(
+        &env,
+        DELAY,
+        DELAY - 1,
+        GRACE,
+        GUARDIAN_PAUSE,
+        roles(&env, &council, &recovery, &guardian),
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Contract, #3001)")]
+fn constructor_rejects_zero_grace() {
+    let env = test_env();
+    let council = Address::generate(&env);
+    let recovery = Address::generate(&env);
+    let guardian = Address::generate(&env);
+
+    register_governor(
+        &env,
+        DELAY,
+        RECOVERY_DELAY,
+        0,
+        GUARDIAN_PAUSE,
+        roles(&env, &council, &recovery, &guardian),
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Contract, #3001)")]
+fn constructor_rejects_a_guardian_pause_equal_to_the_delay() {
+    let env = test_env();
+    let council = Address::generate(&env);
+    let recovery = Address::generate(&env);
+    let guardian = Address::generate(&env);
+
+    register_governor(
+        &env,
+        DELAY,
+        RECOVERY_DELAY,
+        GRACE,
+        DELAY,
+        roles(&env, &council, &recovery, &guardian),
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Contract, #3001)")]
+fn constructor_rejects_an_unknown_role() {
+    let env = test_env();
+    let council = Address::generate(&env);
+    let recovery = Address::generate(&env);
+    let guardian = Address::generate(&env);
+    let stranger = Address::generate(&env);
+
+    let mut grants = roles(&env, &council, &recovery, &guardian);
+    grants.push_back(RoleGrant {
+        role: Symbol::new(&env, "auditor"),
+        member: stranger,
+    });
+
+    register_governor(&env, DELAY, RECOVERY_DELAY, GRACE, GUARDIAN_PAUSE, grants);
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Contract, #3001)")]
+fn constructor_rejects_a_missing_council() {
+    let env = test_env();
+    let recovery = Address::generate(&env);
+    let guardian = Address::generate(&env);
+
+    register_governor(
+        &env,
+        DELAY,
+        RECOVERY_DELAY,
+        GRACE,
+        GUARDIAN_PAUSE,
+        vec![
+            &env,
+            RoleGrant {
+                role: RECOVERY,
+                member: recovery,
+            },
+            RoleGrant {
+                role: GUARDIAN,
+                member: guardian,
+            },
+        ],
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Contract, #3001)")]
+fn constructor_rejects_a_missing_recovery_holder() {
+    let env = test_env();
+    let council = Address::generate(&env);
+    let guardian = Address::generate(&env);
+
+    register_governor(
+        &env,
+        DELAY,
+        RECOVERY_DELAY,
+        GRACE,
+        GUARDIAN_PAUSE,
+        vec![
+            &env,
+            RoleGrant {
+                role: COUNCIL,
+                member: council,
+            },
+            RoleGrant {
+                role: GUARDIAN,
+                member: guardian,
+            },
+        ],
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Contract, #3001)")]
+fn constructor_rejects_a_missing_guardian() {
+    let env = test_env();
+    let council = Address::generate(&env);
+    let recovery = Address::generate(&env);
+
+    register_governor(
+        &env,
+        DELAY,
+        RECOVERY_DELAY,
+        GRACE,
+        GUARDIAN_PAUSE,
+        vec![
+            &env,
+            RoleGrant {
+                role: COUNCIL,
+                member: council,
+            },
+            RoleGrant {
+                role: RECOVERY,
+                member: recovery,
+            },
+        ],
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Contract, #3001)")]
+fn constructor_rejects_one_address_under_two_roles() {
+    let env = test_env();
+    let council = Address::generate(&env);
+    let recovery = Address::generate(&env);
+    let guardian = Address::generate(&env);
+
+    let mut grants = roles(&env, &council, &recovery, &guardian);
+    grants.push_back(RoleGrant {
+        role: OPERATOR,
+        member: council,
+    });
+
+    register_governor(&env, DELAY, RECOVERY_DELAY, GRACE, GUARDIAN_PAUSE, grants);
+}
+
+#[test]
+fn constructor_sets_every_getter() {
+    let env = test_env();
+    let s = setup(&env);
+    let client = GovernorClient::new(&env, &s.governor);
+
+    assert_eq!(
+        client.get_delays(),
+        Delays {
+            delay: DELAY,
+            recovery_delay: RECOVERY_DELAY,
+            grace: GRACE,
+            guardian_pause: GUARDIAN_PAUSE,
+        }
+    );
+
+    assert!(client.has_role(&s.council, &COUNCIL));
+    assert!(client.has_role(&s.recovery, &RECOVERY));
+    assert!(client.has_role(&s.guardian, &GUARDIAN));
+    assert!(!client.has_role(&s.guardian, &COUNCIL));
+
+    assert_eq!(client.get_role_member_count(&COUNCIL), 1);
+    assert_eq!(client.get_role_member_count(&OPERATOR), 0);
+    assert_eq!(client.get_role_member(&COUNCIL, &0), s.council);
+
+    assert_eq!(client.get_pending(), Vec::new(&env));
+
+    env.mock_all_auths();
+    assert_eq!(
+        client.hash_operation(
+            &s.mock,
+            &poke(&env),
+            &poke_args(&env, 7),
+            &no_predecessor(&env),
+            &salt(&env, 1),
+        ),
+        schedule_poke(&env, &s)
+    );
+}
+
+#[test]
+fn constructor_emits_role_granted() {
+    let env = test_env();
+    let council = Address::generate(&env);
+    let recovery = Address::generate(&env);
+    let guardian = Address::generate(&env);
+    let governor = register_governor(
+        &env,
+        DELAY,
+        RECOVERY_DELAY,
+        GRACE,
+        GUARDIAN_PAUSE,
+        roles(&env, &council, &recovery, &guardian),
+    );
+
+    let events = env.events().all();
+    let expected = RoleGranted {
+        role: COUNCIL,
+        account: council,
+        caller: governor.clone(),
+    }
+    .to_xdr(&env, &governor);
+    assert_eq!(events.events()[0], expected);
+}
+
+#[test]
+fn the_constructor_extends_the_ttl_of_the_role_entries() {
+    let env = test_env();
+    let s = setup(&env);
+
+    env.as_contract(&s.governor, || {
+        let store = env.storage().persistent();
+        assert_eq!(
+            store.get_ttl(&access::AccessControlStorageKey::HasRole(
+                s.council.clone(),
+                COUNCIL
+            )),
+            EXTEND_TO
+        );
+        assert_eq!(
+            store.get_ttl(&access::AccessControlStorageKey::RoleAccountsCount(COUNCIL)),
+            EXTEND_TO
+        );
+        assert_eq!(
+            store.get_ttl(&access::AccessControlStorageKey::ExistingRoles),
+            EXTEND_TO
+        );
+    });
+}
+
+// ------------------------------------------------------------------- schedule
+
+#[test]
+fn schedule_accepts_any_target_from_the_council() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    let id = schedule_poke(&env, &s);
+
+    assert_eq!(client.get_operation_state(&id), OperationStatus::Waiting);
+}
+
+#[test]
+fn schedule_accepts_a_role_change_from_recovery() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    let id = schedule_recovery(&env, &s, 1);
+
+    assert_eq!(client.get_operation_state(&id), OperationStatus::Waiting);
+}
+
+#[test]
+fn schedule_accepts_a_role_revocation_from_recovery() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    let id = client.schedule(
+        &s.governor,
+        &Symbol::new(&env, "revoke_role"),
+        &Vec::new(&env),
+        &no_predecessor(&env),
+        &salt(&env, 1),
+        &s.recovery,
+    );
+
+    assert_eq!(client.get_operation_state(&id), OperationStatus::Waiting);
+}
+
+#[test]
+fn schedule_rejects_recovery_on_a_mock_target() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    assert!(matches!(
+        client.try_schedule(
+            &s.mock,
+            &poke(&env),
+            &poke_args(&env, 7),
+            &no_predecessor(&env),
+            &salt(&env, 1),
+            &s.recovery,
+        ),
+        Err(Ok(Error::Unauthorized))
+    ));
+}
+
+#[test]
+fn schedule_rejects_recovery_on_a_non_role_function() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    assert!(matches!(
+        client.try_schedule(
+            &s.governor,
+            &Symbol::new(&env, "set_fn_role"),
+            &Vec::new(&env),
+            &no_predecessor(&env),
+            &salt(&env, 1),
+            &s.recovery,
+        ),
+        Err(Ok(Error::Unauthorized))
+    ));
+}
+
+#[test]
+fn schedule_gives_a_council_operation_the_delay() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+    let scheduled_at = env.ledger().sequence();
+
+    schedule_poke(&env, &s);
+
+    let entry = client.get_pending().get(0).expect("one pending operation");
+    assert_eq!(entry.ready_ledger, scheduled_at.saturating_add(DELAY));
+}
+
+#[test]
+fn schedule_gives_a_recovery_operation_the_recovery_delay() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+    let scheduled_at = env.ledger().sequence();
+
+    schedule_recovery(&env, &s, 1);
+
+    let entry = client.get_pending().get(0).expect("one pending operation");
+    assert_eq!(
+        entry.ready_ledger,
+        scheduled_at.saturating_add(RECOVERY_DELAY)
+    );
+}
+
+#[test]
+fn schedule_rejects_a_caller_with_no_role() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+    let stranger = Address::generate(&env);
+
+    assert!(matches!(
+        client.try_schedule(
+            &s.mock,
+            &poke(&env),
+            &poke_args(&env, 7),
+            &no_predecessor(&env),
+            &salt(&env, 1),
+            &stranger,
+        ),
+        Err(Ok(Error::Unauthorized))
+    ));
+}
+
+#[test]
+fn schedule_rejects_a_duplicate_operation() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    schedule_poke(&env, &s);
+
+    assert!(matches!(
+        client.try_schedule(
+            &s.mock,
+            &poke(&env),
+            &poke_args(&env, 7),
+            &no_predecessor(&env),
+            &salt(&env, 1),
+            &s.council,
+        ),
+        Err(Err(InvokeError::Contract(4000)))
+    ));
+}
+
+#[test]
+fn get_pending_lists_the_scheduled_operation() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+    let scheduled_at = env.ledger().sequence();
+
+    let id = schedule_poke(&env, &s);
+
+    let pending = client.get_pending();
+    assert_eq!(pending.len(), 1);
+    let entry = pending.get(0).expect("one pending operation");
+    assert_eq!(entry.id, id);
+    assert_eq!(entry.ready_ledger, scheduled_at.saturating_add(DELAY));
+    assert_eq!(entry.operation.target, s.mock);
+    assert_eq!(entry.operation.function, poke(&env));
+    assert_eq!(entry.operation.args, poke_args(&env, 7));
+}
+
+#[test]
+fn schedule_accepts_two_operations_with_different_salts() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    let first = schedule_poke(&env, &s);
+    let second = client.schedule(
+        &s.mock,
+        &poke(&env),
+        &poke_args(&env, 7),
+        &no_predecessor(&env),
+        &salt(&env, 2),
+        &s.council,
+    );
+
+    assert_ne!(first, second);
+    assert_eq!(client.get_pending().len(), 2);
+}
+
+#[test]
+fn schedule_rejects_a_delay_that_overflows_the_ledger() {
+    let env = test_env();
+    let mock = env.register(MockTarget, ());
+    let council = Address::generate(&env);
+    let recovery = Address::generate(&env);
+    let guardian = Address::generate(&env);
+    // The delay is fixed at construction, so a ready ledger beyond `u32::MAX`
+    // needs a governor whose delay is near the maximum. The guardian pause
+    // must still exceed it, which leaves two ledgers of headroom.
+    let governor = register_governor(
+        &env,
+        u32::MAX - 2,
+        u32::MAX - 1,
+        GRACE,
+        u32::MAX - 1,
+        roles(&env, &council, &recovery, &guardian),
+    );
+    env.mock_all_auths();
+    // Any non-zero ledger overflows a delay this large, and this one is inside
+    // the lifetime of the entries the call reads.
+    env.ledger().set_sequence_number(1_000_000);
+
+    assert!(matches!(
+        GovernorClient::new(&env, &governor).try_schedule(
+            &mock,
+            &poke(&env),
+            &poke_args(&env, 7),
+            &no_predecessor(&env),
+            &salt(&env, 1),
+            &council,
+        ),
+        Err(Ok(Error::Overflow))
+    ));
+}
+
+#[test]
+fn schedule_prunes_an_operation_that_outlived_its_grace_window() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    let expiring = schedule_poke(&env, &s);
+    advance_to_ready(&env, &s, GRACE.saturating_add(1));
+    let fresh = client.schedule(
+        &s.mock,
+        &poke(&env),
+        &poke_args(&env, 7),
+        &no_predecessor(&env),
+        &salt(&env, 2),
+        &s.council,
+    );
+
+    let pending = client.get_pending();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending.get(0).expect("one pending operation").id, fresh);
+    assert_eq!(
+        client.get_operation_state(&expiring),
+        OperationStatus::Unset
+    );
+}
+
+#[test]
+fn schedule_rejects_an_operation_once_the_council_queue_is_full() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    for byte in 0..MAX_PENDING_COUNCIL {
+        client.schedule(
+            &s.mock,
+            &poke(&env),
+            &poke_args(&env, 7),
+            &no_predecessor(&env),
+            &salt(&env, u8::try_from(byte).expect("a salt byte")),
+            &s.council,
+        );
+    }
+
+    assert!(matches!(
+        client.try_schedule(
+            &s.mock,
+            &poke(&env),
+            &poke_args(&env, 7),
+            &no_predecessor(&env),
+            &salt(&env, 200),
+            &s.council,
+        ),
+        Err(Ok(Error::QueueFull))
+    ));
+}
+
+#[test]
+fn a_full_council_queue_still_leaves_room_for_recovery() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    for byte in 0..MAX_PENDING_COUNCIL {
+        client.schedule(
+            &s.mock,
+            &poke(&env),
+            &poke_args(&env, 7),
+            &no_predecessor(&env),
+            &salt(&env, u8::try_from(byte).expect("a salt byte")),
+            &s.council,
+        );
+    }
+    for byte in MAX_PENDING_COUNCIL..MAX_PENDING {
+        schedule_recovery(&env, &s, u8::try_from(byte).expect("a salt byte"));
+    }
+
+    assert_eq!(client.get_pending().len(), MAX_PENDING);
+    assert!(matches!(
+        client.try_schedule(
+            &s.governor,
+            &grant_role_fn(&env),
+            &Vec::new(&env),
+            &no_predecessor(&env),
+            &salt(&env, 200),
+            &s.recovery,
+        ),
+        Err(Ok(Error::QueueFull))
+    ));
+}
+
+#[test]
+fn schedule_extends_the_instance_and_operation_ttl() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+
+    let id = schedule_poke(&env, &s);
+
+    env.as_contract(&s.governor, || {
+        let store = env.storage().persistent();
+        assert_eq!(env.storage().instance().get_ttl(), EXTEND_TO);
+        assert_eq!(store.get_ttl(&DataKey::Operation(id.clone())), EXTEND_TO);
+        assert_eq!(
+            store.get_ttl(&timelock::TimelockStorageKey::OperationLedger(id.clone())),
+            EXTEND_TO
+        );
+    });
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn schedule_requires_the_caller_signature() {
+    let env = test_env();
+    let s = setup(&env);
+
+    schedule_poke(&env, &s);
+}
+
+#[test]
+fn schedule_emits_operation_scheduled() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+
+    let id = schedule_poke(&env, &s);
+
+    let events = env.events().all();
+    let expected = OperationScheduled {
+        id,
+        target: s.mock.clone(),
+        function: poke(&env),
+        args: poke_args(&env, 7),
+        predecessor: no_predecessor(&env),
+        salt: salt(&env, 1),
+        delay: DELAY,
+    }
+    .to_xdr(&env, &s.governor);
+    assert_eq!(
+        *events.events().last().expect("a scheduled event"),
+        expected
+    );
+}
+
+// -------------------------------------------------------------------- execute
+
+/// Advances the ledger to the ready ledger of the first queued operation, plus
+/// `offset`.
+fn advance_to_ready(env: &Env, s: &Setup, offset: u32) {
+    let ready = GovernorClient::new(env, &s.governor)
+        .get_pending()
+        .get(0)
+        .expect("one pending operation")
+        .ready_ledger;
+    env.ledger()
+        .set_sequence_number(ready.saturating_add(offset));
+}
+
+fn try_execute_poke(
+    env: &Env,
+    s: &Setup,
+) -> Result<Result<Val, soroban_sdk::ConversionError>, Result<Error, InvokeError>> {
+    GovernorClient::new(env, &s.governor).try_execute(
+        &s.mock,
+        &poke(env),
+        &poke_args(env, 7),
+        &no_predecessor(env),
+        &salt(env, 1),
+    )
+}
+
+fn execute_poke(env: &Env, s: &Setup) -> Val {
+    GovernorClient::new(env, &s.governor).execute(
+        &s.mock,
+        &poke(env),
+        &poke_args(env, 7),
+        &no_predecessor(env),
+        &salt(env, 1),
+    )
+}
+
+#[test]
+fn execute_rejects_an_operation_that_is_not_ready() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+
+    schedule_poke(&env, &s);
+    advance_to_ready(&env, &s, 0);
+    let now = env.ledger().sequence();
+    env.ledger().set_sequence_number(now.saturating_sub(1));
+
+    assert!(matches!(
+        try_execute_poke(&env, &s),
+        Err(Err(InvokeError::Contract(4002)))
+    ));
+}
+
+#[test]
+fn execute_invokes_the_target_at_the_ready_ledger() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    let id = schedule_poke(&env, &s);
+    advance_to_ready(&env, &s, 0);
+    execute_poke(&env, &s);
+
+    assert_eq!(MockTargetClient::new(&env, &s.mock).last_poke(), 7);
+    assert_eq!(client.get_pending(), Vec::new(&env));
+    assert_eq!(client.get_operation_state(&id), OperationStatus::Done);
+}
+
+#[test]
+fn execute_rejects_a_replay() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+
+    schedule_poke(&env, &s);
+    advance_to_ready(&env, &s, 0);
+    execute_poke(&env, &s);
+
+    assert!(matches!(
+        try_execute_poke(&env, &s),
+        Err(Err(InvokeError::Contract(4002)))
+    ));
+}
+
+#[test]
+fn execute_accepts_the_last_ledger_of_the_grace_window() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+
+    schedule_poke(&env, &s);
+    advance_to_ready(&env, &s, GRACE);
+    execute_poke(&env, &s);
+
+    assert_eq!(MockTargetClient::new(&env, &s.mock).last_poke(), 7);
+}
+
+#[test]
+fn execute_rejects_an_expired_operation() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    let id = schedule_poke(&env, &s);
+    advance_to_ready(&env, &s, GRACE.saturating_add(1));
+
+    assert!(matches!(
+        try_execute_poke(&env, &s),
+        Err(Ok(Error::Expired))
+    ));
+    assert_eq!(client.get_pending().len(), 1);
+    assert_eq!(client.get_operation_state(&id), OperationStatus::Expired);
+}
+
+#[test]
+fn execute_rejects_an_unexecuted_predecessor() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    let first = schedule_poke(&env, &s);
+    client.schedule(
+        &s.mock,
+        &poke(&env),
+        &poke_args(&env, 8),
+        &first,
+        &salt(&env, 2),
+        &s.council,
+    );
+    advance_to_ready(&env, &s, 0);
+
+    assert!(matches!(
+        client.try_execute(
+            &s.mock,
+            &poke(&env),
+            &poke_args(&env, 8),
+            &first,
+            &salt(&env, 2),
+        ),
+        Err(Err(InvokeError::Contract(4003)))
+    ));
+}
+
+#[test]
+fn execute_accepts_a_predecessor_that_is_done() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    let first = schedule_poke(&env, &s);
+    client.schedule(
+        &s.mock,
+        &poke(&env),
+        &poke_args(&env, 8),
+        &first,
+        &salt(&env, 2),
+        &s.council,
+    );
+    advance_to_ready(&env, &s, 0);
+
+    execute_poke(&env, &s);
+    client.execute(
+        &s.mock,
+        &poke(&env),
+        &poke_args(&env, 8),
+        &first,
+        &salt(&env, 2),
+    );
+
+    assert_eq!(MockTargetClient::new(&env, &s.mock).last_poke(), 8);
+    assert_eq!(client.get_pending(), Vec::new(&env));
+}
+
+#[test]
+fn execute_rejects_the_governor_as_target() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    let id = schedule_recovery(&env, &s, 1);
+    advance_to_ready(&env, &s, 0);
+
+    assert!(matches!(
+        client.try_execute(
+            &s.governor,
+            &grant_role_fn(&env),
+            &Vec::new(&env),
+            &no_predecessor(&env),
+            &salt(&env, 1),
+        ),
+        Err(Ok(Error::Unauthorized))
+    ));
+    assert_eq!(client.get_pending().len(), 1);
+    assert_eq!(client.get_operation_state(&id), OperationStatus::Ready);
+}
+
+#[test]
+fn execute_leaves_a_failing_target_ready() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    let id = client.schedule(
+        &s.mock,
+        &Symbol::new(&env, "fail"),
+        &Vec::new(&env),
+        &no_predecessor(&env),
+        &salt(&env, 1),
+        &s.council,
+    );
+    advance_to_ready(&env, &s, 0);
+
+    assert!(
+        client
+            .try_execute(
+                &s.mock,
+                &Symbol::new(&env, "fail"),
+                &Vec::new(&env),
+                &no_predecessor(&env),
+                &salt(&env, 1),
+            )
+            .is_err()
+    );
+    assert_eq!(client.get_operation_state(&id), OperationStatus::Ready);
+    assert_eq!(client.get_pending().len(), 1);
+}
+
+#[test]
+fn execute_needs_no_signature() {
+    let env = test_env();
+    let s = setup(&env);
+
+    env.mock_all_auths();
+    schedule_poke(&env, &s);
+    advance_to_ready(&env, &s, 0);
+    env.set_auths(&[]);
+
+    execute_poke(&env, &s);
+
+    assert_eq!(MockTargetClient::new(&env, &s.mock).last_poke(), 7);
+}
+
+#[test]
+fn execute_emits_operation_executed() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+
+    let id = schedule_poke(&env, &s);
+    advance_to_ready(&env, &s, 0);
+    execute_poke(&env, &s);
+
+    let events = env.events().all();
+    let expected = OperationExecuted {
+        id,
+        target: s.mock.clone(),
+        function: poke(&env),
+        args: poke_args(&env, 7),
+        predecessor: no_predecessor(&env),
+        salt: salt(&env, 1),
+    }
+    .to_xdr(&env, &s.governor);
+    assert!(events.events().contains(&expected));
+}
+
+// --------------------------------------------------------------------- cancel
+
+fn cancel_poke(env: &Env, s: &Setup, caller: &Address) {
+    GovernorClient::new(env, &s.governor).cancel(
+        &s.mock,
+        &poke(env),
+        &poke_args(env, 7),
+        &no_predecessor(env),
+        &salt(env, 1),
+        caller,
+    );
+}
+
+fn try_cancel_poke(
+    env: &Env,
+    s: &Setup,
+    caller: &Address,
+) -> Result<Result<(), soroban_sdk::ConversionError>, Result<soroban_sdk::Error, InvokeError>> {
+    GovernorClient::new(env, &s.governor).try_cancel(
+        &s.mock,
+        &poke(env),
+        &poke_args(env, 7),
+        &no_predecessor(env),
+        &salt(env, 1),
+        caller,
+    )
+}
+
+#[test]
+fn cancel_removes_a_waiting_operation() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    let id = schedule_poke(&env, &s);
+    cancel_poke(&env, &s, &s.council);
+
+    assert_eq!(client.get_pending(), Vec::new(&env));
+    assert_eq!(client.get_operation_state(&id), OperationStatus::Unset);
+}
+
+#[test]
+fn cancel_removes_a_ready_operation() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    schedule_poke(&env, &s);
+    advance_to_ready(&env, &s, 0);
+    cancel_poke(&env, &s, &s.council);
+
+    assert_eq!(client.get_pending(), Vec::new(&env));
+}
+
+#[test]
+fn cancel_removes_an_expired_operation() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    schedule_poke(&env, &s);
+    advance_to_ready(&env, &s, GRACE.saturating_add(1));
+    cancel_poke(&env, &s, &s.council);
+
+    assert_eq!(client.get_pending(), Vec::new(&env));
+}
+
+#[test]
+fn cancel_rejects_non_council_callers_on_a_mock_operation() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    schedule_poke(&env, &s);
+
+    assert!(matches!(
+        try_cancel_poke(&env, &s, &s.recovery),
+        Err(Ok(e)) if e == host_error(2000)
+    ));
+    assert!(matches!(
+        try_cancel_poke(&env, &s, &s.guardian),
+        Err(Ok(e)) if e == host_error(2000)
+    ));
+    assert_eq!(client.get_pending().len(), 1);
+}
+
+#[test]
+fn cancel_rejects_non_council_callers_on_a_governor_operation() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    schedule_recovery(&env, &s, 1);
+
+    for caller in [&s.recovery, &s.guardian] {
+        assert!(matches!(
+            client.try_cancel(
+                &s.governor,
+                &grant_role_fn(&env),
+                &Vec::new(&env),
+                &no_predecessor(&env),
+                &salt(&env, 1),
+                caller,
+            ),
+            Err(Ok(e)) if e == host_error(2000)
+        ));
+    }
+    assert_eq!(client.get_pending().len(), 1);
+}
+
+#[test]
+fn cancel_rejects_a_done_operation() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+
+    schedule_poke(&env, &s);
+    advance_to_ready(&env, &s, 0);
+    execute_poke(&env, &s);
+
+    assert!(matches!(
+        try_cancel_poke(&env, &s, &s.council),
+        Err(Ok(e)) if e == host_error(4002)
+    ));
+}
+
+#[test]
+fn cancel_rejects_an_unset_operation() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+
+    assert!(matches!(
+        try_cancel_poke(&env, &s, &s.council),
+        Err(Ok(e)) if e == host_error(4002)
+    ));
+}
+
+#[test]
+fn cancel_rejects_the_wrong_salt() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    schedule_poke(&env, &s);
+
+    assert!(matches!(
+        client.try_cancel(
+            &s.mock,
+            &poke(&env),
+            &poke_args(&env, 7),
+            &no_predecessor(&env),
+            &salt(&env, 9),
+            &s.council,
+        ),
+        Err(Ok(e)) if e == host_error(4002)
+    ));
+    assert_eq!(client.get_pending().len(), 1);
+}
+
+#[test]
+fn cancel_leaves_the_other_pending_operation() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    schedule_poke(&env, &s);
+    let second = client.schedule(
+        &s.mock,
+        &poke(&env),
+        &poke_args(&env, 7),
+        &no_predecessor(&env),
+        &salt(&env, 2),
+        &s.council,
+    );
+
+    cancel_poke(&env, &s, &s.council);
+
+    let pending = client.get_pending();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending.get(0).expect("one pending operation").id, second);
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn cancel_requires_the_council_signature() {
+    let env = test_env();
+    let s = setup(&env);
+
+    env.mock_all_auths();
+    schedule_poke(&env, &s);
+    env.set_auths(&[]);
+
+    cancel_poke(&env, &s, &s.council);
+}
+
+#[test]
+fn cancel_emits_operation_cancelled() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+
+    let id = schedule_poke(&env, &s);
+    cancel_poke(&env, &s, &s.council);
+
+    let events = env.events().all();
+    let expected = OperationCancelled { id }.to_xdr(&env, &s.governor);
+    assert_eq!(
+        *events.events().last().expect("a cancelled event"),
+        expected
+    );
+}

--- a/deny.toml
+++ b/deny.toml
@@ -94,7 +94,8 @@ unused = 'warn'
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-git = [
-    "https://github.com/wasmerio/wasmer"
+    "https://github.com/OpenZeppelin/stellar-contracts",
+    "https://github.com/wasmerio/wasmer",
 ]
 
 [sources.allow-org]


### PR DESCRIPTION
Today every contract in the deployment answers to a single `Admin` address. One key can
allowlist, blocklist, re-point a pool at a different ASP, and hand the contract to a new owner,
with no delay and nobody to stop it. This PR adds the contract that replaces that key with a
queue.

## The dependency

The governor is built on OpenZeppelin's `stellar-governance` timelock and `stellar-access`
access control, pinned to a git revision rather than a crates.io release. Every published
release (0.7.2, and the 0.8.0 release candidates) requires `soroban-sdk ^26.1.0`; this
workspace is on 27.0.6, and a contract cannot link two SDK versions. Revision
`9c5e279aa7efabf94ef84fdef29497ff13656e9d` (2026-09-01) targets `soroban-sdk 27.0.2`, and its
`timelock` and `access_control` modules are byte-for-byte the 0.7.2 code apart from comment
wrapping. The pin also does not turn on the `experimental_spec_shaking_v2` SDK feature for the
rest of the workspace.

Move to the first crates.io release that targets SDK 27 when one exists. No governor code
changes then. `deny.toml` carries the source allowance.

## What the queue does

One governor holds four roles, named by `Symbol`: `council`, `operator`, `guardian`, and
`recovery`. This PR builds the queue and the council and recovery paths through it. The
operator's fast path, the guardian's pause, and role administration land in the next PR.

`schedule(target, function, args, predecessor, salt, caller)` records a call and returns its
id. The council may schedule any function on any target and waits `delay`. A recovery holder
may schedule only `grant_role` and `revoke_role` on the governor itself and waits
`recovery_delay`; anything else is `Unauthorized`. Callers do not pass a delay, because with one
delay per role there is nothing to choose.

`execute(target, function, args, predecessor, salt)` needs no signature from anybody. Once an
operation is ready, whoever pays the fee can run it. It refuses an operation past
`ready + grace` with `Expired`, checked before OpenZeppelin sees the operation, and forwards
whatever the target returns.

`cancel(...)` is the council's, and takes the same five arguments `execute` takes rather than an
operation hash. OpenZeppelin's own `cancel_operation` is hash-based; the council has the
scheduled call in front of it and `get_pending` returns the full operation, so a hash entry
point would be a second way to say the same thing.

## Delays cannot change

There is no function that changes a delay after construction. A different delay is a new
governor. The constructor takes all four and checks them: `delay >= DELAY_FLOOR` (12 ledgers,
about a minute), `recovery_delay >= delay`, `grace >= 1`, and `guardian_pause > delay`.

`guardian_pause` is a constructor argument rather than a constant because testnet wants an hour
where mainnet wants eight days, and a compile-time constant cannot differ per network without a
feature flag. `get_delays` returns all four in one call so the deployment verifier reads them
together.

## The pending queue is on chain

Public RPC keeps events for about a week, which is shorter than the seven-day mainnet delay. An
operator who relied on events could lose sight of what is queued before it becomes executable.
Next to OpenZeppelin's `OperationLedger(id)`, the governor stores each pending `Operation` under
its id and keeps a `Pending` list, so `get_pending` answers "what is queued" from ledger state.
The executed event still carries the full call data for the audit trail.

The queue is capped and prunes itself. An operation left past its grace window returns `Expired`
from `execute`, which rolls back, so nothing removes it; left alone the `Pending` vector would
grow until `get_pending` no longer fits a transaction's read-entry budget, at which point
governance could neither execute nor cancel anything. `schedule` drops every operation that is
done, cancelled, or expired before it appends, and refuses with `QueueFull` at `MAX_PENDING`,
which is 16.

The cap reserves four slots. A council whose key is compromised could otherwise queue all 16
operations, which pruning cannot drop until their grace windows close, and every recovery
`schedule` would answer `QueueFull`. That is the one path the recovery role exists to keep
open, so the council is capped at `MAX_PENDING_COUNCIL`, 12, and the gap up to 16 answers only
to recovery.

## Constructor invariants

`InvalidConfig` unless every role symbol is one of the four, at least one council holder, one
recovery holder, and one guardian are named, and no address appears under two roles.

A council holder and a recovery holder are both required because `revoke_role` refuses to remove
the last of either while the other is empty, so a deployment starting below that invariant could
never be brought up to it through the queue. A guardian is required because it holds the only
instant pause, and a deployment script that forgot one would ship a pool with no stop button.
An operator is optional: a deployment with an empty permission table needs none.

One address, one role. The constructor refuses a configuration granting two roles to one
address, which is why the deployment script and the e2e fixture use four distinct addresses.

## Error codes start at 3000

`execute` forwards whatever the target contract raises, so codes 1 to 9 would have collided with
the pools' and the ASPs' own codes: an operator reading `Error(Contract, #2)` could not tell the
governor's error from `asp-membership`'s `MerkleTreeFull`. The base follows the crates the
governor links, where OpenZeppelin reserves 2000 for access control and 4000 for the timelock.
`InvalidConfig` is 3001 through `UnknownRole` at 3009, with `QueueFull` appended as 3010.

`InsufficientDelay` stays in the enum at 3002 even though no entry point takes a delay any more,
so the numbering never moves. Nothing returns it.

## Scope

Splitting this commit would have meant re-authoring `lib.rs` into two halves that each build,
and re-signing every commit after it, to move a test file across a boundary. It stands as one
commit.

No existing contract's wasm hash changes. The pool wasm was rebuilt before and after and
compared.

Part of #372.
