### PR TITLE
Add the governor's permissions, pausing, and self-administration

### DIFF
--- a/.github/workflows/ub-detection.yml
+++ b/.github/workflows/ub-detection.yml
@@ -44,7 +44,7 @@ jobs:
             cargo_args: "--lib -p stellar-private-payments -p stellar-private-payments-web"
           - group: contracts-light
             miri_flags: "-Zmiri-strict-provenance"
-            cargo_args: "--lib -p contract-types -p soroban-utils -p public-key-registry -p circuit-keys -p e2e-tests"
+            cargo_args: "--lib -p contract-types -p soroban-utils -p public-key-registry -p circuit-keys -p governor -p e2e-tests"
           - group: circom-groth16-verifier
             miri_flags: "-Zmiri-permissive-provenance -Zmiri-tree-borrows -Zmiri-ignore-leaks"
             cargo_args: "--lib -p circom-groth16-verifier"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2881,6 +2881,7 @@ dependencies = [
 name = "governor"
 version = "0.1.0"
 dependencies = [
+ "asp-membership",
  "soroban-sdk",
  "soroban-utils",
  "stellar-access",

--- a/contracts/governor/Cargo.toml
+++ b/contracts/governor/Cargo.toml
@@ -21,6 +21,9 @@ stellar-governance = { workspace = true }
 stellar-macros = { workspace = true }
 
 [dev-dependencies]
+# workspace
+asp-membership = { workspace = true }
+
 # external
 soroban-sdk = { workspace = true, features = ["testutils"] }
 

--- a/contracts/governor/src/lib.rs
+++ b/contracts/governor/src/lib.rs
@@ -17,8 +17,8 @@
 //! makes the calls that the permission table opens to it.
 #![no_std]
 use soroban_sdk::{
-    Address, BytesN, Env, Symbol, Val, Vec, contract, contracterror, contractimpl, contracttype,
-    panic_with_error, symbol_short,
+    Address, BytesN, Env, Symbol, Val, Vec, contract, contractclient, contracterror, contractimpl,
+    contracttype, panic_with_error, symbol_short,
 };
 use soroban_utils::{bump_entry, bump_instance};
 use stellar_access::access_control as access;
@@ -167,6 +167,15 @@ pub enum Error {
     /// The queue already holds as many operations as the caller's role may
     /// leave in it.
     QueueFull = 3010,
+}
+
+/// The pause entry points every contract the governor administers exposes.
+#[contractclient(name = "PausableTargetClient")]
+pub trait PausableTarget {
+    /// Sets `flags`, which stop being honored at `until` when it is given.
+    fn pause(env: Env, flags: u32, until: Option<u32>);
+    /// Clears `flags`.
+    fn unpause(env: Env, flags: u32);
 }
 
 /// The timelocked administrator of the pools and the association set providers.
@@ -444,6 +453,68 @@ impl Governor {
             timelock::hash_operation(&env, &operation(target, function, args, predecessor, salt));
         timelock::cancel_operation(&env, &id);
         forget(&env, &id);
+    }
+
+    /// Pauses `flags` on `target` until the guardian window closes.
+    ///
+    /// The deadline is the current ledger plus the guardian pause the governor
+    /// was constructed with. The target decides what that deadline means: a
+    /// contract with a pause already in force keeps the deadline it has and
+    /// only adds the bits, one whose bits the council cleared while an earlier
+    /// deadline is still ahead refuses the call, and one whose earlier deadline
+    /// has passed takes the new deadline for every bit still set.
+    ///
+    /// That last case widens a pause beyond the bits `flags` names, because a
+    /// lapsed deadline stops a bit being honored without clearing it. Read the
+    /// target's pause state before pausing one shape, and have the council
+    /// clear the stale bits through the queue.
+    ///
+    /// The council pauses without a deadline through the queue, as
+    /// [`Governor::unpause`] describes. `flags` is read in the target's own
+    /// mask.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Overflow`] if the deadline would exceed `u32::MAX`.
+    ///
+    /// # Panics
+    ///
+    /// Panics with OpenZeppelin's `Unauthorized` if `caller` does not hold the
+    /// guardian role. A target that refuses the pause raises its own error,
+    /// which rolls the call back: `InvalidPauseFlags` when `flags` is zero or
+    /// outside its mask, and `TimedPauseArmed` when its bits were all cleared
+    /// while an earlier deadline is still ahead. Panics with
+    /// [`Error::InvalidConfig`] if the governor holds no configuration, which
+    /// a constructed governor always does.
+    #[only_role(caller, "guardian")]
+    pub fn pause(env: Env, target: Address, flags: u32, caller: Address) -> Result<(), Error> {
+        bump_instance(&env);
+        let until = env
+            .ledger()
+            .sequence()
+            .checked_add(setting(&env, &DataKey::GuardianPause))
+            .ok_or(Error::Overflow)?;
+        PausableTargetClient::new(&env, &target).pause(&flags, &Some(until));
+        Ok(())
+    }
+
+    /// Clears `flags` on `target`.
+    ///
+    /// This is the only pause entry point the council holds. Its pause with
+    /// no deadline is a queued call to the target's own `pause` with `until`
+    /// absent: [`Governor::schedule`] it against the target, then
+    /// [`Governor::execute`] it once the delay has passed. `flags` is read in
+    /// the target's own mask.
+    ///
+    /// # Panics
+    ///
+    /// Panics with OpenZeppelin's `Unauthorized` if `caller` does not hold the
+    /// council role, and with the target's `InvalidPauseFlags` if `flags` is
+    /// zero or outside its mask.
+    #[only_role(caller, "council")]
+    pub fn unpause(env: Env, target: Address, flags: u32, caller: Address) {
+        bump_instance(&env);
+        PausableTargetClient::new(&env, &target).unpause(&flags);
     }
 
     /// Returns the four waiting periods the governor was constructed with.

--- a/contracts/governor/src/lib.rs
+++ b/contracts/governor/src/lib.rs
@@ -17,8 +17,8 @@
 //! makes the calls that the permission table opens to it.
 #![no_std]
 use soroban_sdk::{
-    Address, BytesN, Env, Symbol, Val, Vec, contract, contractclient, contracterror, contractimpl,
-    contracttype, panic_with_error, symbol_short,
+    Address, BytesN, Env, Symbol, TryFromVal, Val, Vec, contract, contractclient, contracterror,
+    contractimpl, contracttype, panic_with_error, symbol_short,
 };
 use soroban_utils::{bump_entry, bump_instance};
 use stellar_access::access_control as access;
@@ -238,14 +238,11 @@ impl Governor {
             return Err(Error::InvalidConfig);
         }
 
-        let store = env.storage().persistent();
         for rule in fn_roles.iter() {
             if !is_known_role(&rule.role) {
                 return Err(Error::InvalidConfig);
             }
-            let key = DataKey::FnRole(rule.target, rule.function);
-            store.set(&key, &rule.role);
-            bump_entry(&env, &key);
+            set_fn_role(&env, rule.target, rule.function, &rule.role);
         }
 
         timelock::set_min_delay(&env, delay);
@@ -351,21 +348,39 @@ impl Governor {
     /// Anyone may execute. The delay is what protects the call, not the
     /// identity of whoever finally makes it.
     ///
+    /// An operation whose target is the governor itself administers the
+    /// governor. Its function is one of `grant_role` and `revoke_role`, each
+    /// taking a member address and a role symbol, or `set_fn_role` and
+    /// `clear_fn_role`, taking a target address and a function symbol, with
+    /// the role symbol to require for `set_fn_role`. The operation is marked
+    /// done before the call is made, and an error rolls the whole invocation
+    /// back, so a self-operation with bad arguments stays ready until the
+    /// council cancels it.
+    ///
     /// # Errors
     ///
-    /// Returns [`Error::Expired`] if the grace window closed, and
-    /// [`Error::Unauthorized`] if the target is the governor itself.
+    /// Returns [`Error::Expired`] if the grace window closed. For a
+    /// self-operation, returns [`Error::UnknownFunction`] if the function is
+    /// not one of the four above, [`Error::InvalidArgs`] if the arguments do
+    /// not decode as that function expects, [`Error::UnknownRole`] if a role
+    /// to grant or require is not one of the four roles, and
+    /// [`Error::RoleInvariant`] if a grant would give a member a second role
+    /// or a revocation would leave no council holder while there is no
+    /// recovery holder, or the reverse.
     ///
     /// # Panics
     ///
     /// Panics with OpenZeppelin's `InvalidOperationState` if the operation is
-    /// not ready, `UnexecutedPredecessor` if its predecessor has not run, and
+    /// not ready, `UnexecutedPredecessor` if its predecessor has not run,
+    /// `RoleNotHeld` if a revocation names a member without the role, and
     /// [`Error::InvalidConfig`] if the governor holds no configuration, which
     /// a constructed governor always does.
     ///
     /// # Events
     ///
-    /// Publishes `OperationExecuted` from the OpenZeppelin timelock.
+    /// Publishes `OperationExecuted` from the OpenZeppelin timelock, and
+    /// `RoleGranted` or `RoleRevoked` from its access control module for a
+    /// role change.
     pub fn execute(
         env: Env,
         target: Address,
@@ -389,7 +404,7 @@ impl Governor {
         forget(&env, &id);
 
         if operation.target == env.current_contract_address() {
-            return Err(Error::Unauthorized);
+            return dispatch_self(&env, &operation.function, &operation.args);
         }
         Ok(env.invoke_contract::<Val>(&operation.target, &operation.function, operation.args))
     }
@@ -646,9 +661,85 @@ fn operation(
     }
 }
 
+/// The four roles the governor defines.
+const ROLES: [Symbol; 4] = [COUNCIL, OPERATOR, GUARDIAN, RECOVERY];
+
 /// Reports whether `role` is one of the four roles the governor defines.
 fn is_known_role(role: &Symbol) -> bool {
-    [COUNCIL, OPERATOR, GUARDIAN, RECOVERY].contains(role)
+    ROLES.contains(role)
+}
+
+/// Performs a ready operation whose target is the governor itself.
+///
+/// Every branch returns a void value, because the operation's effect is read
+/// back through the governor's getters.
+fn dispatch_self(env: &Env, function: &Symbol, args: &Vec<Val>) -> Result<Val, Error> {
+    let governor = env.current_contract_address();
+    if *function == Symbol::new(env, "grant_role") {
+        let (member, role): (Address, Symbol) = decode(env, args, 2)?;
+        if !is_known_role(&role) {
+            return Err(Error::UnknownRole);
+        }
+        if ROLES
+            .iter()
+            .any(|held| *held != role && access::has_role(env, &member, held).is_some())
+        {
+            return Err(Error::RoleInvariant);
+        }
+        grant_role(env, &member, &role, &governor);
+    } else if *function == Symbol::new(env, "revoke_role") {
+        let (member, role): (Address, Symbol) = decode(env, args, 2)?;
+        let last_of = |role: &Symbol, other: &Symbol| {
+            access::get_role_member_count(env, role) == 1
+                && access::get_role_member_count(env, other) == 0
+        };
+        if (role == COUNCIL && last_of(&COUNCIL, &RECOVERY))
+            || (role == RECOVERY && last_of(&RECOVERY, &COUNCIL))
+        {
+            return Err(Error::RoleInvariant);
+        }
+        access::revoke_role_no_auth(env, &member, &role, &governor);
+        // A revoke rewrites the holder count every time, and rewrites the role
+        // enumeration only when it removes a role's last holder.
+        bump_entry(
+            env,
+            &access::AccessControlStorageKey::RoleAccountsCount(role.clone()),
+        );
+        bump_entry(env, &access::AccessControlStorageKey::ExistingRoles);
+    } else if *function == Symbol::new(env, "set_fn_role") {
+        let (target, function, role): (Address, Symbol, Symbol) = decode(env, args, 3)?;
+        if !is_known_role(&role) {
+            return Err(Error::UnknownRole);
+        }
+        set_fn_role(env, target, function, &role);
+    } else if *function == Symbol::new(env, "clear_fn_role") {
+        let (target, function): (Address, Symbol) = decode(env, args, 2)?;
+        env.storage()
+            .persistent()
+            .remove(&DataKey::FnRole(target, function));
+    } else {
+        return Err(Error::UnknownFunction);
+    }
+    Ok(Val::VOID.to_val())
+}
+
+/// Decodes `args` as the `count` positional arguments of type `T`.
+///
+/// The count is checked before the conversion because the host rejects a
+/// vector of the wrong length by trapping the invocation, which would leave
+/// the caller with a host error instead of [`Error::InvalidArgs`].
+fn decode<T: TryFromVal<Env, Val>>(env: &Env, args: &Vec<Val>, count: u32) -> Result<T, Error> {
+    if args.len() != count {
+        return Err(Error::InvalidArgs);
+    }
+    T::try_from_val(env, args.as_val()).map_err(|_| Error::InvalidArgs)
+}
+
+/// Writes one permission table row and extends the entry's lifetime.
+fn set_fn_role(env: &Env, target: Address, function: Symbol, role: &Symbol) {
+    let key = DataKey::FnRole(target, function);
+    env.storage().persistent().set(&key, role);
+    bump_entry(env, &key);
 }
 
 /// Reports whether `function` is one of the role changes a recovery address

--- a/contracts/governor/src/lib.rs
+++ b/contracts/governor/src/lib.rs
@@ -61,6 +61,18 @@ pub struct RoleGrant {
     pub member: Address,
 }
 
+/// The role that one target function requires of an undelayed caller.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FnRule {
+    /// The contract the rule covers.
+    pub target: Address,
+    /// The function on that contract.
+    pub function: Symbol,
+    /// The role a caller must hold to invoke it without the queue.
+    pub role: Symbol,
+}
+
 /// The four waiting periods a governor is constructed with.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -120,6 +132,8 @@ enum DataKey {
     Pending,
     /// The queued call, stored under its hash while it is pending.
     Operation(BytesN<32>),
+    /// The role a target function requires of an undelayed caller.
+    FnRole(Address, Symbol),
 }
 
 /// The errors the governor raises.
@@ -168,12 +182,14 @@ impl Governor {
     /// least 1, and `guardian_pause` exceeds `delay` so that the council can
     /// queue an unpause inside the window. `roles` covers at least one council
     /// address, one recovery address, and one guardian, with no address under
-    /// two roles.
+    /// two roles. `fn_roles` is the permission table, one row per target
+    /// function that a role may call without the queue.
     ///
     /// # Errors
     ///
     /// Returns [`Error::InvalidConfig`] if any of those conditions fails, or
-    /// if a grant names a symbol that is not one of the four roles.
+    /// if a grant or a table row names a symbol that is not one of the four
+    /// roles.
     ///
     /// # Events
     ///
@@ -186,6 +202,7 @@ impl Governor {
         grace: u32,
         guardian_pause: u32,
         roles: Vec<RoleGrant>,
+        fn_roles: Vec<FnRule>,
     ) -> Result<(), Error> {
         if delay < DELAY_FLOOR || recovery_delay < delay || grace == 0 || guardian_pause <= delay {
             return Err(Error::InvalidConfig);
@@ -210,6 +227,16 @@ impl Governor {
             || access::get_role_member_count(&env, &GUARDIAN) == 0
         {
             return Err(Error::InvalidConfig);
+        }
+
+        let store = env.storage().persistent();
+        for rule in fn_roles.iter() {
+            if !is_known_role(&rule.role) {
+                return Err(Error::InvalidConfig);
+            }
+            let key = DataKey::FnRole(rule.target, rule.function);
+            store.set(&key, &rule.role);
+            bump_entry(&env, &key);
         }
 
         timelock::set_min_delay(&env, delay);
@@ -358,6 +385,39 @@ impl Governor {
         Ok(env.invoke_contract::<Val>(&operation.target, &operation.function, operation.args))
     }
 
+    /// Calls a target function that the permission table opens to the caller's
+    /// role, without the queue.
+    ///
+    /// The table is what lets a compliance owner keep an allowlist current
+    /// without a delay on every write. It never reaches the governor itself,
+    /// so no row can hand out a role or change a delay.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Unauthorized`] if `target` is the governor itself, or
+    /// if the table holds no row for the target function.
+    ///
+    /// # Panics
+    ///
+    /// Panics with OpenZeppelin's `Unauthorized` if `caller` does not hold the
+    /// role the row names.
+    pub fn execute_now(
+        env: Env,
+        target: Address,
+        function: Symbol,
+        args: Vec<Val>,
+        caller: Address,
+    ) -> Result<Val, Error> {
+        bump_instance(&env);
+        caller.require_auth();
+        if target == env.current_contract_address() {
+            return Err(Error::Unauthorized);
+        }
+        let role = read_fn_role(&env, &target, &function).ok_or(Error::Unauthorized)?;
+        access::ensure_role(&env, &role, &caller);
+        Ok(env.invoke_contract::<Val>(&target, &function, args))
+    }
+
     /// Cancels a queued operation, which is named by the call it would make.
     ///
     /// # Panics
@@ -401,6 +461,13 @@ impl Governor {
             grace: setting(&env, &DataKey::Grace),
             guardian_pause: setting(&env, &DataKey::GuardianPause),
         }
+    }
+
+    /// Returns the role one target function requires of an undelayed caller,
+    /// or `None` when the permission table holds no row for it.
+    pub fn get_fn_role(env: Env, target: Address, function: Symbol) -> Option<Symbol> {
+        bump_instance(&env);
+        read_fn_role(&env, &target, &function)
     }
 
     /// Reports whether `member` holds `role`.
@@ -562,6 +629,15 @@ fn setting(env: &Env, key: &DataKey) -> u32 {
         .instance()
         .get(key)
         .unwrap_or_else(|| panic_with_error!(env, Error::InvalidConfig))
+}
+
+/// Reads one permission table row and extends the entry's lifetime.
+fn read_fn_role(env: &Env, target: &Address, function: &Symbol) -> Option<Symbol> {
+    let key = DataKey::FnRole(target.clone(), function.clone());
+    env.storage()
+        .persistent()
+        .get(&key)
+        .inspect(|_| bump_entry(env, &key))
 }
 
 /// Reads the queued operation hashes, treating an absent list as empty.

--- a/contracts/governor/src/test.rs
+++ b/contracts/governor/src/test.rs
@@ -13,7 +13,7 @@ use soroban_sdk::{
 };
 use soroban_utils::{
     pausable::{MUTATIONS, PauseState},
-    ttl::EXTEND_TO,
+    ttl::{EXTEND_TO, THRESHOLD},
 };
 use stellar_access::access_control::RoleGranted;
 use stellar_governance::timelock::{OperationCancelled, OperationExecuted, OperationScheduled};
@@ -1071,7 +1071,7 @@ fn execute_accepts_a_predecessor_that_is_done() {
 }
 
 #[test]
-fn execute_rejects_the_governor_as_target() {
+fn execute_rejects_a_self_operation_with_the_wrong_argument_count() {
     let env = test_env();
     let s = setup(&env);
     env.mock_all_auths();
@@ -1088,7 +1088,7 @@ fn execute_rejects_the_governor_as_target() {
             &no_predecessor(&env),
             &salt(&env, 1),
         ),
-        Err(Ok(Error::Unauthorized))
+        Err(Ok(Error::InvalidArgs))
     ));
     assert_eq!(client.get_pending().len(), 1);
     assert_eq!(client.get_operation_state(&id), OperationStatus::Ready);
@@ -1898,4 +1898,680 @@ fn unpause_requires_the_council_signature() {
     env.set_auths(&[]);
 
     GovernorClient::new(&env, &t.governor).unpause(&t.asp, &MUTATIONS, &t.council);
+}
+
+// ------------------------------------------------------------ self-operations
+
+fn role_args(env: &Env, member: &Address, role: &Symbol) -> Vec<Val> {
+    vec![env, member.into_val(env), role.into_val(env)]
+}
+
+fn fn_role_args(env: &Env, target: &Address, function: &Symbol, role: &Symbol) -> Vec<Val> {
+    vec![
+        env,
+        target.into_val(env),
+        function.into_val(env),
+        role.into_val(env),
+    ]
+}
+
+/// Schedules `function(args)` against the governor from `caller`, advances the
+/// ledger to the operation's ready ledger, and executes it.
+fn try_execute_self(
+    env: &Env,
+    governor: &Address,
+    function: &str,
+    args: &Vec<Val>,
+    byte: u8,
+    caller: &Address,
+) -> Result<Result<Val, soroban_sdk::ConversionError>, Result<Error, InvokeError>> {
+    let client = GovernorClient::new(env, governor);
+    let function = Symbol::new(env, function);
+    let id = client.schedule(
+        governor,
+        &function,
+        args,
+        &no_predecessor(env),
+        &salt(env, byte),
+        caller,
+    );
+    let ready = client
+        .get_pending()
+        .iter()
+        .find(|entry| entry.id == id)
+        .expect("the scheduled operation")
+        .ready_ledger;
+    env.ledger().set_sequence_number(ready);
+    client.try_execute(
+        governor,
+        &function,
+        args,
+        &no_predecessor(env),
+        &salt(env, byte),
+    )
+}
+
+fn execute_self(
+    env: &Env,
+    governor: &Address,
+    function: &str,
+    args: &Vec<Val>,
+    byte: u8,
+    caller: &Address,
+) {
+    try_execute_self(env, governor, function, args, byte, caller)
+        .expect("the operation executes")
+        .expect("a void result");
+}
+
+fn try_cancel_self(
+    env: &Env,
+    governor: &Address,
+    function: &str,
+    args: &Vec<Val>,
+    byte: u8,
+    caller: &Address,
+) -> Result<Result<(), soroban_sdk::ConversionError>, Result<soroban_sdk::Error, InvokeError>> {
+    GovernorClient::new(env, governor).try_cancel(
+        governor,
+        &Symbol::new(env, function),
+        args,
+        &no_predecessor(env),
+        &salt(env, byte),
+        caller,
+    )
+}
+
+#[test]
+fn grant_role_through_the_queue_adds_the_holder() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+    let second = Address::generate(&env);
+
+    execute_self(
+        &env,
+        &s.governor,
+        "grant_role",
+        &role_args(&env, &second, &GUARDIAN),
+        1,
+        &s.council,
+    );
+
+    assert!(client.has_role(&second, &GUARDIAN));
+    assert_eq!(client.get_role_member_count(&GUARDIAN), 2);
+    assert_eq!(client.get_role_member(&GUARDIAN, &1), second);
+}
+
+#[test]
+fn revoke_role_through_the_queue_removes_the_only_guardian() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    execute_self(
+        &env,
+        &s.governor,
+        "revoke_role",
+        &role_args(&env, &s.guardian, &GUARDIAN),
+        1,
+        &s.council,
+    );
+
+    assert!(!client.has_role(&s.guardian, &GUARDIAN));
+    assert_eq!(client.get_role_member_count(&GUARDIAN), 0);
+    assert!(matches!(
+        client.try_pause(&s.mock, &MUTATIONS, &s.guardian),
+        Err(Err(InvokeError::Contract(2000)))
+    ));
+}
+
+#[test]
+fn set_fn_role_through_the_queue_opens_the_fast_path() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let mock = env.register(MockTarget, ());
+    let client = GovernorClient::new(&env, &t.governor);
+
+    execute_self(
+        &env,
+        &t.governor,
+        "set_fn_role",
+        &fn_role_args(&env, &mock, &poke(&env), &OPERATOR),
+        1,
+        &t.council,
+    );
+
+    assert_eq!(client.get_fn_role(&mock, &poke(&env)), Some(OPERATOR));
+    client.execute_now(&mock, &poke(&env), &poke_args(&env, 7), &t.operator);
+    assert_eq!(MockTargetClient::new(&env, &mock).last_poke(), 7);
+}
+
+#[test]
+fn clear_fn_role_through_the_queue_closes_the_fast_path() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let client = GovernorClient::new(&env, &t.governor);
+
+    execute_self(
+        &env,
+        &t.governor,
+        "clear_fn_role",
+        &vec![&env, t.asp.into_val(&env), insert_leaf(&env).into_val(&env)],
+        1,
+        &t.council,
+    );
+
+    assert_eq!(client.get_fn_role(&t.asp, &insert_leaf(&env)), None);
+    assert!(matches!(
+        client.try_execute_now(&t.asp, &insert_leaf(&env), &leaf_args(&env, 7), &t.operator),
+        Err(Ok(Error::Unauthorized))
+    ));
+}
+
+#[test]
+fn grant_role_with_an_unknown_role_stays_ready_until_cancelled() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+    let args = role_args(
+        &env,
+        &Address::generate(&env),
+        &Symbol::new(&env, "auditor"),
+    );
+
+    assert!(matches!(
+        try_execute_self(&env, &s.governor, "grant_role", &args, 1, &s.council),
+        Err(Ok(Error::UnknownRole))
+    ));
+    let id = client
+        .get_pending()
+        .get(0)
+        .expect("one pending operation")
+        .id;
+    assert_eq!(client.get_operation_state(&id), OperationStatus::Ready);
+
+    try_cancel_self(&env, &s.governor, "grant_role", &args, 1, &s.council)
+        .expect("the council cancels")
+        .expect("a void result");
+    assert_eq!(client.get_pending(), Vec::new(&env));
+}
+
+#[test]
+fn grant_role_for_a_holder_changes_nothing() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+
+    execute_self(
+        &env,
+        &s.governor,
+        "grant_role",
+        &role_args(&env, &s.guardian, &GUARDIAN),
+        1,
+        &s.council,
+    );
+
+    assert_eq!(client.get_role_member_count(&GUARDIAN), 1);
+    assert_eq!(client.get_role_member(&GUARDIAN, &0), s.guardian);
+}
+
+#[test]
+fn grant_role_refuses_a_second_role_for_one_address() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+    let args = role_args(&env, &s.council, &GUARDIAN);
+
+    assert!(matches!(
+        try_execute_self(&env, &s.governor, "grant_role", &args, 1, &s.council),
+        Err(Ok(Error::RoleInvariant))
+    ));
+    let id = client
+        .get_pending()
+        .get(0)
+        .expect("one pending operation")
+        .id;
+    assert_eq!(client.get_operation_state(&id), OperationStatus::Ready);
+
+    try_cancel_self(&env, &s.governor, "grant_role", &args, 1, &s.council)
+        .expect("the council cancels")
+        .expect("a void result");
+    assert!(!client.has_role(&s.council, &GUARDIAN));
+    assert_eq!(client.get_pending(), Vec::new(&env));
+}
+
+#[test]
+fn revoke_role_for_a_non_holder_panics() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+
+    assert!(matches!(
+        try_execute_self(
+            &env,
+            &s.governor,
+            "revoke_role",
+            &role_args(&env, &Address::generate(&env), &OPERATOR),
+            1,
+            &s.council,
+        ),
+        Err(Err(InvokeError::Contract(2007)))
+    ));
+}
+
+#[test]
+fn revoke_role_keeps_the_last_council_holder_while_recovery_is_empty() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+    let revoke_council = role_args(&env, &s.council, &COUNCIL);
+
+    execute_self(
+        &env,
+        &s.governor,
+        "revoke_role",
+        &role_args(&env, &s.recovery, &RECOVERY),
+        1,
+        &s.council,
+    );
+    assert!(matches!(
+        try_execute_self(
+            &env,
+            &s.governor,
+            "revoke_role",
+            &revoke_council,
+            2,
+            &s.council
+        ),
+        Err(Ok(Error::RoleInvariant))
+    ));
+    assert!(client.has_role(&s.council, &COUNCIL));
+
+    execute_self(
+        &env,
+        &s.governor,
+        "grant_role",
+        &role_args(&env, &Address::generate(&env), &RECOVERY),
+        3,
+        &s.council,
+    );
+    execute_self(
+        &env,
+        &s.governor,
+        "revoke_role",
+        &revoke_council,
+        4,
+        &s.council,
+    );
+
+    assert_eq!(client.get_role_member_count(&COUNCIL), 0);
+}
+
+#[test]
+fn revoke_role_removes_one_of_two_council_holders_while_recovery_is_empty() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+    let second = Address::generate(&env);
+
+    execute_self(
+        &env,
+        &s.governor,
+        "grant_role",
+        &role_args(&env, &second, &COUNCIL),
+        1,
+        &s.council,
+    );
+    execute_self(
+        &env,
+        &s.governor,
+        "revoke_role",
+        &role_args(&env, &s.recovery, &RECOVERY),
+        2,
+        &s.council,
+    );
+    execute_self(
+        &env,
+        &s.governor,
+        "revoke_role",
+        &role_args(&env, &s.council, &COUNCIL),
+        3,
+        &s.council,
+    );
+
+    assert_eq!(client.get_role_member_count(&COUNCIL), 1);
+    assert!(client.has_role(&second, &COUNCIL));
+}
+
+#[test]
+fn revoke_role_extends_the_ttl_of_the_holder_count() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let second = Address::generate(&env);
+    let count = access::AccessControlStorageKey::RoleAccountsCount(GUARDIAN);
+
+    execute_self(
+        &env,
+        &s.governor,
+        "grant_role",
+        &role_args(&env, &second, &GUARDIAN),
+        1,
+        &s.council,
+    );
+    // Age the count entry past the point where an extension takes effect. The
+    // role's other entries stay alive, so the revoke can still read them. The
+    // guardian role is the one whose revoke reaches no getter that would
+    // extend the count on its own.
+    let aged = env
+        .ledger()
+        .sequence()
+        .saturating_add(EXTEND_TO.saturating_sub(THRESHOLD).saturating_add(1));
+    env.ledger().set_sequence_number(aged);
+    env.as_contract(&s.governor, || {
+        assert!(env.storage().persistent().get_ttl(&count) < THRESHOLD);
+    });
+
+    execute_self(
+        &env,
+        &s.governor,
+        "revoke_role",
+        &role_args(&env, &second, &GUARDIAN),
+        2,
+        &s.council,
+    );
+
+    env.as_contract(&s.governor, || {
+        assert_eq!(env.storage().persistent().get_ttl(&count), EXTEND_TO);
+    });
+}
+
+#[test]
+fn revoke_role_keeps_the_last_recovery_holder_while_the_council_is_empty() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+    let revoke_recovery = role_args(&env, &s.recovery, &RECOVERY);
+    let council = Address::generate(&env);
+
+    execute_self(
+        &env,
+        &s.governor,
+        "revoke_role",
+        &role_args(&env, &s.council, &COUNCIL),
+        1,
+        &s.council,
+    );
+    assert!(matches!(
+        try_execute_self(
+            &env,
+            &s.governor,
+            "revoke_role",
+            &revoke_recovery,
+            2,
+            &s.recovery
+        ),
+        Err(Ok(Error::RoleInvariant))
+    ));
+    assert!(client.has_role(&s.recovery, &RECOVERY));
+
+    execute_self(
+        &env,
+        &s.governor,
+        "grant_role",
+        &role_args(&env, &council, &COUNCIL),
+        3,
+        &s.recovery,
+    );
+    execute_self(
+        &env,
+        &s.governor,
+        "revoke_role",
+        &revoke_recovery,
+        4,
+        &council,
+    );
+
+    assert_eq!(client.get_role_member_count(&RECOVERY), 0);
+}
+
+// The old operator's refusal is raised inside a call whose arguments hold a
+// `U256` leaf, which reaches the `ethnum` formatting path described above.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn the_council_replaces_the_operator_through_the_queue() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let client = GovernorClient::new(&env, &t.governor);
+    let asp = ASPMembershipClient::new(&env, &t.asp);
+    let operator = Address::generate(&env);
+
+    execute_self(
+        &env,
+        &t.governor,
+        "revoke_role",
+        &role_args(&env, &t.operator, &OPERATOR),
+        1,
+        &t.council,
+    );
+    execute_self(
+        &env,
+        &t.governor,
+        "grant_role",
+        &role_args(&env, &operator, &OPERATOR),
+        2,
+        &t.council,
+    );
+
+    assert!(matches!(
+        client.try_execute_now(&t.asp, &insert_leaf(&env), &leaf_args(&env, 7), &t.operator),
+        Err(Err(InvokeError::Contract(2000)))
+    ));
+    let root_before = asp.get_root();
+    client.execute_now(&t.asp, &insert_leaf(&env), &leaf_args(&env, 7), &operator);
+    assert_ne!(asp.get_root(), root_before);
+}
+
+#[test]
+fn recovery_replaces_a_lost_council() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+    let client = GovernorClient::new(&env, &s.governor);
+    let council = Address::generate(&env);
+    let grant = role_args(&env, &council, &COUNCIL);
+    let scheduled_at = env.ledger().sequence();
+
+    let id = client.schedule(
+        &s.governor,
+        &grant_role_fn(&env),
+        &grant,
+        &no_predecessor(&env),
+        &salt(&env, 1),
+        &s.recovery,
+    );
+    let ready = client
+        .get_pending()
+        .get(0)
+        .expect("one pending operation")
+        .ready_ledger;
+    assert_eq!(ready, scheduled_at.saturating_add(RECOVERY_DELAY));
+    env.ledger().set_sequence_number(ready);
+    env.set_auths(&[]);
+    client.execute(
+        &s.governor,
+        &grant_role_fn(&env),
+        &grant,
+        &no_predecessor(&env),
+        &salt(&env, 1),
+    );
+    assert_eq!(client.get_operation_state(&id), OperationStatus::Done);
+    assert!(client.has_role(&council, &COUNCIL));
+
+    env.mock_all_auths();
+    execute_self(
+        &env,
+        &s.governor,
+        "revoke_role",
+        &role_args(&env, &s.council, &COUNCIL),
+        2,
+        &council,
+    );
+    assert!(!client.has_role(&s.council, &COUNCIL));
+    assert_eq!(client.get_role_member_count(&COUNCIL), 1);
+}
+
+#[test]
+fn execute_rejects_a_self_operation_with_the_wrong_argument_type() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+
+    assert!(matches!(
+        try_execute_self(
+            &env,
+            &s.governor,
+            "grant_role",
+            &vec![&env, 7u32.into_val(&env), GUARDIAN.into_val(&env)],
+            1,
+            &s.council,
+        ),
+        Err(Ok(Error::InvalidArgs))
+    ));
+}
+
+#[test]
+fn update_delay_is_not_a_governor_function() {
+    let env = test_env();
+    let s = setup(&env);
+    env.mock_all_auths();
+
+    assert!(matches!(
+        try_execute_self(
+            &env,
+            &s.governor,
+            "update_delay",
+            &vec![&env, 100u32.into_val(&env)],
+            1,
+            &s.council,
+        ),
+        Err(Ok(Error::UnknownFunction))
+    ));
+    assert_eq!(
+        GovernorClient::new(&env, &s.governor).get_delays().delay,
+        DELAY
+    );
+}
+
+#[test]
+fn the_council_replaces_the_guardian_through_the_queue() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let client = GovernorClient::new(&env, &t.governor);
+    let guardian = Address::generate(&env);
+    let revoke = role_args(&env, &t.guardian, &GUARDIAN);
+    let grant = role_args(&env, &guardian, &GUARDIAN);
+
+    let revoke_fn = Symbol::new(&env, "revoke_role");
+    client.schedule(
+        &t.governor,
+        &revoke_fn,
+        &revoke,
+        &no_predecessor(&env),
+        &salt(&env, 1),
+        &t.council,
+    );
+    client.schedule(
+        &t.governor,
+        &grant_role_fn(&env),
+        &grant,
+        &no_predecessor(&env),
+        &salt(&env, 2),
+        &t.council,
+    );
+
+    assert!(matches!(
+        try_cancel_self(&env, &t.governor, "revoke_role", &revoke, 1, &t.guardian),
+        Err(Ok(e)) if e == host_error(2000)
+    ));
+    assert!(matches!(
+        try_cancel_self(&env, &t.governor, "grant_role", &grant, 2, &t.guardian),
+        Err(Ok(e)) if e == host_error(2000)
+    ));
+    assert_eq!(client.get_pending().len(), 2);
+
+    let ready = client
+        .get_pending()
+        .get(0)
+        .expect("two pending operations")
+        .ready_ledger;
+    env.ledger().set_sequence_number(ready);
+    client.execute(
+        &t.governor,
+        &revoke_fn,
+        &revoke,
+        &no_predecessor(&env),
+        &salt(&env, 1),
+    );
+    client.execute(
+        &t.governor,
+        &grant_role_fn(&env),
+        &grant,
+        &no_predecessor(&env),
+        &salt(&env, 2),
+    );
+
+    client.pause(&t.asp, &MUTATIONS, &guardian);
+    assert_eq!(pause_state(&env, &t).flags, MUTATIONS);
+    assert!(matches!(
+        client.try_pause(&t.asp, &MUTATIONS, &t.guardian),
+        Err(Err(InvokeError::Contract(2000)))
+    ));
+}
+
+#[test]
+fn the_guardian_cannot_cancel_a_table_change() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let client = GovernorClient::new(&env, &t.governor);
+    let update_admin = Symbol::new(&env, "update_admin");
+    let args = fn_role_args(&env, &t.asp, &update_admin, &OPERATOR);
+
+    client.schedule(
+        &t.governor,
+        &Symbol::new(&env, "set_fn_role"),
+        &args,
+        &no_predecessor(&env),
+        &salt(&env, 1),
+        &t.council,
+    );
+
+    assert!(matches!(
+        try_cancel_self(&env, &t.governor, "set_fn_role", &args, 1, &t.guardian),
+        Err(Ok(e)) if e == host_error(2000)
+    ));
+    assert_eq!(client.get_pending().len(), 1);
+
+    try_cancel_self(&env, &t.governor, "set_fn_role", &args, 1, &t.council)
+        .expect("the council cancels")
+        .expect("a void result");
+    assert_eq!(client.get_pending(), Vec::new(&env));
+    assert!(matches!(
+        client.try_execute_now(
+            &t.asp,
+            &update_admin,
+            &vec![&env, Address::generate(&env).into_val(&env)],
+            &t.operator,
+        ),
+        Err(Ok(Error::Unauthorized))
+    ));
 }

--- a/contracts/governor/src/test.rs
+++ b/contracts/governor/src/test.rs
@@ -1,14 +1,15 @@
 #![cfg(test)]
 
 use super::*;
+use asp_membership::{ASPMembership, ASPMembershipClient};
 use soroban_sdk::{
-    Address, BytesN, Env, IntoVal, InvokeError, Symbol, Val, Vec,
+    Address, BytesN, Env, IntoVal, InvokeError, Symbol, U256, Val, Vec,
     events::Event,
     testutils::{
-        Address as _, Events, Ledger as _,
+        Address as _, Events, Ledger as _, MockAuth, MockAuthInvoke,
         storage::{Instance as _, Persistent as _},
     },
-    vec,
+    vec, xdr,
 };
 use soroban_utils::ttl::EXTEND_TO;
 use stellar_access::access_control::RoleGranted;
@@ -96,10 +97,18 @@ fn register_governor(
     grace: u32,
     guardian_pause: u32,
     roles: Vec<RoleGrant>,
+    fn_roles: Vec<FnRule>,
 ) -> Address {
     env.register(
         Governor,
-        (delay, recovery_delay, grace, guardian_pause, roles),
+        (
+            delay,
+            recovery_delay,
+            grace,
+            guardian_pause,
+            roles,
+            fn_roles,
+        ),
     )
 }
 
@@ -115,6 +124,7 @@ fn setup(env: &Env) -> Setup {
         GRACE,
         GUARDIAN_PAUSE,
         roles(env, &council, &recovery, &guardian),
+        Vec::new(env),
     );
     Setup {
         mock,
@@ -199,6 +209,7 @@ fn constructor_rejects_delay_below_floor() {
         GRACE,
         GUARDIAN_PAUSE,
         roles(&env, &council, &recovery, &guardian),
+        Vec::new(&env),
     );
 }
 
@@ -218,6 +229,7 @@ fn constructor_rejects_recovery_delay_below_delay() {
         GRACE,
         GUARDIAN_PAUSE,
         roles(&env, &council, &recovery, &guardian),
+        Vec::new(&env),
     );
 }
 
@@ -237,6 +249,7 @@ fn constructor_rejects_zero_grace() {
         0,
         GUARDIAN_PAUSE,
         roles(&env, &council, &recovery, &guardian),
+        Vec::new(&env),
     );
 }
 
@@ -256,6 +269,7 @@ fn constructor_rejects_a_guardian_pause_equal_to_the_delay() {
         GRACE,
         DELAY,
         roles(&env, &council, &recovery, &guardian),
+        Vec::new(&env),
     );
 }
 
@@ -275,7 +289,15 @@ fn constructor_rejects_an_unknown_role() {
         member: stranger,
     });
 
-    register_governor(&env, DELAY, RECOVERY_DELAY, GRACE, GUARDIAN_PAUSE, grants);
+    register_governor(
+        &env,
+        DELAY,
+        RECOVERY_DELAY,
+        GRACE,
+        GUARDIAN_PAUSE,
+        grants,
+        Vec::new(&env),
+    );
 }
 
 #[test]
@@ -303,6 +325,7 @@ fn constructor_rejects_a_missing_council() {
                 member: guardian,
             },
         ],
+        Vec::new(&env),
     );
 }
 
@@ -331,6 +354,7 @@ fn constructor_rejects_a_missing_recovery_holder() {
                 member: guardian,
             },
         ],
+        Vec::new(&env),
     );
 }
 
@@ -359,6 +383,7 @@ fn constructor_rejects_a_missing_guardian() {
                 member: recovery,
             },
         ],
+        Vec::new(&env),
     );
 }
 
@@ -377,7 +402,15 @@ fn constructor_rejects_one_address_under_two_roles() {
         member: council,
     });
 
-    register_governor(&env, DELAY, RECOVERY_DELAY, GRACE, GUARDIAN_PAUSE, grants);
+    register_governor(
+        &env,
+        DELAY,
+        RECOVERY_DELAY,
+        GRACE,
+        GUARDIAN_PAUSE,
+        grants,
+        Vec::new(&env),
+    );
 }
 
 #[test]
@@ -405,6 +438,7 @@ fn constructor_sets_every_getter() {
     assert_eq!(client.get_role_member_count(&OPERATOR), 0);
     assert_eq!(client.get_role_member(&COUNCIL, &0), s.council);
 
+    assert_eq!(client.get_fn_role(&s.mock, &poke(&env)), None);
     assert_eq!(client.get_pending(), Vec::new(&env));
 
     env.mock_all_auths();
@@ -433,6 +467,7 @@ fn constructor_emits_role_granted() {
         GRACE,
         GUARDIAN_PAUSE,
         roles(&env, &council, &recovery, &guardian),
+        Vec::new(&env),
     );
 
     let events = env.events().all();
@@ -687,6 +722,7 @@ fn schedule_rejects_a_delay_that_overflows_the_ledger() {
         GRACE,
         u32::MAX - 1,
         roles(&env, &council, &recovery, &guardian),
+        Vec::new(&env),
     );
     env.mock_all_auths();
     // Any non-zero ledger overflows a delay this large, and this one is inside
@@ -1343,5 +1379,297 @@ fn cancel_emits_operation_cancelled() {
     assert_eq!(
         *events.events().last().expect("a cancelled event"),
         expected
+    );
+}
+
+// ----------------------------------------------------------- permission table
+
+struct TableSetup {
+    asp: Address,
+    governor: Address,
+    council: Address,
+    recovery: Address,
+    guardian: Address,
+    operator: Address,
+}
+
+fn insert_leaf(env: &Env) -> Symbol {
+    Symbol::new(env, "insert_leaf")
+}
+
+fn leaf_args(env: &Env, value: u32) -> Vec<Val> {
+    vec![env, U256::from_u32(env, value).into_val(env)]
+}
+
+/// Registers an ASP with a Merkle tree `levels` deep and a governor whose
+/// table lets the operator insert leaves, then hands the ASP over to the
+/// governor the way a deployment does.
+fn table_setup(env: &Env, levels: u32) -> TableSetup {
+    let deployer = Address::generate(env);
+    let asp = env.register(ASPMembership, (deployer, levels));
+    let council = Address::generate(env);
+    let recovery = Address::generate(env);
+    let guardian = Address::generate(env);
+    let operator = Address::generate(env);
+    let mut grants = roles(env, &council, &recovery, &guardian);
+    grants.push_back(RoleGrant {
+        role: OPERATOR,
+        member: operator.clone(),
+    });
+    let governor = register_governor(
+        env,
+        DELAY,
+        RECOVERY_DELAY,
+        GRACE,
+        GUARDIAN_PAUSE,
+        grants,
+        vec![
+            env,
+            FnRule {
+                target: asp.clone(),
+                function: insert_leaf(env),
+                role: OPERATOR,
+            },
+        ],
+    );
+    env.mock_all_auths();
+    ASPMembershipClient::new(env, &asp).update_admin(&governor);
+    TableSetup {
+        asp,
+        governor,
+        council,
+        recovery,
+        guardian,
+        operator,
+    }
+}
+
+#[test]
+fn execute_now_lets_the_operator_call_a_mapped_function() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let asp = ASPMembershipClient::new(&env, &t.asp);
+    let root_before = asp.get_root();
+
+    let args = leaf_args(&env, 7);
+    // Only the operator's own call is authorized, and nothing beneath it, so
+    // the ASP's admin check passes on the governor being its direct invoker.
+    env.mock_auths(&[MockAuth {
+        address: &t.operator,
+        invoke: &MockAuthInvoke {
+            contract: &t.governor,
+            fn_name: "execute_now",
+            args: (
+                t.asp.clone(),
+                insert_leaf(&env),
+                args.clone(),
+                t.operator.clone(),
+            )
+                .into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    GovernorClient::new(&env, &t.governor).execute_now(
+        &t.asp,
+        &insert_leaf(&env),
+        &args,
+        &t.operator,
+    );
+
+    // The ASP's event struct is private to its crate, so the topic is the
+    // strongest shape this crate can name.
+    let asp_events = env.events().all().filter_by_contract(&t.asp);
+    assert_eq!(asp_events.events().len(), 1);
+    let xdr::ContractEventBody::V0(body) = &asp_events.events()[0].body;
+    assert_eq!(
+        body.topics.first().expect("a topic"),
+        &xdr::ScVal::Symbol(xdr::ScSymbol(
+            "LeafAdded".try_into().expect("a topic symbol")
+        ))
+    );
+    assert_ne!(asp.get_root(), root_before);
+}
+
+#[test]
+fn schedule_rejects_the_guardian_and_the_operator() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let client = GovernorClient::new(&env, &t.governor);
+
+    for caller in [&t.guardian, &t.operator] {
+        assert!(matches!(
+            client.try_schedule(
+                &t.asp,
+                &insert_leaf(&env),
+                &leaf_args(&env, 7),
+                &no_predecessor(&env),
+                &salt(&env, 1),
+                caller,
+            ),
+            Err(Ok(Error::Unauthorized))
+        ));
+    }
+    assert!(client.get_pending().is_empty());
+}
+
+#[test]
+fn the_constructor_records_the_permission_table() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let client = GovernorClient::new(&env, &t.governor);
+
+    assert_eq!(
+        client.get_fn_role(&t.asp, &insert_leaf(&env)),
+        Some(OPERATOR)
+    );
+    assert_eq!(
+        client.get_fn_role(&t.asp, &Symbol::new(&env, "update_admin")),
+        None
+    );
+
+    env.as_contract(&t.governor, || {
+        assert_eq!(
+            env.storage()
+                .persistent()
+                .get_ttl(&DataKey::FnRole(t.asp.clone(), insert_leaf(&env))),
+            EXTEND_TO
+        );
+    });
+}
+
+#[test]
+fn execute_now_rejects_the_operator_on_an_unmapped_function() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let client = GovernorClient::new(&env, &t.governor);
+    let stranger = Address::generate(&env);
+
+    assert!(matches!(
+        client.try_execute_now(
+            &t.asp,
+            &Symbol::new(&env, "update_admin"),
+            &vec![&env, stranger.into_val(&env)],
+            &t.operator,
+        ),
+        Err(Ok(Error::Unauthorized))
+    ));
+}
+
+#[test]
+fn execute_now_rejects_an_unmapped_target() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let mock = env.register(MockTarget, ());
+    let client = GovernorClient::new(&env, &t.governor);
+
+    assert!(matches!(
+        client.try_execute_now(&mock, &poke(&env), &poke_args(&env, 7), &t.operator),
+        Err(Ok(Error::Unauthorized))
+    ));
+}
+
+// A panic raised inside a nested invocation is formatted with the failing
+// frame's events, and the association set provider's leaves are `U256`
+// values, so these two reach the same `ethnum` formatting path the
+// `should_panic` tests above avoid.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn execute_now_rejects_every_role_but_the_one_the_row_names() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let client = GovernorClient::new(&env, &t.governor);
+
+    for caller in [&t.council, &t.guardian, &t.recovery] {
+        assert!(matches!(
+            client.try_execute_now(&t.asp, &insert_leaf(&env), &leaf_args(&env, 7), caller),
+            Err(Err(InvokeError::Contract(2000)))
+        ));
+    }
+}
+
+#[test]
+fn execute_now_rejects_the_governor_as_target() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let client = GovernorClient::new(&env, &t.governor);
+
+    assert!(matches!(
+        client.try_execute_now(
+            &t.governor,
+            &grant_role_fn(&env),
+            &Vec::new(&env),
+            &t.operator,
+        ),
+        Err(Ok(Error::Unauthorized))
+    ));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn execute_now_forwards_a_failure_from_the_target() {
+    let env = test_env();
+    // A one-level tree holds two leaves, so the third insertion is refused.
+    let t = table_setup(&env, 1);
+    let client = GovernorClient::new(&env, &t.governor);
+    let asp = ASPMembershipClient::new(&env, &t.asp);
+
+    for value in 1..=2u32 {
+        client.execute_now(
+            &t.asp,
+            &insert_leaf(&env),
+            &leaf_args(&env, value),
+            &t.operator,
+        );
+    }
+    let root_before = asp.get_root();
+
+    assert!(matches!(
+        client.try_execute_now(&t.asp, &insert_leaf(&env), &leaf_args(&env, 3), &t.operator),
+        Err(Err(InvokeError::Contract(2)))
+    ));
+    assert_eq!(asp.get_root(), root_before);
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Contract, #3001)")]
+fn constructor_rejects_a_table_entry_with_an_unknown_role() {
+    let env = test_env();
+    let mock = env.register(MockTarget, ());
+    let council = Address::generate(&env);
+    let recovery = Address::generate(&env);
+    let guardian = Address::generate(&env);
+
+    register_governor(
+        &env,
+        DELAY,
+        RECOVERY_DELAY,
+        GRACE,
+        GUARDIAN_PAUSE,
+        roles(&env, &council, &recovery, &guardian),
+        vec![
+            &env,
+            FnRule {
+                target: mock,
+                function: poke(&env),
+                role: Symbol::new(&env, "auditor"),
+            },
+        ],
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn execute_now_requires_the_caller_signature() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    env.set_auths(&[]);
+
+    GovernorClient::new(&env, &t.governor).execute_now(
+        &t.asp,
+        &insert_leaf(&env),
+        &leaf_args(&env, 7),
+        &t.operator,
     );
 }

--- a/contracts/governor/src/test.rs
+++ b/contracts/governor/src/test.rs
@@ -11,7 +11,10 @@ use soroban_sdk::{
     },
     vec, xdr,
 };
-use soroban_utils::ttl::EXTEND_TO;
+use soroban_utils::{
+    pausable::{MUTATIONS, PauseState},
+    ttl::EXTEND_TO,
+};
 use stellar_access::access_control::RoleGranted;
 use stellar_governance::timelock::{OperationCancelled, OperationExecuted, OperationScheduled};
 
@@ -1672,4 +1675,227 @@ fn execute_now_requires_the_caller_signature() {
         &leaf_args(&env, 7),
         &t.operator,
     );
+}
+
+// ---------------------------------------------------------------------- pause
+
+fn pause_state(env: &Env, t: &TableSetup) -> PauseState {
+    ASPMembershipClient::new(env, &t.asp).get_pause_state()
+}
+
+#[test]
+fn pause_sets_the_guardian_deadline_on_the_target() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let now = env.ledger().sequence();
+
+    GovernorClient::new(&env, &t.governor).pause(&t.asp, &MUTATIONS, &t.guardian);
+
+    assert_eq!(
+        pause_state(&env, &t),
+        PauseState {
+            flags: MUTATIONS,
+            until: Some(now.saturating_add(GUARDIAN_PAUSE)),
+        }
+    );
+}
+
+#[test]
+fn pause_rejects_every_role_but_the_guardian() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let client = GovernorClient::new(&env, &t.governor);
+
+    for caller in [&t.council, &t.recovery, &t.operator] {
+        assert!(matches!(
+            client.try_pause(&t.asp, &MUTATIONS, caller),
+            Err(Err(InvokeError::Contract(2000)))
+        ));
+    }
+    assert_eq!(pause_state(&env, &t), PauseState::default());
+}
+
+#[test]
+fn a_second_guardian_pause_keeps_the_deadline() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let client = GovernorClient::new(&env, &t.governor);
+    let now = env.ledger().sequence();
+
+    client.pause(&t.asp, &MUTATIONS, &t.guardian);
+    env.ledger().set_sequence_number(now.saturating_add(5));
+    client.pause(&t.asp, &MUTATIONS, &t.guardian);
+
+    assert_eq!(
+        pause_state(&env, &t).until,
+        Some(now.saturating_add(GUARDIAN_PAUSE))
+    );
+}
+
+// The next two refusals are the association set provider's own errors, raised
+// inside the nested invocation, so they reach the `ethnum` formatting path
+// described above.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn pause_is_refused_after_the_council_cleared_the_window() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let client = GovernorClient::new(&env, &t.governor);
+
+    client.pause(&t.asp, &MUTATIONS, &t.guardian);
+    client.unpause(&t.asp, &MUTATIONS, &t.council);
+    let cleared = pause_state(&env, &t);
+
+    assert!(matches!(
+        client.try_pause(&t.asp, &MUTATIONS, &t.guardian),
+        Err(Err(InvokeError::Contract(8)))
+    ));
+    assert_eq!(pause_state(&env, &t), cleared);
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn pause_forwards_the_targets_rejection_of_the_flags() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+
+    assert!(matches!(
+        GovernorClient::new(&env, &t.governor).try_pause(&t.asp, &2, &t.guardian),
+        Err(Err(InvokeError::Contract(7)))
+    ));
+    assert_eq!(pause_state(&env, &t), PauseState::default());
+}
+
+#[test]
+fn pause_is_accepted_at_the_deadline_and_records_a_new_one() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let client = GovernorClient::new(&env, &t.governor);
+    let until = env.ledger().sequence().saturating_add(GUARDIAN_PAUSE);
+
+    client.pause(&t.asp, &MUTATIONS, &t.guardian);
+    client.unpause(&t.asp, &MUTATIONS, &t.council);
+    env.ledger().set_sequence_number(until);
+    client.pause(&t.asp, &MUTATIONS, &t.guardian);
+
+    assert_eq!(
+        pause_state(&env, &t),
+        PauseState {
+            flags: MUTATIONS,
+            until: Some(until.saturating_add(GUARDIAN_PAUSE)),
+        }
+    );
+}
+
+#[test]
+fn the_council_pauses_without_a_deadline_through_the_queue() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let client = GovernorClient::new(&env, &t.governor);
+    let pause_fn = Symbol::new(&env, "pause");
+    let args = vec![&env, MUTATIONS.into_val(&env), None::<u32>.into_val(&env)];
+
+    client.schedule(
+        &t.asp,
+        &pause_fn,
+        &args,
+        &no_predecessor(&env),
+        &salt(&env, 1),
+        &t.council,
+    );
+    let ready = client
+        .get_pending()
+        .get(0)
+        .expect("one pending operation")
+        .ready_ledger;
+    env.ledger().set_sequence_number(ready);
+    client.execute(
+        &t.asp,
+        &pause_fn,
+        &args,
+        &no_predecessor(&env),
+        &salt(&env, 1),
+    );
+    assert_eq!(
+        pause_state(&env, &t),
+        PauseState {
+            flags: MUTATIONS,
+            until: None,
+        }
+    );
+
+    client.pause(&t.asp, &MUTATIONS, &t.guardian);
+    assert_eq!(pause_state(&env, &t).until, None);
+
+    client.unpause(&t.asp, &MUTATIONS, &t.council);
+    assert_eq!(pause_state(&env, &t).flags, 0);
+}
+
+#[test]
+fn unpause_rejects_every_role_but_the_council() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    let client = GovernorClient::new(&env, &t.governor);
+
+    client.pause(&t.asp, &MUTATIONS, &t.guardian);
+    for caller in [&t.guardian, &t.recovery, &t.operator] {
+        assert!(matches!(
+            client.try_unpause(&t.asp, &MUTATIONS, caller),
+            Err(Ok(e)) if e == host_error(2000)
+        ));
+    }
+    assert_eq!(pause_state(&env, &t).flags, MUTATIONS);
+
+    client.unpause(&t.asp, &MUTATIONS, &t.council);
+    assert_eq!(pause_state(&env, &t).flags, 0);
+}
+
+#[test]
+fn pause_rejects_a_deadline_that_overflows_the_ledger() {
+    let env = test_env();
+    let mock = env.register(MockTarget, ());
+    let council = Address::generate(&env);
+    let recovery = Address::generate(&env);
+    let guardian = Address::generate(&env);
+    // The guardian pause is fixed at construction, so a deadline beyond
+    // `u32::MAX` needs a governor whose window is near the maximum, on a ledger
+    // inside the lifetime of the entries the call reads.
+    let governor = register_governor(
+        &env,
+        DELAY,
+        RECOVERY_DELAY,
+        GRACE,
+        u32::MAX,
+        roles(&env, &council, &recovery, &guardian),
+        Vec::new(&env),
+    );
+    env.mock_all_auths();
+    env.ledger().set_sequence_number(1_000_000);
+
+    assert!(matches!(
+        GovernorClient::new(&env, &governor).try_pause(&mock, &MUTATIONS, &guardian),
+        Err(Ok(Error::Overflow))
+    ));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn pause_requires_the_guardian_signature() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    env.set_auths(&[]);
+
+    GovernorClient::new(&env, &t.governor).pause(&t.asp, &MUTATIONS, &t.guardian);
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn unpause_requires_the_council_signature() {
+    let env = test_env();
+    let t = table_setup(&env, 3);
+    env.set_auths(&[]);
+
+    GovernorClient::new(&env, &t.governor).unpause(&t.asp, &MUTATIONS, &t.council);
 }


### PR DESCRIPTION
Completes the governor's entry points: the operator's fast path, the guardian's pause, and the
governor administering its own roles and tables through its own queue. Four commits, all inside
`contracts/governor/src`.

## The permission table and `execute_now`

Some writes should not wait a week. Allowlisting an address is a routine compliance action, and
a seven-day delay on it would mean the queue is the compliance process.

The constructor gains `fn_roles: Vec<FnRule>`, where a rule maps a `(target, function)` pair to
one role. `execute_now(target, function, args, caller)` runs the call immediately when
`get_fn_role(target, function)` names a role the caller holds, and refuses otherwise. The
deployment maps `insert_leaf` on the membership ASP and `insert_leaf` and `delete_leaf` on the
non-membership ASP to `operator`, and nothing else. `update_admin`, `update_asp_membership`,
`update_asp_non_membership`, `pause`, and `unpause` stay queue-only.

The table exists so a deployment can change that policy without new code, and
`set_fn_role`/`clear_fn_role` are themselves queued operations, covered below.

`unpause` is a dedicated entry point rather than a table row, because a row per target is one
more thing for the deployment script to forget.

## Pause and unpause

```
pause(target, flags, caller)      only the guardian
    until = now + guardian_pause
    invoke target.pause(flags, Some(until))

unpause(target, flags, caller)    only the council
    invoke target.unpause(flags)
```

The guardian's pause always carries a deadline, `now + guardian_pause`, which is why the
constructor requires `guardian_pause > delay`: the pause must outlast the time the council needs
to queue a considered response.

The council has no instant pause and no entry point of its own for one. A council pause with no
deadline is `schedule(target, "pause", [flags, ()])` followed by `execute`, which the queue
forwards like any other target call. That keeps one pause path in the governor and no council
branch inside `pause`. The doc comment on `unpause` says so, because that is where an operator
looking for the council's pause will look.

The target decides what a deadline means. A contract with a pause already in force keeps the
deadline it has, and a target that refuses the pause raises its own error, which rolls the
governor's call back. Both cases are tested against the real `asp-membership`.

`pause` and `unpause` each take one target. Pausing a deployment is one transaction per contract,
sent by the incident script. The governor does not know which contracts it administers; the
manifest does.

The guardian cancels nothing. `cancel` and `unpause` are council-only, so a compromised guardian
can stall traffic for one `guardian_pause` window and cannot touch the queue.

## Roles and tables go through the queue

`execute` previously refused an operation whose target was the governor itself. It now dispatches
those to four internal functions:

| Function | Arguments | Rule |
| --- | --- | --- |
| `grant_role` | `(member, role)` | role must be one of the four, else `UnknownRole`; `RoleInvariant` when the member already holds a different role; idempotent for a role already held |
| `revoke_role` | `(member, role)` | `RoleInvariant` when it would leave zero council holders while recovery is empty, or the reverse |
| `set_fn_role` | `(target, function, role)` | role must be one of the four |
| `clear_fn_role` | `(target, function)` | |

Any other symbol is `UnknownFunction`, and a decode failure or wrong argument count is
`InvalidArgs`. There is deliberately no `update_delay`, and a test asserts it returns
`UnknownFunction`, which is what pins the delays as immutable.

This is why the governor needs no `__check_auth`, no bootstrap admin, and no
`finalize_bootstrap`. OpenZeppelin's public admin functions authorize an admin address; the
governor never exposes them, and instead calls the `*_no_auth` storage helpers from inside
`execute`. A self-operation is then a plain `stellar contract invoke`, where a custom-account
signature would have needed a tool to fill in the auth entry.

`execute` marks an operation done before dispatching, following OpenZeppelin's order, and a
contract error rolls the whole invocation back. A self-operation with bad arguments therefore
stays `Ready` until the council cancels it. The doc comment on `execute` says so.

Replacing a guardian or an operator is ordinary role administration: one queued `revoke_role`
and one queued `grant_role`, neither of which the guardian can cancel. There is no
`revoke_operator` and no instant revocation, because the council holds no operator role and no
table row, so an instant revocation would leave the allowlists exactly as stale as a queued one.
An operator compromise is stopped by the guardian's `MUTATIONS` pause in the meantime.

`revoke_role` keeps no last-guardian rule, so removing a guardian is one operation. A
last-guardian rule would have forced a two-operation replacement with a predecessor.

## Miri

One commit adds the governor crate to the `contracts-light` group of the UB detection workflow.
That workflow runs nightly and on dispatch, not on push, which matters here: miri over this
crate measured 2 h 25 min at 88 tests, and the crate ends this PR at 91. The job's timeout is
six hours.

Part of #372.
