### PR TITLE
Drive pools and ASPs through the governor end to end

### DIFF
--- a/.github/workflows/contracts-build.yml
+++ b/.github/workflows/contracts-build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build contracts
         run: |
           mkdir -p target/stellar
-          for pkg in asp-membership asp-non-membership circom-groth16-verifier pool pool-gvk; do
+          for pkg in asp-membership asp-non-membership circom-groth16-verifier pool pool-gvk governor; do
             stellar contract build --manifest-path Cargo.toml --out-dir target/stellar --optimize \
               --package "$pkg"
           done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,6 +2293,7 @@ dependencies = [
  "circom-groth16-verifier",
  "circuits",
  "contract-types",
+ "governor",
  "num-bigint",
  "pool",
  "soroban-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ futures = { version = "0.3.33", default-features = false, features = ["async-awa
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
 gloo-timers = { version = "0.4", default-features = false, features = ["futures"] }
 gloo-worker = { version = "0.6", default-features = false, features = ["futures"] }
+governor = { path = "contracts/governor" }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 js-sys = "0.3"
 log = { version = "0.4", default-features = false }

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -19,6 +19,7 @@ circom-groth16-verifier = { workspace = true }
 circuits = { workspace = true, features = ["std"] }
 # Contract dependencies
 contract-types = { workspace = true }
+governor = { workspace = true }
 num-bigint = { workspace = true }
 pool = { workspace = true }
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/e2e-tests/src/tests/e2e_pool_2_in_2_out.rs
+++ b/e2e-tests/src/tests/e2e_pool_2_in_2_out.rs
@@ -5,9 +5,9 @@
 //! and the verification from the pool contract. That is the pipeline the CLI,
 //! the SDK and the browser use.
 use super::utils::{
-    DeployedContracts, LEAF_PREFIX, LEVELS, NonMembership, TRANSACT_STEMS, build_membership_trees,
-    build_policy_inputs, bytes32_to_bigint, deploy_contracts, generate_proof, prove_with_graph,
-    scalar_to_u256, sync_contract_state, test_env, wrap_groth16_proof,
+    DeployedContracts, LEAF_PREFIX, NonMembership, TRANSACT_STEMS, TransactOutcome,
+    build_membership_trees, build_policy_inputs, deploy_contracts, prove_transaction,
+    prove_with_graph, scalar_to_u256, sync_contract_state, test_env, transact,
 };
 use anyhow::Result;
 use ark_bn254::Fr as Scalar;
@@ -16,21 +16,12 @@ use circuits::test::utils::{
     general::scalar_to_bigint,
     keypair::derive_public_key,
     transaction::{commitment, prepopulated_prefix},
-    transaction_case::{InputNote, OutputNote, TxCase, prepare_transaction_witness},
+    transaction_case::{InputNote, OutputNote, TxCase},
 };
 use contract_types::Groth16Error;
-use pool::{Error, ExtData, PoolContractClient, Proof, hash_ext_data};
-use soroban_sdk::{
-    Address, Bytes, I256, InvokeError, U256, Vec as SorobanVec, testutils::Address as _,
-};
+use pool::{Error, ExtData, Proof};
+use soroban_sdk::InvokeError;
 use stellar_private_payments::types::PolicyFlags;
-
-/// Result of `PoolContractClient::try_transact`.
-///
-/// The outer error holds the contract error, and the inner one holds a return
-/// value conversion error.
-type TransactOutcome =
-    Result<Result<(), soroban_sdk::ConversionError>, Result<Error, soroban_sdk::InvokeError>>;
 
 /// A pool transaction that is ready for `transact`, with its proof made from
 /// the committed witness graph.
@@ -44,16 +35,12 @@ struct TransactFixture {
 impl TransactFixture {
     /// Send the transaction to the pool contract.
     fn transact(&self) -> TransactOutcome {
-        let sender = Address::generate(&self.env);
-        PoolContractClient::new(&self.env, &self.contracts.pool).try_transact(
-            &self.proof,
-            &self.ext_data,
-            &sender,
-        )
+        transact(&self.env, &self.contracts, &self.proof, &self.ext_data)
     }
 }
 
-/// Build a 2-in/2-out pool transaction and prove it from the witness graph.
+/// Build a 2-in/2-out pool transaction, prove it from the witness graph, and
+/// put the contracts into the state the proof was made against.
 ///
 /// The amounts must balance: `inputs + ext_amount = outputs`. A positive
 /// `ext_amount` is a deposit, and zero is a private transfer.
@@ -62,122 +49,27 @@ fn transact_fixture(
     out_amounts: [u64; 2],
     ext_amount: i32,
 ) -> Result<TransactFixture> {
-    assert!(ext_amount >= 0, "this fixture only covers deposits");
     let env = test_env();
-    let recipient = Address::generate(&env);
-
-    let ext_data = ExtData {
-        recipient,
-        ext_amount: I256::from_i32(&env, ext_amount),
-        encrypted_output0: Bytes::new(&env),
-        encrypted_output1: Bytes::new(&env),
-    };
-    let ext_data_hash_bytes = hash_ext_data(&env, &ext_data);
-    let ext_data_hash_bigint = bytes32_to_bigint(&ext_data_hash_bytes);
-
-    let case = TxCase::new(
-        vec![
-            InputNote {
-                leaf_index: 0,
-                priv_key: Scalar::from(101u64),
-                blinding: Scalar::from(201u64),
-                amount: Scalar::from(in_amounts[0]),
-            },
-            InputNote {
-                leaf_index: 1,
-                priv_key: Scalar::from(102u64),
-                blinding: Scalar::from(211u64),
-                amount: Scalar::from(in_amounts[1]),
-            },
-        ],
-        vec![
-            OutputNote {
-                pub_key: Scalar::from(501u64),
-                blinding: Scalar::from(601u64),
-                amount: Scalar::from(out_amounts[0]),
-            },
-            OutputNote {
-                pub_key: Scalar::from(502u64),
-                blinding: Scalar::from(602u64),
-                amount: Scalar::from(out_amounts[1]),
-            },
-        ],
-    );
-
-    // Pool state. `transact` appends its two outputs past this prefix.
-    let mut leaves = prepopulated_prefix(
-        0xDEAD_BEEFu64,
-        &[case.inputs[0].leaf_index, case.inputs[1].leaf_index],
-        LEAF_PREFIX,
-    );
-
-    let membership_trees = build_membership_trees(&case, |j| 0xFEED_FACEu64 ^ ((j as u64) << 40));
-    let keys = case
-        .inputs
-        .iter()
-        .map(|input| NonMembership {
-            key_non_inclusion: scalar_to_bigint(derive_public_key(input.priv_key)),
-        })
-        .collect::<Vec<_>>();
-
-    let witness = prepare_transaction_witness(&case, leaves.clone(), LEVELS)?;
-    let public_amount = Scalar::from(u64::try_from(ext_amount).expect("non-negative ext amount"));
-    let result = generate_proof(
-        &case,
-        leaves.clone(),
-        public_amount,
-        &membership_trees,
-        &keys,
-        Some(ext_data_hash_bigint),
-    )?;
-    assert!(result.verified, "Proof should verify locally");
+    let mut proven = prove_transaction(&env, in_amounts, out_amounts, ext_amount)?;
 
     env.mock_all_auths();
     let contracts = deploy_contracts(&env);
     let roots = sync_contract_state(
         &env,
         &contracts,
-        &case,
-        &mut leaves,
-        &membership_trees,
-        &witness,
+        &proven.case,
+        &mut proven.leaves,
+        &proven.membership_trees,
+        &proven.witness,
     );
 
-    let mut input_nullifiers: SorobanVec<U256> = SorobanVec::new(&env);
-    for nullifier in &witness.nullifiers {
-        input_nullifiers.push_back(scalar_to_u256(&env, *nullifier));
-    }
-
-    let proof = Proof {
-        proof: wrap_groth16_proof(&env, result),
-        root: roots.pool_root,
-        input_nullifiers,
-        output_commitment0: scalar_to_u256(&env, output_commitment(&case, 0)),
-        output_commitment1: scalar_to_u256(&env, output_commitment(&case, 1)),
-        public_amount: U256::from_u32(
-            &env,
-            u32::try_from(ext_amount).expect("non-negative ext amount"),
-        ),
-        ext_data_hash: ext_data_hash_bytes,
-        asp_membership_root: roots.asp_membership_root,
-        asp_non_membership_root: roots.asp_non_membership_root,
-    };
-
+    let ext_data = proven.ext_data.clone();
     Ok(TransactFixture {
+        proof: proven.into_proof(&env, &roots),
         env,
         contracts,
-        proof,
         ext_data,
     })
-}
-
-/// Commitment of one output note of a case.
-fn output_commitment(case: &TxCase, index: usize) -> Scalar {
-    commitment(
-        case.outputs[index].amount,
-        case.outputs[index].pub_key,
-        case.outputs[index].blinding,
-    )
 }
 
 /// Keep only the signals that a circuit with these policy flags declares.

--- a/e2e-tests/src/tests/governance.rs
+++ b/e2e-tests/src/tests/governance.rs
@@ -1,0 +1,539 @@
+//! End-to-end tests that drive the pool and the association set providers
+//! through the governor.
+//!
+//! Each case runs against a real Groth16 proof and the compiled verifier, so an
+//! operator write, a pause, or an administrator rotation is observed the way a
+//! deployment observes it: through the governor, with the target's own
+//! administrator role already handed over.
+
+use super::utils::{
+    ASP_MEMBERSHIP_LEVELS, GOV_DELAY, GOV_GUARDIAN_PAUSE, GOV_RECOVERY_DELAY, GovernedContracts,
+    TransactOutcome, allowlist_leaves, bigint_to_u256, deploy_governed_contracts,
+    non_membership_overrides_from_pubs, prove_transaction, scalar_to_u256, sync_pool_state,
+    test_env, transact,
+};
+use anyhow::Result;
+use asp_membership::{ASPMembership, ASPMembershipClient};
+use governor::GovernorClient;
+use pool::{Error, ExtData, PoolContractClient, Proof};
+use soroban_sdk::{
+    Address, BytesN, Env, IntoVal, InvokeError, Symbol, U256, Val, Vec,
+    events::Event as _,
+    testutils::{Address as _, Events as _, Ledger as _, MockAuth, MockAuthInvoke},
+};
+use soroban_utils::{AdminUpdated, pausable};
+
+/// Result of `GovernorClient::try_execute_now`.
+type ExecuteNowOutcome =
+    Result<Result<Val, soroban_sdk::ConversionError>, Result<governor::Error, InvokeError>>;
+
+/// A governed deployment with one proven pool transaction ready to send.
+struct GovernedFixture {
+    env: Env,
+    gov: GovernedContracts,
+    proof: Proof,
+    ext_data: ExtData,
+}
+
+impl GovernedFixture {
+    fn governor(&self) -> GovernorClient<'_> {
+        GovernorClient::new(&self.env, &self.gov.governor)
+    }
+
+    fn pool(&self) -> PoolContractClient<'_> {
+        PoolContractClient::new(&self.env, &self.gov.contracts.pool)
+    }
+
+    /// Sends the transaction to the pool contract.
+    fn transact(&self) -> TransactOutcome {
+        transact(&self.env, &self.gov.contracts, &self.proof, &self.ext_data)
+    }
+
+    /// Inserts one allowlist leaf through the governor's undelayed path as
+    /// `caller`, returning the outcome so a refusal can be observed.
+    fn try_allowlist(&self, leaf: u32, caller: &Address) -> ExecuteNowOutcome {
+        self.governor().try_execute_now(
+            &self.gov.contracts.asp_membership,
+            &insert_leaf(&self.env),
+            &soroban_sdk::vec![
+                &self.env,
+                U256::from_u32(&self.env, leaf).into_val(&self.env),
+            ],
+            caller,
+        )
+    }
+}
+
+fn insert_leaf(env: &Env) -> Symbol {
+    Symbol::new(env, "insert_leaf")
+}
+
+fn no_predecessor(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[0u8; 32])
+}
+
+fn salt(env: &Env, byte: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[byte; 32])
+}
+
+/// Moves the ledger forward by `ledgers`.
+fn advance(env: &Env, ledgers: u32) {
+    let target = env.ledger().sequence().saturating_add(ledgers);
+    env.ledger().set_sequence_number(target);
+}
+
+/// Queues `function(args)` on `target` from the council.
+fn schedule(
+    env: &Env,
+    gov: &GovernedContracts,
+    target: &Address,
+    function: &Symbol,
+    args: &Vec<Val>,
+    byte: u8,
+) {
+    GovernorClient::new(env, &gov.governor).schedule(
+        target,
+        function,
+        args,
+        &no_predecessor(env),
+        &salt(env, byte),
+        &gov.council,
+    );
+}
+
+/// Executes a ready operation with no signature at all, the way any observer
+/// would once the delay has passed.
+fn execute_by_anyone(
+    env: &Env,
+    gov: &GovernedContracts,
+    target: &Address,
+    function: &Symbol,
+    args: &Vec<Val>,
+    byte: u8,
+) {
+    env.set_auths(&[]);
+    GovernorClient::new(env, &gov.governor).execute(
+        target,
+        function,
+        args,
+        &no_predecessor(env),
+        &salt(env, byte),
+    );
+    env.mock_all_auths();
+}
+
+/// Builds a governed deployment and proves one pool transaction against the
+/// association set state the operator writes into it.
+///
+/// Every allowlist and blocklist write goes through `execute_now`, so the roots
+/// the pool checks are the ones the governor produced.
+fn governed_fixture(
+    in_amounts: [u64; 2],
+    out_amounts: [u64; 2],
+    ext_amount: i32,
+) -> Result<GovernedFixture> {
+    let env = test_env();
+    let mut proven = prove_transaction(&env, in_amounts, out_amounts, ext_amount)?;
+
+    env.mock_all_auths();
+    let gov = deploy_governed_contracts(&env);
+    let client = GovernorClient::new(&env, &gov.governor);
+
+    for leaf in allowlist_leaves(&proven.case, &proven.membership_trees, &proven.witness) {
+        client.execute_now(
+            &gov.contracts.asp_membership,
+            &insert_leaf(&env),
+            &soroban_sdk::vec![&env, scalar_to_u256(&env, leaf).into_val(&env)],
+            &gov.operator,
+        );
+    }
+    for (key, value) in non_membership_overrides_from_pubs(&proven.witness.public_keys) {
+        client.execute_now(
+            &gov.contracts.asp_non_membership,
+            &insert_leaf(&env),
+            &soroban_sdk::vec![
+                &env,
+                bigint_to_u256(&env, &key).into_val(&env),
+                bigint_to_u256(&env, &value).into_val(&env),
+            ],
+            &gov.operator,
+        );
+    }
+
+    let roots = sync_pool_state(
+        &env,
+        &gov.contracts,
+        &proven.case,
+        &mut proven.leaves,
+        &proven.witness,
+    );
+
+    let ext_data = proven.ext_data.clone();
+    Ok(GovernedFixture {
+        proof: proven.into_proof(&env, &roots),
+        env,
+        gov,
+        ext_data,
+    })
+}
+
+/// The operator writes both association sets through the governor, a deposit
+/// proved against the resulting roots verifies on chain, and the council does
+/// not reach the operator's row.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn the_operator_writes_both_association_sets_through_the_governor() -> Result<()> {
+    let fixture = governed_fixture([0, 0], [13, 0], 13)?;
+
+    assert_ne!(
+        fixture.proof.asp_membership_root,
+        U256::from_u32(&fixture.env, 0),
+        "the allowlist writes must have landed"
+    );
+    assert!(
+        fixture.transact().is_ok(),
+        "a deposit proved against the governed roots should verify"
+    );
+    assert!(
+        matches!(
+            fixture.try_allowlist(42, &fixture.gov.council),
+            Err(Err(InvokeError::Contract(2000)))
+        ),
+        "the council must not reach the operator's row"
+    );
+    Ok(())
+}
+
+/// A guardian shuts deposits through the governor and only the council reopens
+/// them.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn a_guardian_pause_of_deposits_holds_until_the_council_lifts_it() -> Result<()> {
+    let fixture = governed_fixture([0, 0], [13, 0], 13)?;
+    let pool = fixture.gov.contracts.pool.clone();
+    let root_before = fixture.pool().get_root();
+
+    fixture
+        .governor()
+        .pause(&pool, &pausable::DEPOSITS, &fixture.gov.guardian);
+
+    assert!(
+        matches!(fixture.transact(), Err(Ok(Error::Paused))),
+        "a paused pool must refuse the deposit"
+    );
+    assert_eq!(
+        fixture.pool().get_root(),
+        root_before,
+        "a refused deposit must leave the commitment tree alone"
+    );
+
+    fixture
+        .governor()
+        .unpause(&pool, &pausable::DEPOSITS, &fixture.gov.council);
+
+    assert!(
+        fixture.transact().is_ok(),
+        "the deposit should land once the council lifts the pause"
+    );
+    Ok(())
+}
+
+/// The incident script's shape: the guardian pauses the pool and both
+/// association set providers in three calls, and every write stops.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn the_guardian_pauses_the_pool_and_both_association_sets() -> Result<()> {
+    let fixture = governed_fixture([0, 0], [13, 0], 13)?;
+    let gov = &fixture.gov;
+    let governor = fixture.governor();
+
+    governor.pause(&gov.contracts.pool, &pausable::DEPOSITS, &gov.guardian);
+    governor.pause(
+        &gov.contracts.asp_membership,
+        &pausable::MUTATIONS,
+        &gov.guardian,
+    );
+    governor.pause(
+        &gov.contracts.asp_non_membership,
+        &pausable::MUTATIONS,
+        &gov.guardian,
+    );
+
+    assert!(
+        matches!(
+            fixture.try_allowlist(42, &gov.operator),
+            Err(Err(InvokeError::Contract(code)))
+                if code == asp_membership::Error::Paused as u32
+        ),
+        "a paused association set must refuse an operator write"
+    );
+    assert!(
+        matches!(fixture.transact(), Err(Ok(Error::Paused))),
+        "the paused pool must refuse the deposit"
+    );
+    Ok(())
+}
+
+/// A guardian's pause of withdrawals releases itself, and a proof made before
+/// it still verifies afterwards.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn a_guardian_pause_of_withdrawals_expires_on_its_own() -> Result<()> {
+    let fixture = governed_fixture([13, 0], [0, 0], -13)?;
+    let pool = fixture.gov.contracts.pool.clone();
+
+    fixture
+        .governor()
+        .pause(&pool, &pausable::WITHDRAWALS, &fixture.gov.guardian);
+
+    assert!(
+        matches!(fixture.transact(), Err(Ok(Error::Paused))),
+        "a paused pool must refuse the withdrawal"
+    );
+
+    advance(&fixture.env, GOV_GUARDIAN_PAUSE);
+
+    assert!(
+        fixture.transact().is_ok(),
+        "the withdrawal should land once the guardian's pause lapses"
+    );
+    Ok(())
+}
+
+/// The council's pause with no deadline is a queued call to the pool's own
+/// `pause`, and it outlives the guardian's window that covered the delay.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn the_council_pauses_without_a_deadline_through_the_queue() -> Result<()> {
+    let fixture = governed_fixture([13, 0], [0, 0], -13)?;
+    let env = &fixture.env;
+    let gov = &fixture.gov;
+    let pool = gov.contracts.pool.clone();
+    let pause = Symbol::new(env, "pause");
+    let args = soroban_sdk::vec![
+        env,
+        pausable::POOL_MASK.into_val(env),
+        None::<u32>.into_val(env),
+    ];
+
+    fixture
+        .governor()
+        .pause(&pool, &pausable::POOL_MASK, &gov.guardian);
+    schedule(env, gov, &pool, &pause, &args, 1);
+    advance(env, GOV_DELAY);
+    execute_by_anyone(env, gov, &pool, &pause, &args, 1);
+
+    advance(env, GOV_GUARDIAN_PAUSE);
+    assert_eq!(
+        fixture.pool().get_pause_state(),
+        pausable::PauseState {
+            flags: pausable::POOL_MASK,
+            until: None,
+        }
+    );
+    assert!(
+        matches!(fixture.transact(), Err(Ok(Error::Paused))),
+        "the council's pause must hold after the guardian's window closed"
+    );
+
+    fixture
+        .governor()
+        .unpause(&pool, &pausable::POOL_MASK, &gov.council);
+
+    assert!(
+        fixture.transact().is_ok(),
+        "the withdrawal should land once the council reopens the pool"
+    );
+    Ok(())
+}
+
+/// The guardian cannot cancel an administrator rotation; the council cancels
+/// its own and the second attempt lands once the delay passes.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn the_council_rotates_the_pool_administrator_through_the_queue() {
+    let env = test_env();
+    env.mock_all_auths();
+    let gov = deploy_governed_contracts(&env);
+    let client = GovernorClient::new(&env, &gov.governor);
+    let pool = gov.contracts.pool.clone();
+    let successor = Address::generate(&env);
+    let update_admin = Symbol::new(&env, "update_admin");
+    let args = soroban_sdk::vec![&env, successor.clone().into_val(&env)];
+
+    schedule(&env, &gov, &pool, &update_admin, &args, 1);
+    assert!(
+        matches!(
+            client.try_cancel(
+                &pool,
+                &update_admin,
+                &args,
+                &no_predecessor(&env),
+                &salt(&env, 1),
+                &gov.guardian,
+            ),
+            Err(Ok(e)) if e == soroban_sdk::Error::from_contract_error(2000)
+        ),
+        "the guardian cancels nothing"
+    );
+    assert_eq!(client.get_pending().len(), 1);
+
+    client.cancel(
+        &pool,
+        &update_admin,
+        &args,
+        &no_predecessor(&env),
+        &salt(&env, 1),
+        &gov.council,
+    );
+    assert_eq!(
+        client.get_pending().len(),
+        0,
+        "the council clears its queue"
+    );
+
+    schedule(&env, &gov, &pool, &update_admin, &args, 2);
+    advance(&env, GOV_DELAY);
+    execute_by_anyone(&env, &gov, &pool, &update_admin, &args, 2);
+
+    let expected = AdminUpdated {
+        old_admin: gov.governor.clone(),
+        new_admin: successor,
+    }
+    .to_xdr(&env, &pool);
+    let pool_events = env.events().all().filter_by_contract(&pool);
+    assert!(
+        pool_events.events().contains(&expected),
+        "the pool must record the rotation to the new administrator"
+    );
+}
+
+/// The recovery address restores a council after its key is lost, and the
+/// replacement then revokes the old one.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn the_recovery_address_replaces_a_lost_council() {
+    let env = test_env();
+    env.mock_all_auths();
+    let gov = deploy_governed_contracts(&env);
+    let client = GovernorClient::new(&env, &gov.governor);
+    let successor = Address::generate(&env);
+    let grant = Symbol::new(&env, "grant_role");
+    let grant_args = soroban_sdk::vec![
+        &env,
+        successor.clone().into_val(&env),
+        governor::COUNCIL.into_val(&env),
+    ];
+    let scheduled_at = env.ledger().sequence();
+
+    client.schedule(
+        &gov.governor,
+        &grant,
+        &grant_args,
+        &no_predecessor(&env),
+        &salt(&env, 1),
+        &gov.recovery,
+    );
+    assert_eq!(
+        client
+            .get_pending()
+            .get(0)
+            .expect("one pending operation")
+            .ready_ledger,
+        scheduled_at.saturating_add(GOV_RECOVERY_DELAY)
+    );
+    advance(&env, GOV_RECOVERY_DELAY);
+    execute_by_anyone(&env, &gov, &gov.governor, &grant, &grant_args, 1);
+    assert!(client.has_role(&successor, &governor::COUNCIL));
+
+    let revoke = Symbol::new(&env, "revoke_role");
+    let revoke_args = soroban_sdk::vec![
+        &env,
+        gov.council.clone().into_val(&env),
+        governor::COUNCIL.into_val(&env),
+    ];
+    client.schedule(
+        &gov.governor,
+        &revoke,
+        &revoke_args,
+        &no_predecessor(&env),
+        &salt(&env, 2),
+        &successor,
+    );
+    advance(&env, GOV_DELAY);
+    execute_by_anyone(&env, &gov, &gov.governor, &revoke, &revoke_args, 2);
+
+    assert!(!client.has_role(&gov.council, &governor::COUNCIL));
+    assert_eq!(client.get_role_member_count(&governor::COUNCIL), 1);
+}
+
+/// The council re-points the pool at a second allowlist through the queue, and
+/// the pool reads its root afterwards.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn the_council_re_points_the_pool_at_a_new_allowlist() {
+    let env = test_env();
+    env.mock_all_auths();
+    let gov = deploy_governed_contracts(&env);
+    let pool = PoolContractClient::new(&env, &gov.contracts.pool);
+    let root_before = pool.get_asp_membership_root();
+
+    let new_asp = env.register(
+        ASPMembership,
+        (
+            Address::generate(&env),
+            u32::try_from(ASP_MEMBERSHIP_LEVELS).expect("ASP_MEMBERSHIP_LEVELS fits in u32"),
+        ),
+    );
+    let new_asp_client = ASPMembershipClient::new(&env, &new_asp);
+    new_asp_client.insert_leaf(&U256::from_u32(&env, 42));
+    assert_ne!(new_asp_client.get_root(), root_before);
+
+    let update = Symbol::new(&env, "update_asp_membership");
+    let args = soroban_sdk::vec![&env, new_asp.clone().into_val(&env)];
+    schedule(&env, &gov, &gov.contracts.pool, &update, &args, 1);
+    advance(&env, GOV_DELAY);
+    execute_by_anyone(&env, &gov, &gov.contracts.pool, &update, &args, 1);
+
+    assert_eq!(pool.get_asp_membership_root(), new_asp_client.get_root());
+}
+
+/// After the handover the association set answers the governor and nobody else,
+/// including the address that deployed it.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn a_direct_association_set_write_is_refused_after_the_handover() {
+    let env = test_env();
+    env.mock_all_auths();
+    let gov = deploy_governed_contracts(&env);
+    let asp = ASPMembershipClient::new(&env, &gov.contracts.asp_membership);
+    let leaf = U256::from_u32(&env, 42);
+    let before = asp.get_root();
+
+    // The deployer signs the call it could have made before the rotation. The
+    // governor now holds the role, so the signature no longer authorizes it.
+    env.mock_auths(&[MockAuth {
+        address: &gov.contracts.deployer,
+        invoke: &MockAuthInvoke {
+            contract: &gov.contracts.asp_membership,
+            fn_name: "insert_leaf",
+            args: (leaf.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    assert!(
+        matches!(asp.try_insert_leaf(&leaf), Err(Err(InvokeError::Abort))),
+        "the deployer must not reach the association set after the handover"
+    );
+    assert_eq!(asp.get_root(), before);
+
+    // The same write lands when the operator routes it through the governor.
+    env.mock_all_auths();
+    GovernorClient::new(&env, &gov.governor).execute_now(
+        &gov.contracts.asp_membership,
+        &insert_leaf(&env),
+        &soroban_sdk::vec![&env, leaf.into_val(&env)],
+        &gov.operator,
+    );
+    assert_ne!(asp.get_root(), before);
+}

--- a/e2e-tests/src/tests/mod.rs
+++ b/e2e-tests/src/tests/mod.rs
@@ -6,4 +6,5 @@
 mod coherence;
 mod e2e_pool_2_in_2_out;
 mod e2e_pool_2tx_plan;
+mod governance;
 pub mod utils;

--- a/e2e-tests/src/tests/utils.rs
+++ b/e2e-tests/src/tests/utils.rs
@@ -12,13 +12,15 @@ use circuits::test::utils::{
     sparse_merkle_tree::prepare_smt_proof_with_overrides,
     transaction::{commitment, prepopulated_prefix},
     transaction_case::{
-        TransactionWitness, TxCase, build_base_inputs, prepare_transaction_witness,
+        InputNote, OutputNote, TransactionWitness, TxCase, build_base_inputs,
+        prepare_transaction_witness,
     },
 };
+use governor::{FnRule, Governor, RoleGrant};
 use num_bigint::{BigInt, BigUint};
-use pool::{PoolContract, PoolContractClient};
+use pool::{ExtData, PoolContract, PoolContractClient, Proof, hash_ext_data};
 use soroban_sdk::{
-    Address, Bytes, BytesN, Env, U256,
+    Address, Bytes, BytesN, Env, I256, Symbol, U256, Vec as SorobanVec,
     crypto::bn254::{Bn254G1Affine as G1Affine, Bn254G2Affine as G2Affine},
     testutils::Address as _,
 };
@@ -178,6 +180,9 @@ pub fn prove_with_graph(stem: &str, inputs: &Inputs) -> Result<ProofResult> {
 pub struct DeployedContracts {
     /// Address of the pool contract
     pub pool: Address,
+    /// Address every constructor was given as administrator. A deployment that
+    /// later rotates the role keeps this as the address it rotated away from.
+    pub deployer: Address,
     /// Address of the ASP membership contract
     pub asp_membership: Address,
     /// Address of the ASP non-membership contract
@@ -198,7 +203,7 @@ pub struct DeployedContracts {
 ///
 /// A `DeployedContracts` struct containing all deployed contract addresses
 pub fn deploy_contracts(env: &Env) -> DeployedContracts {
-    let admin = Address::generate(env);
+    let deployer = Address::generate(env);
 
     let token_address = env.register(MockToken, ());
 
@@ -207,18 +212,18 @@ pub fn deploy_contracts(env: &Env) -> DeployedContracts {
     let asp_membership = env.register(
         ASPMembership,
         (
-            admin.clone(),
+            deployer.clone(),
             u32::try_from(ASP_MEMBERSHIP_LEVELS).expect("ASP_MEMBERSHIP_LEVELS fits in u32"),
         ),
     );
 
-    let asp_non_membership = env.register(ASPNonMembership, (admin.clone(),));
+    let asp_non_membership = env.register(ASPNonMembership, (deployer.clone(),));
 
     let max_deposit = U256::from_u32(env, MAX_DEPOSIT);
     let pool = env.register(
         PoolContract,
         (
-            admin,
+            deployer.clone(),
             token_address.clone(),
             verifier_address.clone(),
             asp_membership.clone(),
@@ -233,6 +238,118 @@ pub fn deploy_contracts(env: &Env) -> DeployedContracts {
         pool,
         asp_membership,
         asp_non_membership,
+        deployer,
+    }
+}
+
+/// Ledgers a council operation waits before anyone may execute it.
+pub const GOV_DELAY: u32 = governor::DELAY_FLOOR;
+
+/// Ledgers a recovery operation waits, above [`GOV_DELAY`].
+pub const GOV_RECOVERY_DELAY: u32 = 20;
+
+/// Ledgers a ready operation stays executable.
+pub const GOV_GRACE: u32 = 5;
+
+/// Ledgers a guardian pause holds, above [`GOV_DELAY`] so that the council can
+/// queue its own pause inside the window.
+pub const GOV_GUARDIAN_PAUSE: u32 = 15;
+
+/// A deployment whose contracts are administered by a governor.
+pub struct GovernedContracts {
+    /// The pool and the two association set providers.
+    pub contracts: DeployedContracts,
+    /// The governor that administers all three.
+    pub governor: Address,
+    /// Holds the council role, so it queues, cancels, and unpauses.
+    pub council: Address,
+    /// Holds the operator role, so it writes to the association sets without
+    /// waiting out a delay.
+    pub operator: Address,
+    /// Holds the guardian role, so it pauses without the queue.
+    pub guardian: Address,
+    /// Holds the recovery role, so it replaces a lost council.
+    pub recovery: Address,
+}
+
+/// Deploys the contracts and hands each one's administrator role to a governor.
+///
+/// The permission table opens the association set writes to the operator role
+/// and nothing else, so every other change goes through the queue.
+///
+/// The rotation needs each contract's current administrator to authorize it, so
+/// call `Env::mock_all_auths` first.
+///
+/// # Arguments
+///
+/// * `env` - The Soroban environment
+///
+/// # Returns
+///
+/// The deployed addresses together with the governor and its role holders
+pub fn deploy_governed_contracts(env: &Env) -> GovernedContracts {
+    let contracts = deploy_contracts(env);
+    let council = Address::generate(env);
+    let operator = Address::generate(env);
+    let guardian = Address::generate(env);
+    let recovery = Address::generate(env);
+
+    let mut roles = SorobanVec::new(env);
+    for (role, member) in [
+        (governor::COUNCIL, &council),
+        (governor::OPERATOR, &operator),
+        (governor::GUARDIAN, &guardian),
+        (governor::RECOVERY, &recovery),
+    ] {
+        roles.push_back(RoleGrant {
+            role,
+            member: member.clone(),
+        });
+    }
+
+    let insert_leaf = Symbol::new(env, "insert_leaf");
+    let fn_roles = soroban_sdk::vec![
+        env,
+        FnRule {
+            target: contracts.asp_membership.clone(),
+            function: insert_leaf.clone(),
+            role: governor::OPERATOR,
+        },
+        FnRule {
+            target: contracts.asp_non_membership.clone(),
+            function: insert_leaf,
+            role: governor::OPERATOR,
+        },
+        FnRule {
+            target: contracts.asp_non_membership.clone(),
+            function: Symbol::new(env, "delete_leaf"),
+            role: governor::OPERATOR,
+        },
+    ];
+
+    let governor_address = env.register(
+        Governor,
+        (
+            GOV_DELAY,
+            GOV_RECOVERY_DELAY,
+            GOV_GRACE,
+            GOV_GUARDIAN_PAUSE,
+            roles,
+            fn_roles,
+        ),
+    );
+
+    PoolContractClient::new(env, &contracts.pool).update_admin(&governor_address);
+    ASPMembershipClient::new(env, &contracts.asp_membership).update_admin(&governor_address);
+    ASPNonMembershipClient::new(env, &contracts.asp_non_membership).update_admin(&governor_address);
+
+    GovernedContracts {
+        contracts,
+        governor: governor_address,
+        council,
+        operator,
+        guardian,
+        recovery,
     }
 }
 
@@ -566,6 +683,175 @@ pub fn generate_proof(
     prove_with_graph(POLICY_STEM, &inputs)
 }
 
+/// Result of `PoolContractClient::try_transact`.
+///
+/// The outer error holds the contract error, and the inner one holds a return
+/// value conversion error.
+pub type TransactOutcome =
+    Result<Result<(), soroban_sdk::ConversionError>, Result<pool::Error, soroban_sdk::InvokeError>>;
+
+/// Sends a proven transaction to a pool from a freshly generated sender.
+pub fn transact(
+    env: &Env,
+    contracts: &DeployedContracts,
+    proof: &Proof,
+    ext_data: &ExtData,
+) -> TransactOutcome {
+    let sender = Address::generate(env);
+    PoolContractClient::new(env, &contracts.pool).try_transact(proof, ext_data, &sender)
+}
+
+/// Commitment of one output note of a case.
+pub fn output_commitment(case: &TxCase, index: usize) -> Scalar {
+    commitment(
+        case.outputs[index].amount,
+        case.outputs[index].pub_key,
+        case.outputs[index].blinding,
+    )
+}
+
+/// A proven 2-in/2-out pool transaction, before any contract holds the state
+/// the proof was made against.
+///
+/// A test deploys its contracts, writes the association set entries however it
+/// means to write them, calls [`sync_contract_state`] or [`sync_pool_state`],
+/// and passes the roots it gets back to [`ProvenTransaction::into_proof`].
+pub struct ProvenTransaction {
+    /// The transaction the proof covers.
+    pub case: TxCase,
+    /// Pool leaves the proof was made against. [`sync_pool_state`] writes the
+    /// input commitments into them.
+    pub leaves: Vec<Scalar>,
+    /// Nullifiers, public keys, and root the circuit derived.
+    pub witness: TransactionWitness,
+    /// Frozen membership trees the proof committed to.
+    pub membership_trees: Vec<MembershipTreeProof>,
+    /// External data the proof is bound to.
+    pub ext_data: ExtData,
+    result: ProofResult,
+    ext_data_hash: BytesN<32>,
+    public_amount: Scalar,
+}
+
+impl ProvenTransaction {
+    /// Assemble the pool's `Proof` from the roots the contracts now hold.
+    pub fn into_proof(self, env: &Env, roots: &SyncedRoots) -> Proof {
+        let mut input_nullifiers: SorobanVec<U256> = SorobanVec::new(env);
+        for nullifier in &self.witness.nullifiers {
+            input_nullifiers.push_back(scalar_to_u256(env, *nullifier));
+        }
+
+        Proof {
+            proof: wrap_groth16_proof(env, self.result),
+            root: roots.pool_root.clone(),
+            input_nullifiers,
+            output_commitment0: scalar_to_u256(env, output_commitment(&self.case, 0)),
+            output_commitment1: scalar_to_u256(env, output_commitment(&self.case, 1)),
+            public_amount: scalar_to_u256(env, self.public_amount),
+            ext_data_hash: self.ext_data_hash,
+            asp_membership_root: roots.asp_membership_root.clone(),
+            asp_non_membership_root: roots.asp_non_membership_root.clone(),
+        }
+    }
+}
+
+/// Proves one 2-in/2-out pool transaction from the committed witness graph.
+///
+/// The amounts must balance: `inputs + ext_amount = outputs`. A positive
+/// `ext_amount` is a deposit, a negative one a withdrawal, and zero a private
+/// transfer.
+///
+/// # Panics
+///
+/// Panics if the proof does not verify against its own verification key, which
+/// means the amounts do not describe a valid transaction.
+///
+/// # Errors
+///
+/// Returns an error if the witness cannot be computed or the proof cannot be
+/// generated.
+pub fn prove_transaction(
+    env: &Env,
+    in_amounts: [u64; 2],
+    out_amounts: [u64; 2],
+    ext_amount: i32,
+) -> Result<ProvenTransaction> {
+    let ext_data = ExtData {
+        recipient: Address::generate(env),
+        ext_amount: I256::from_i32(env, ext_amount),
+        encrypted_output0: Bytes::new(env),
+        encrypted_output1: Bytes::new(env),
+    };
+    let ext_data_hash = hash_ext_data(env, &ext_data);
+
+    let case = TxCase::new(
+        vec![
+            InputNote {
+                leaf_index: 0,
+                priv_key: Scalar::from(101u64),
+                blinding: Scalar::from(201u64),
+                amount: Scalar::from(in_amounts[0]),
+            },
+            InputNote {
+                leaf_index: 1,
+                priv_key: Scalar::from(102u64),
+                blinding: Scalar::from(211u64),
+                amount: Scalar::from(in_amounts[1]),
+            },
+        ],
+        vec![
+            OutputNote {
+                pub_key: Scalar::from(501u64),
+                blinding: Scalar::from(601u64),
+                amount: Scalar::from(out_amounts[0]),
+            },
+            OutputNote {
+                pub_key: Scalar::from(502u64),
+                blinding: Scalar::from(602u64),
+                amount: Scalar::from(out_amounts[1]),
+            },
+        ],
+    );
+
+    // `transact` appends its two outputs past this prefix.
+    let leaves = prepopulated_prefix(
+        0xDEAD_BEEFu64,
+        &[case.inputs[0].leaf_index, case.inputs[1].leaf_index],
+        LEAF_PREFIX,
+    );
+    let membership_trees = build_membership_trees(&case, |j| 0xFEED_FACEu64 ^ ((j as u64) << 40));
+    let keys = case
+        .inputs
+        .iter()
+        .map(|input| NonMembership {
+            key_non_inclusion: scalar_to_bigint(derive_public_key(input.priv_key)),
+        })
+        .collect::<Vec<_>>();
+
+    let witness = prepare_transaction_witness(&case, leaves.clone(), LEVELS)?;
+    let public_amount = Scalar::from(ext_amount);
+    let result = generate_proof(
+        &case,
+        leaves.clone(),
+        public_amount,
+        &membership_trees,
+        &keys,
+        Some(bytes32_to_bigint(&ext_data_hash)),
+    )?;
+    assert!(result.verified, "Proof should verify locally");
+
+    Ok(ProvenTransaction {
+        case,
+        leaves,
+        witness,
+        membership_trees,
+        ext_data,
+        result,
+        ext_data_hash,
+        public_amount,
+    })
+}
+
 /// Merkle roots of the contracts after a state sync
 pub struct SyncedRoots {
     /// Pool commitment root, which must equal the root inside the proof
@@ -608,27 +894,57 @@ pub fn sync_contract_state(
     witness: &TransactionWitness,
 ) -> SyncedRoots {
     let asp_membership_client = ASPMembershipClient::new(env, &contracts.asp_membership);
+    for leaf in allowlist_leaves(case, membership_trees, witness) {
+        asp_membership_client.insert_leaf(&scalar_to_u256(env, leaf));
+    }
+
     let asp_non_membership_client = ASPNonMembershipClient::new(env, &contracts.asp_non_membership);
-
-    // Membership tree: rebuild the frozen leaves the proof used.
-    let mut memb_leaves = membership_trees[0].leaves.clone();
-    for (i, tree) in membership_trees.iter().enumerate().take(case.inputs.len()) {
-        memb_leaves[tree.index] = poseidon2_hash2(
-            witness.public_keys[i],
-            tree.blinding,
-            Some(Scalar::from(1u64)),
-        );
-    }
-    for leaf in &memb_leaves {
-        asp_membership_client.insert_leaf(&scalar_to_u256(env, *leaf));
-    }
-
-    // Non-membership tree: insert the same sparse Merkle tree overrides.
     for (key, value) in non_membership_overrides_from_pubs(&witness.public_keys) {
         asp_non_membership_client
             .insert_leaf(&bigint_to_u256(env, &key), &bigint_to_u256(env, &value));
     }
 
+    sync_pool_state(env, contracts, case, leaves, witness)
+}
+
+/// Returns the allowlist leaves a proof was made against.
+///
+/// The circuit froze one membership tree and proved each input's public key
+/// against it, so the contract only matches the proof once it holds these
+/// leaves in this order.
+pub fn allowlist_leaves(
+    case: &TxCase,
+    membership_trees: &[MembershipTreeProof],
+    witness: &TransactionWitness,
+) -> Vec<Scalar> {
+    let mut leaves = membership_trees[0].leaves.clone();
+    for (i, tree) in membership_trees.iter().enumerate().take(case.inputs.len()) {
+        leaves[tree.index] = poseidon2_hash2(
+            witness.public_keys[i],
+            tree.blinding,
+            Some(Scalar::from(1u64)),
+        );
+    }
+    leaves
+}
+
+/// Writes the pool commitments the proof was made against and returns the three
+/// roots the pool checks.
+///
+/// The association set contracts must already hold their own leaves, because
+/// the returned roots are read back from them.
+///
+/// # Panics
+///
+/// Panics if the pool root does not equal the circuit root, because the
+/// on-chain verification cannot succeed in that state.
+pub fn sync_pool_state(
+    env: &Env,
+    contracts: &DeployedContracts,
+    case: &TxCase,
+    leaves: &mut [Scalar],
+    witness: &TransactionWitness,
+) -> SyncedRoots {
     // Pool tree: write the input commitments, then insert the leaves in pairs.
     for note in &case.inputs {
         let pub_key = derive_public_key(note.priv_key);
@@ -655,8 +971,9 @@ pub fn sync_contract_state(
 
     SyncedRoots {
         pool_root,
-        asp_membership_root: asp_membership_client.get_root(),
-        asp_non_membership_root: asp_non_membership_client.get_root(),
+        asp_membership_root: ASPMembershipClient::new(env, &contracts.asp_membership).get_root(),
+        asp_non_membership_root: ASPNonMembershipClient::new(env, &contracts.asp_non_membership)
+            .get_root(),
     }
 }
 


### PR DESCRIPTION
Proof that the governor governs. Nine end-to-end tests drive real pools and ASPs
through it with real Groth16 proofs against the compiled verifier, and one commit adds the
governor to the wasm build in CI.

## The fixture

`deploy_governed_contracts` deploys the pool, both ASPs, the verifier, and the token the way
`deploy_contracts` already does, then deploys a governor with four distinct council, operator,
guardian, and recovery addresses generated in the test, and finally rotates each target's admin
to the governor. After that the deployer key can no longer write to anything, which one test
asserts directly by calling `asp_membership.insert_leaf` with it and watching the call fail on
authorization.

The utility refactor in the first commit pulls `prove_transaction`, `transact`,
`allowlist_leaves`, and `sync_pool_state` out of the existing pool test, which is why
`e2e_pool_2_in_2_out.rs` shrinks.

## What the tests cover

- The operator allowlists and blocklists through `execute_now`, and a deposit whose proof was
  generated against the resulting roots verifies on chain. The council's `execute_now` on the
  same row is refused.
- The guardian pauses `DEPOSITS` through the governor, the same deposit fails with `Paused`, the
  pool root is unchanged, the council unpauses, and the deposit succeeds.
- The incident script's shape: the guardian pauses the pool with `DEPOSITS` and both ASPs with
  `MUTATIONS` in three calls, after which an allowlist insert and a deposit each fail with their
  own contract's `Paused`.
- A guardian pause of `WITHDRAWALS` lapses after `guardian_pause` ledgers, and a withdrawal proof
  generated before the pause still verifies afterwards.
- The council's pause with no deadline: the guardian pauses flags 7, the council schedules
  `pool.pause(7, ())` the same ledger, anyone executes it after the delay, and a withdrawal still
  fails after the guardian's window has passed. The council unpause reopens it.
- The council schedules `pool.update_admin(new)`, the guardian's cancel fails on authorization,
  the council cancels and reschedules with a new salt, and after the delay an address with no
  role executes it. The pool emits `AdminUpdated` from the governor to the new address.
- The recovery account replaces a lost council: `grant_role(council, new)` after the recovery
  delay, then the new council revokes the old one.
- The council re-points the pool at a second membership ASP through
  `pool.update_asp_membership`, executed from an address with no role, and
  `get_asp_membership_root` reads the new ASP's root.

The re-pointing test is the governor-path row of #373's test plan, which that plan assigns to
this branch. It uses `pool`'s existing setter, already on `main`, so nothing here waits on #373.

Part of #372.
