### PR TITLE
Carry the governor in the manifest and drive it from the admin page

### DIFF
--- a/app/admin.html
+++ b/app/admin.html
@@ -56,6 +56,8 @@
                         <button type="button" data-target="overview" class="tab-btn rounded-full border border-cyan-300/30 bg-cyan-400/10 px-4 py-2 text-sm font-medium text-cyan-100 transition">Overview</button>
                         <button type="button" data-target="allowlist" class="tab-btn rounded-full border border-white/10 px-4 py-2 text-sm font-medium text-slate-400 transition hover:border-cyan-300/30 hover:text-cyan-100">Allowlist</button>
                         <button type="button" data-target="blocklist" class="tab-btn rounded-full border border-white/10 px-4 py-2 text-sm font-medium text-slate-400 transition hover:border-cyan-300/30 hover:text-cyan-100">Blocklist</button>
+                        <button type="button" data-target="pause" class="tab-btn rounded-full border border-white/10 px-4 py-2 text-sm font-medium text-slate-400 transition hover:border-cyan-300/30 hover:text-cyan-100">Pause</button>
+                        <button type="button" data-target="queue" class="tab-btn rounded-full border border-white/10 px-4 py-2 text-sm font-medium text-slate-400 transition hover:border-cyan-300/30 hover:text-cyan-100">Queue</button>
                     </nav>
 
                     <div class="flex items-center gap-2">
@@ -177,6 +179,53 @@
                 </div>
             </section>
 
+            <!-- 4. Pause Tab -->
+            <section id="pause" class="tab-content hidden rounded-[28px] border border-white/8 bg-white/[0.03] p-6 backdrop-blur-xl space-y-6" aria-labelledby="pause-heading">
+                <div>
+                    <p class="text-[11px] font-semibold uppercase tracking-[0.34em] text-cyan-200/70">Governance</p>
+                    <h2 id="pause-heading" class="mt-2 text-2xl font-semibold tracking-tight text-white">Pause Control</h2>
+                </div>
+
+                <div class="rounded-2xl border border-white/8 bg-ink-900/70 p-5 overflow-x-auto">
+                    <table class="w-full min-w-[720px] text-left text-sm">
+                        <thead>
+                            <tr class="text-[10px] uppercase tracking-wide text-slate-500">
+                                <th class="pb-3 pr-4 font-medium" scope="col">Target</th>
+                                <th class="pb-3 pr-4 font-medium" scope="col">Flags</th>
+                                <th class="pb-3 pr-4 font-medium" scope="col">Until</th>
+                                <th class="pb-3 font-medium" scope="col">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody id="pauseRows" class="divide-y divide-white/5"></tbody>
+                    </table>
+                </div>
+            </section>
+
+            <!-- 5. Queue Tab -->
+            <section id="queue" class="tab-content hidden rounded-[28px] border border-white/8 bg-white/[0.03] p-6 backdrop-blur-xl space-y-6" aria-labelledby="queue-heading">
+                <div>
+                    <p class="text-[11px] font-semibold uppercase tracking-[0.34em] text-cyan-200/70">Governance</p>
+                    <h2 id="queue-heading" class="mt-2 text-2xl font-semibold tracking-tight text-white">Timelock Queue</h2>
+                </div>
+
+                <div class="rounded-2xl border border-white/8 bg-ink-900/70 p-5 overflow-x-auto">
+                    <table class="w-full min-w-[840px] text-left text-sm">
+                        <thead>
+                            <tr class="text-[10px] uppercase tracking-wide text-slate-500">
+                                <th class="pb-3 pr-4 font-medium" scope="col">Operation ID</th>
+                                <th class="pb-3 pr-4 font-medium" scope="col">Target</th>
+                                <th class="pb-3 pr-4 font-medium" scope="col">Function</th>
+                                <th class="pb-3 pr-4 font-medium" scope="col">Ready Ledger</th>
+                                <th class="pb-3 pr-4 font-medium" scope="col">State</th>
+                                <th class="pb-3 font-medium" scope="col">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody id="queueRows" class="divide-y divide-white/5"></tbody>
+                    </table>
+                    <p id="queueNotice" class="mt-4 text-xs text-slate-400"></p>
+                </div>
+            </section>
+
         </main>
 
         <footer class="mt-8 border-t border-white/10">
@@ -210,6 +259,39 @@
                 <button type="button" class="toast-close mt-2 text-xs font-medium text-slate-400 hover:text-slate-200 transition underline underline-offset-4">Dismiss</button>
             </div>
         </div>
+    </template>
+
+    <!-- Pause Row Template -->
+    <template id="tpl-pause-row">
+        <tr>
+            <td class="pause-target py-3 pr-4 font-mono text-xs text-slate-200"></td>
+            <td class="pause-flags py-3 pr-4 font-mono text-xs text-slate-300"></td>
+            <td class="pause-until py-3 pr-4 font-mono text-xs text-slate-300"></td>
+            <td class="py-3">
+                <div class="flex flex-wrap items-center gap-2">
+                    <input class="pause-flags-input w-24 rounded-lg border border-white/10 bg-ink-950 px-3 py-2 font-mono text-xs text-slate-100 outline-none transition focus:border-cyan-300/40" type="text" placeholder="flags" autocomplete="off" spellcheck="false" aria-label="Pause flags" />
+                    <button type="button" class="pause-btn rounded-full border border-white/10 px-3 py-2 text-xs font-medium text-slate-300 transition hover:border-cyan-300/30 hover:text-cyan-100">Pause</button>
+                    <button type="button" class="unpause-btn rounded-full border border-white/10 px-3 py-2 text-xs font-medium text-slate-300 transition hover:border-cyan-300/30 hover:text-cyan-100">Unpause</button>
+                </div>
+            </td>
+        </tr>
+    </template>
+
+    <!-- Queue Row Template -->
+    <template id="tpl-queue-row">
+        <tr>
+            <td class="queue-id py-3 pr-4 font-mono text-xs text-slate-200"></td>
+            <td class="queue-target py-3 pr-4 font-mono text-xs text-slate-300"></td>
+            <td class="queue-function py-3 pr-4 font-mono text-xs text-slate-300"></td>
+            <td class="queue-ready py-3 pr-4 font-mono text-xs text-slate-300"></td>
+            <td class="queue-state py-3 pr-4 font-mono text-xs text-slate-300"></td>
+            <td class="py-3">
+                <div class="flex flex-wrap items-center gap-2">
+                    <button type="button" class="queue-execute-btn rounded-full border border-white/10 px-3 py-2 text-xs font-medium text-slate-300 transition hover:border-cyan-300/30 hover:text-cyan-100">Execute</button>
+                    <button type="button" class="queue-cancel-btn rounded-full border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs font-medium text-rose-100 transition hover:border-rose-500/50 hover:bg-rose-500/20">Cancel</button>
+                </div>
+            </td>
+        </tr>
     </template>
 
     <script type="module" src="js/admin.js"></script>

--- a/app/js/admin.js
+++ b/app/js/admin.js
@@ -1,4 +1,4 @@
-import { contract, nativeToScVal } from '@stellar/stellar-sdk';
+import { contract, nativeToScVal, scValToNative } from '@stellar/stellar-sdk';
 import { client, initializeRuntime, bootnodeRequired, ensureStorage, deriveAspUserLeaf } from './wasm-facade.js';
 import { connectWallet, getWalletNetwork, signWalletAuthEntry, signWalletTransaction } from './wallet.js';
 import { isDbLockedError, showDbLockedModal } from './db-locked.js';
@@ -34,6 +34,13 @@ const blocklistPublicKeyInput = document.getElementById('blocklistPublicKey');
 const addToAllowlistBtn = document.getElementById('addToAllowlistBtn');
 const addToBlocklistBtn = document.getElementById('addToBlocklistBtn');
 const removeFromBlocklistBtn = document.getElementById('removeFromBlocklistBtn');
+
+// Governance panels
+const pauseRowsEl = document.getElementById('pauseRows');
+const queueRowsEl = document.getElementById('queueRows');
+const queueNoticeEl = document.getElementById('queueNotice');
+const pauseRowTemplate = document.getElementById('tpl-pause-row');
+const queueRowTemplate = document.getElementById('tpl-queue-row');
 
 const state = {
   address: null,
@@ -174,11 +181,13 @@ async function getGovernorClient() {
 
 const u256 = (value) => nativeToScVal(value, { type: 'u256' });
 
-function failureMessage(err) {
+function failureMessage(err, role = 'an operator') {
   return /Error\(Contract, #2000\)/.test(err.message)
-    ? 'the connected wallet is not an operator'
+    ? `the connected wallet is not ${role}`
     : err.message;
 }
+
+const PAUSE_ROLES = { pause: 'a guardian', unpause: 'a council member' };
 
 async function ensureCryptoReady() {
   if (!state.cryptoReady) {
@@ -297,7 +306,7 @@ function disconnect() {
 async function refreshState() {
   try {
     setStatus('Loading contract state...', 'info');
-    const appState = await client().aspState();
+    const appState = await client().allContractsData();
     const membershipState = appState.aspMembership;
     const nonMembershipState = appState.aspNonMembership;
 
@@ -322,9 +331,115 @@ async function refreshState() {
     nonMembershipRootEl.textContent = nonMembershipState.root || '--';
     nonMembershipRootEl.href = nonMembershipStorageUrl;
 
+    refreshPausePanel(appState);
     setStatus('State loaded', 'ok');
   } catch (err) {
     setStatus('State load error', 'error');
+    return;
+  }
+
+  // The queue is read by simulating against the governor, which fails for
+  // reasons that have nothing to do with the contract state above.
+  try {
+    await refreshQueuePanel();
+  } catch (err) {
+    queueNoticeEl.textContent = 'The queue could not be read.';
+    showToast(`Queue load failed: ${failureMessage(err)}`, 'error');
+  }
+}
+
+function refreshPausePanel(data) {
+  pauseRowsEl.replaceChildren();
+
+  for (const target of [...data.pools, data.aspMembership, data.aspNonMembership]) {
+    const { contractId, contractType, pause } = target;
+    const row = pauseRowTemplate.content.cloneNode(true).firstElementChild;
+
+    row.querySelector('.pause-target').textContent = `${contractType} ${shortAddress(contractId)}`;
+    // A contract writes its pause entry on the first pause, so an absent one
+    // reads the same as a contract that has never been paused. Report what the
+    // contract itself reports in that case, which is no flags set.
+    row.querySelector('.pause-flags').textContent = pause?.flags ?? 0;
+    row.querySelector('.pause-until').textContent = pause?.until ?? '--';
+
+    const flagsInput = row.querySelector('.pause-flags-input');
+    row.querySelector('.pause-btn').addEventListener('click', () => togglePause(contractId, flagsInput, 'pause'));
+    row.querySelector('.unpause-btn').addEventListener('click', () => togglePause(contractId, flagsInput, 'unpause'));
+
+    pauseRowsEl.appendChild(row);
+  }
+}
+
+// Returns the value a contract struct holds under `name`.
+function scField(value, name) {
+  const entry = value.map()?.find((e) => e.key().sym().toString() === name);
+  if (!entry) throw new Error(`the governor's queue entry has no ${name} field`);
+  return entry.val();
+}
+
+// The governor hashes an operation over its own arguments, and `args` is
+// `Vec<Val>`, whose element type the contract spec cannot describe. Decoding
+// through the spec loses what each argument was queued as, so `execute` and
+// `cancel` would name a different operation than the one in the queue. Read
+// the simulation's own XDR and hand the arguments back untouched.
+function pendingOperations(assembled) {
+  return (assembled.simulationData.result.retval.vec() ?? []).map((entry) => {
+    const operation = scField(entry, 'operation');
+    return {
+      id: scField(entry, 'id'),
+      readyLedger: scField(entry, 'ready_ledger').u32(),
+      call: {
+        target: scField(operation, 'target'),
+        function: scField(operation, 'function'),
+        args: scField(operation, 'args').vec() ?? [],
+        predecessor: scField(operation, 'predecessor'),
+        salt: scField(operation, 'salt'),
+      },
+    };
+  });
+}
+
+async function refreshQueuePanel() {
+  queueRowsEl.replaceChildren();
+
+  if (!governorId()) {
+    queueNoticeEl.textContent = 'This deployment has no governor.';
+    return;
+  }
+  // The queue is read by simulation, which needs the wallet's RPC URL and source account.
+  if (!state.address) {
+    const link = document.createElement('a');
+    link.href = Utils.explorerContractStorageUrl(governorId());
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.className = 'text-cyan-300/80 transition hover:text-cyan-100 hover:underline';
+    link.textContent = "the governor's stored data";
+    queueNoticeEl.replaceChildren(
+      document.createTextNode('Connect a wallet to read the queue, or read it on '),
+      link,
+    );
+    return;
+  }
+  queueNoticeEl.replaceChildren();
+
+  const gov = await getGovernorClient();
+  const pending = pendingOperations(await gov.get_pending());
+  queueNoticeEl.textContent = pending.length ? '' : 'No pending operations.';
+
+  for (const entry of pending) {
+    const { result: status } = await gov.get_operation_state({ id: entry.id });
+    const row = queueRowTemplate.content.cloneNode(true).firstElementChild;
+
+    row.querySelector('.queue-id').textContent = Utils.truncateHex(entry.id.bytes().toString('hex'));
+    row.querySelector('.queue-target').textContent = shortAddress(scValToNative(entry.call.target));
+    row.querySelector('.queue-function').textContent = scValToNative(entry.call.function);
+    row.querySelector('.queue-ready').textContent = entry.readyLedger;
+    row.querySelector('.queue-state').textContent = status.tag;
+
+    row.querySelector('.queue-execute-btn').addEventListener('click', () => runQueueOperation(entry, 'execute'));
+    row.querySelector('.queue-cancel-btn').addEventListener('click', () => runQueueOperation(entry, 'cancel'));
+
+    queueRowsEl.appendChild(row);
   }
 }
 
@@ -451,6 +566,56 @@ async function removeNonMembershipLeaf() {
   } finally {
     if (state.address) removeFromBlocklistBtn.disabled = false;
     removeFromBlocklistBtn.textContent = originalText;
+  }
+}
+
+async function togglePause(contractId, flagsInput, method) {
+  try {
+    ensureWalletConnected();
+    const flags = parseBigIntInput(flagsInput.value, 'Pause flags');
+    if (flags === null) throw new Error('Pause flags are required');
+    if (flags === 0n) throw new Error('Pause flags must name at least one bit');
+    if (flags > 0xffffffffn) throw new Error('Pause flags must fit in 32 bits');
+
+    setStatus(`Submitting the ${method} transaction...`, 'info');
+    const gov = await getGovernorClient();
+    const tx = await gov[method]({
+      target: contractId,
+      flags: Number(flags),
+      caller: state.address,
+    });
+    await tx.signAndSend();
+
+    setStatus(`The ${method} transaction sent`, 'ok');
+    showToast(`Sent ${method} for ${shortAddress(contractId)}`, 'success');
+    await refreshState();
+  } catch (err) {
+    setStatus(`The ${method} failed`, 'error');
+    showToast(`The ${method} failed: ${failureMessage(err, PAUSE_ROLES[method])}`, 'error');
+  }
+}
+
+async function runQueueOperation(entry, method) {
+  try {
+    ensureWalletConnected();
+    const call = { ...entry.call };
+    if (method === 'cancel') call.caller = state.address;
+
+    setStatus(`Submitting the ${method} transaction...`, 'info');
+    const gov = await getGovernorClient();
+    const tx = await gov[method](call);
+    await tx.signAndSend();
+
+    setStatus(`The ${method} transaction sent`, 'ok');
+    showToast(`Sent ${method} for ${Utils.truncateHex(entry.id.bytes().toString('hex'))}`, 'success');
+    await refreshState();
+  } catch (err) {
+    setStatus(`The ${method} failed`, 'error');
+    // `execute` carries no role gate, so a 2000 raised during one comes from
+    // the target contract and must not be reported against the wallet's
+    // governor role.
+    const message = method === 'cancel' ? failureMessage(err, 'a council member') : err.message;
+    showToast(`The ${method} failed: ${message}`, 'error');
   }
 }
 

--- a/app/js/admin.js
+++ b/app/js/admin.js
@@ -1,4 +1,4 @@
-import { contract } from '@stellar/stellar-sdk';
+import { contract, nativeToScVal } from '@stellar/stellar-sdk';
 import { client, initializeRuntime, bootnodeRequired, ensureStorage, deriveAspUserLeaf } from './wasm-facade.js';
 import { connectWallet, getWalletNetwork, signWalletAuthEntry, signWalletTransaction } from './wallet.js';
 import { isDbLockedError, showDbLockedModal } from './db-locked.js';
@@ -40,10 +40,7 @@ const state = {
   networkPassphrase: null,
   rpcUrl: null,
   contracts: null,
-  membershipClient: null,
-  nonMembershipClient: null,
-  membershipClientId: null,
-  nonMembershipClientId: null,
+  governorClient: null,
   cryptoReady: false,
 };
 
@@ -157,34 +154,30 @@ function buildSigner() {
   };
 }
 
-async function getMembershipClient(contractId) {
-  if (state.membershipClient && state.membershipClientId === contractId) return state.membershipClient;
-  const signer = buildSigner();
-  state.membershipClient = await contract.Client.from({
-    rpcUrl: state.rpcUrl,
-    networkPassphrase: state.networkPassphrase,
-    publicKey: state.address,
-    signTransaction: signer.signTransaction,
-    signAuthEntry: signer.signAuthEntry,
-    contractId,
-  });
-  state.membershipClientId = contractId;
-  return state.membershipClient;
+function governorId() {
+  return client().contractConfig().governance?.governor ?? null;
 }
 
-async function getNonMembershipClient(contractId) {
-  if (state.nonMembershipClient && state.nonMembershipClientId === contractId) return state.nonMembershipClient;
+async function getGovernorClient() {
+  if (state.governorClient) return state.governorClient;
   const signer = buildSigner();
-  state.nonMembershipClient = await contract.Client.from({
+  state.governorClient = await contract.Client.from({
     rpcUrl: state.rpcUrl,
     networkPassphrase: state.networkPassphrase,
     publicKey: state.address,
     signTransaction: signer.signTransaction,
     signAuthEntry: signer.signAuthEntry,
-    contractId,
+    contractId: governorId(),
   });
-  state.nonMembershipClientId = contractId;
-  return state.nonMembershipClient;
+  return state.governorClient;
+}
+
+const u256 = (value) => nativeToScVal(value, { type: 'u256' });
+
+function failureMessage(err) {
+  return /Error\(Contract, #2000\)/.test(err.message)
+    ? 'the connected wallet is not an operator'
+    : err.message;
 }
 
 async function ensureCryptoReady() {
@@ -249,6 +242,14 @@ async function connect() {
     connectBtn.classList.remove('bg-[linear-gradient(135deg,#74c5ff,#2f6dff)]', 'text-ink-950');
     connectBtn.classList.add('bg-white/[0.05]', 'text-slate-100');
 
+    state.governorClient = null;
+    showToast(`Connected: ${shortAddress(address)}`, 'success');
+
+    if (!governorId()) {
+      setStatus('This deployment has no governor', 'error');
+      return;
+    }
+
     // Enable Action Buttons & remove tooltips
     const actionBtns = [addToAllowlistBtn, addToBlocklistBtn, removeFromBlocklistBtn];
     actionBtns.forEach(btn => {
@@ -256,12 +257,7 @@ async function connect() {
       btn.removeAttribute('title');
     });
 
-    state.membershipClient = null;
-    state.nonMembershipClient = null;
-
     setStatus('Wallet connected', 'ok');
-    showToast(`Connected: ${shortAddress(address)}`, 'success');
-
   } catch (err) {
     if (err.code === 'USER_REJECTED') {
       setStatus('Connection cancelled', 'info');
@@ -276,8 +272,7 @@ function disconnect() {
   state.address = null;
   state.networkPassphrase = null;
   state.rpcUrl = null;
-  state.membershipClient = null;
-  state.nonMembershipClient = null;
+  state.governorClient = null;
 
   walletChip.textContent = 'Connect Freighter';
   connectBtn.removeAttribute('title');
@@ -362,8 +357,13 @@ async function insertMembershipLeaf() {
     const leafHex = await deriveAspUserLeaf(notePublicKey, aspSecret);
     const leafValue = BigInt(leafHex);
 
-    const mClient = await getMembershipClient(contractId);
-    const tx = await mClient.insert_leaf({ leaf: leafValue });
+    const gov = await getGovernorClient();
+    const tx = await gov.execute_now({
+      target: contractId,
+      function: 'insert_leaf',
+      args: [u256(leafValue)],
+      caller: state.address,
+    });
     await tx.signAndSend();
 
     setStatus('The allowlist insert transaction sent', 'ok');
@@ -373,7 +373,7 @@ async function insertMembershipLeaf() {
     await refreshState();
   } catch (err) {
     setStatus('Allowlist insert failed', 'error');
-    showToast(`Allowlist insert failed: ${err.message}`, 'error');
+    showToast(`Allowlist insert failed: ${failureMessage(err)}`, 'error');
   } finally {
     if (state.address) addToAllowlistBtn.disabled = false;
     addToAllowlistBtn.textContent = originalText;
@@ -396,8 +396,13 @@ async function insertNonMembershipLeaf() {
     addToBlocklistBtn.textContent = 'Processing...';
 
     setStatus('Submitting blocklist insert transaction...', 'info');
-    const nmClient = await getNonMembershipClient(contractId);
-    const tx = await nmClient.insert_leaf({ key: keyValue, value: valueValue });
+    const gov = await getGovernorClient();
+    const tx = await gov.execute_now({
+      target: contractId,
+      function: 'insert_leaf',
+      args: [u256(keyValue), u256(valueValue)],
+      caller: state.address,
+    });
     await tx.signAndSend();
 
     setStatus('The blocklist insert transaction sent', 'ok');
@@ -406,7 +411,7 @@ async function insertNonMembershipLeaf() {
     await refreshState();
   } catch (err) {
     setStatus('Blocklist insert failed', 'error');
-    showToast(`Blocklist insert failed: ${err.message}`, 'error');
+    showToast(`Blocklist insert failed: ${failureMessage(err)}`, 'error');
   } finally {
     if (state.address) addToBlocklistBtn.disabled = false;
     addToBlocklistBtn.textContent = originalText;
@@ -427,8 +432,13 @@ async function removeNonMembershipLeaf() {
     removeFromBlocklistBtn.textContent = 'Processing...';
 
     setStatus('Submitting blocklist removal transaction...', 'info');
-    const nmClient = await getNonMembershipClient(contractId);
-    const tx = await nmClient.delete_leaf({ key: keyValue });
+    const gov = await getGovernorClient();
+    const tx = await gov.execute_now({
+      target: contractId,
+      function: 'delete_leaf',
+      args: [u256(keyValue)],
+      caller: state.address,
+    });
     await tx.signAndSend();
 
     setStatus('The blocklist removal transaction sent', 'ok');
@@ -437,7 +447,7 @@ async function removeNonMembershipLeaf() {
     await refreshState();
   } catch (err) {
     setStatus('User key removal from the blocklist failed', 'error');
-    showToast(`User key removal from the blocklist failed: ${err.message}`, 'error');
+    showToast(`User key removal from the blocklist failed: ${failureMessage(err)}`, 'error');
   } finally {
     if (state.address) removeFromBlocklistBtn.disabled = false;
     removeFromBlocklistBtn.textContent = originalText;

--- a/sdk/native/src/client.rs
+++ b/sdk/native/src/client.rs
@@ -269,6 +269,7 @@ mod signer_is_note_owner_tests {
                 verifiers: Default::default(),
                 public_key_registry: String::new(),
                 pools: Vec::new(),
+                governance: None,
             },
             None,
         )

--- a/sdk/native/src/types/client.rs
+++ b/sdk/native/src/types/client.rs
@@ -130,6 +130,7 @@ mod split_tests {
                 verifiers: Default::default(),
                 public_key_registry: String::new(),
                 pools: Vec::new(),
+                governance: None,
             },
             pool_contract_id: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".into(),
             user_address: NoteOwnerAddress::new(user),

--- a/sdk/native/src/types/mod.rs
+++ b/sdk/native/src/types/mod.rs
@@ -44,6 +44,41 @@ pub struct ContractConfig {
     pub public_key_registry: String,
     /// Pool deployments (one per supported asset/token).
     pub pools: Vec<PoolConfigEntry>,
+    /// Governor addresses and delays, absent from a deployment that predates
+    /// the governor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub governance: Option<GovernanceConfig>,
+}
+
+/// Governor addresses and delays recorded in a deployment manifest.
+///
+/// The deploy script writes every field. The governor is a contract address,
+/// the four role holders and the keeper are the accounts the deployment named,
+/// and the four delays are counts of ledgers, the arguments the governor was
+/// constructed with.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GovernanceConfig {
+    /// Contract that administers the pools and the association set providers.
+    pub governor: String,
+    /// Account holding the council role.
+    pub council: String,
+    /// Account holding the operator role.
+    pub operator: String,
+    /// Account holding the guardian role.
+    pub guardian: String,
+    /// Account holding the recovery role.
+    pub recovery: String,
+    /// Account authorized to submit storage lifetime extensions.
+    pub ttl_keeper: String,
+    /// Ledgers a council operation waits before anyone may execute it.
+    pub delay: u32,
+    /// Ledgers a recovery operation waits.
+    pub recovery_delay: u32,
+    /// Ledgers a ready operation stays executable.
+    pub grace: u32,
+    /// Ledgers a guardian pause holds before the deadline it sets.
+    pub guardian_pause: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -663,5 +698,83 @@ mod pool_config_gvk_tests {
         assert_eq!(parsed.gvk_authority_pub_key, pool.gvk_authority_pub_key);
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod contract_config_governance_tests {
+    use super::*;
+
+    /// A deployment manifest with every field the SDK requires and no pools.
+    fn manifest(governance: &str) -> String {
+        format!(
+            r#"{{
+            "network": "testnet",
+            "deployer": "GDEPLOYER",
+            "admin": "GADMIN",
+            "asp_membership": "CASPMEM",
+            "asp_non_membership": "CASPNON",
+            "verifiers": {{"AB": "CVERIFIER"}},
+            "public_key_registry": "CREGISTRY",
+            "pools": []{governance}
+        }}"#
+        )
+    }
+
+    const GOVERNANCE_BLOCK: &str = r#",
+            "governance": {
+                "governor": "CGOVERNOR",
+                "council": "GCOUNCIL",
+                "operator": "GOPERATOR",
+                "guardian": "GGUARDIAN",
+                "recovery": "GRECOVERY",
+                "ttlKeeper": "GKEEPER",
+                "delay": 12,
+                "recoveryDelay": 20,
+                "grace": 5,
+                "guardianPause": 15
+            }"#;
+
+    #[test]
+    fn contract_config_round_trips_with_the_governance_block() -> Result<()> {
+        let config: ContractConfig = serde_json::from_str(&manifest(GOVERNANCE_BLOCK))?;
+        let governance = config
+            .governance
+            .as_ref()
+            .ok_or_else(|| anyhow!("governance block should parse"))?;
+        assert_eq!(governance.governor, "CGOVERNOR");
+        assert_eq!(governance.council, "GCOUNCIL");
+        assert_eq!(governance.ttl_keeper, "GKEEPER");
+        assert_eq!(governance.delay, 12);
+        assert_eq!(governance.recovery_delay, 20);
+        assert_eq!(governance.grace, 5);
+        assert_eq!(governance.guardian_pause, 15);
+
+        let round_tripped: ContractConfig = serde_json::from_str(&serde_json::to_string(&config)?)?;
+        assert_eq!(
+            round_tripped.governance.map(|g| g.governor),
+            Some("CGOVERNOR".to_owned())
+        );
+        Ok(())
+    }
+
+    /// A manifest written before the governor existed still parses, and
+    /// serializing it back leaves the block out.
+    #[test]
+    fn contract_config_parses_without_the_governance_block() -> Result<()> {
+        let config: ContractConfig = serde_json::from_str(&manifest(""))?;
+        assert!(config.governance.is_none());
+        assert!(!serde_json::to_string(&config)?.contains("governance"));
+        Ok(())
+    }
+
+    #[test]
+    fn a_governance_block_missing_the_keeper_fails_to_parse() {
+        let without_keeper = GOVERNANCE_BLOCK.replace("\"ttlKeeper\": \"GKEEPER\",\n", "");
+        assert_ne!(
+            without_keeper, GOVERNANCE_BLOCK,
+            "the keeper field should have been removed"
+        );
+        assert!(serde_json::from_str::<ContractConfig>(&manifest(&without_keeper)).is_err());
     }
 }

--- a/sdk/web/src/models/config.rs
+++ b/sdk/web/src/models/config.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 use stellar_private_payments::types::{
     AssetDescriptor as NativeAssetDescriptor, ContractConfig as NativeContractConfig,
-    PoolConfigEntry as NativePoolConfigEntry,
+    GovernanceConfig as NativeGovernanceConfig, PoolConfigEntry as NativePoolConfigEntry,
 };
 use wasm_bindgen::prelude::*;
 
@@ -152,6 +152,73 @@ impl From<NativePoolConfigEntry> for PoolConfigEntry {
     }
 }
 
+/// Governor addresses and delays recorded in the deployment manifest.
+#[wasm_bindgen]
+pub struct GovernanceConfig {
+    inner: NativeGovernanceConfig,
+}
+
+#[wasm_bindgen]
+impl GovernanceConfig {
+    #[wasm_bindgen(getter)]
+    pub fn governor(&self) -> String {
+        self.inner.governor.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn council(&self) -> String {
+        self.inner.council.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn operator(&self) -> String {
+        self.inner.operator.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn guardian(&self) -> String {
+        self.inner.guardian.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn recovery(&self) -> String {
+        self.inner.recovery.clone()
+    }
+
+    #[wasm_bindgen(getter, js_name = ttlKeeper)]
+    pub fn ttl_keeper(&self) -> String {
+        self.inner.ttl_keeper.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn delay(&self) -> u32 {
+        self.inner.delay
+    }
+
+    #[wasm_bindgen(getter, js_name = recoveryDelay)]
+    pub fn recovery_delay(&self) -> u32 {
+        self.inner.recovery_delay
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn grace(&self) -> u32 {
+        self.inner.grace
+    }
+
+    #[wasm_bindgen(getter, js_name = guardianPause)]
+    pub fn guardian_pause(&self) -> u32 {
+        self.inner.guardian_pause
+    }
+}
+
+impl From<&NativeGovernanceConfig> for GovernanceConfig {
+    fn from(inner: &NativeGovernanceConfig) -> Self {
+        Self {
+            inner: inner.clone(),
+        }
+    }
+}
+
 #[wasm_bindgen]
 pub struct ContractConfig {
     inner: NativeContractConfig,
@@ -207,6 +274,11 @@ impl ContractConfig {
             .cloned()
             .map(PoolConfigEntry::from)
             .collect()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn governance(&self) -> Option<GovernanceConfig> {
+        self.inner.governance.as_ref().map(GovernanceConfig::from)
     }
 
     /// Plain JSON object matching `deployments.json` (for round-trip input).


### PR DESCRIPTION
The manifest starts carrying the governor's addresses, and the admin page starts using them:
allowlist and blocklist writes go through the governor, and two new panels drive pause and the
queue.

## The manifest block

`ContractConfig` gains a `governance` block holding the governor's id, the four role addresses,
the four delays, and the TTL keeper's address. The native type carries it as an
`Option<GovernanceConfig>`, so a manifest written before this change still decodes and a
deployment without a governor serializes no new key.

The browser `ContractConfig` exposes it through a `governance` getter returning a
`GovernanceConfig` class. It is a getter rather than a field read through `toJSON()` on purpose:
wasm-bindgen writes the npm package's TypeScript declarations from the hand-written getters, and
a page reading fields through `toJSON()` would get `any` where every other field is typed.

This is the breaking change in the PR. The public SDK type gains a variant that consumers
matching exhaustively on the manifest shape will see.

## Allowlist and blocklist writes

`insertMembershipLeaf`, `insertNonMembershipLeaf`, and `removeNonMembershipLeaf` now call
`gov.execute_now({ target, function, args, caller })` instead of the ASP clients, and the two
ASP client helpers are deleted along with their fields on `state`. The governor's `args` is
`Vec<Val>`, so arguments are built as `ScVal` with `nativeToScVal`. Freighter signs the caller's
auth entry exactly as it does today.

A manifest with no `governance` block leaves the three write buttons disabled after connect and
sets a status line saying the deployment has no governor. A wallet without the operator role
gets `Error(Contract, #2000)` from the governor, mapped to a message naming the role rather than
shown as a raw code.

## The pause and queue panels

Two sections after the blocklist section. The pause panel has a row per target, every enabled
pool from the manifest plus both ASPs, showing flags and `until` with per-row pause and unpause
buttons. The queue panel lists pending operations with id, target, function, ready ledger, and
state, with per-row execute and cancel.

Two details in here are the result of getting them wrong first:

The pause row reports what the contract reports. It previously read "not supported by this
deployment" when `pause` was absent, but a contract writes its pause entry only on the first
pause, so that string appeared on every healthy target and read as though pause were
unavailable during the one incident the panel exists for. The read cannot separate a
never-paused contract from one deployed before the key existed, so the row shows flags `0`.

The queue reads its arguments from the raw simulation result rather than from the generated
client's decode. `args` is `Vec<Val>`, whose element type the contract spec cannot describe, so
decoding and re-encoding turns an `Address` into `scvString` and a `u256` into `scvU64`. The
governor hashes an operation over its arguments, so `execute` and `cancel` would have named an
operation that is not in the queue.

The panel also rejects a zero pause mask before submitting. `check_flags` refuses a zero mask
with `InvalidFlags`, and the field previously validated only that the input parsed and fit in 32
bits, so an operator submitting an empty mask during an incident got a raw contract error
instead of a message naming the field.

## Ship order

The admin page refuses a manifest with no `governance` block, so this PR wants the testnet
redeploy behind it. Merge it, redeploy with the governance flags, and land the regenerated
manifest in its own PR.

## What cannot be checked from the browser

The council is a 3-of-5 native account, so it cannot be a Freighter source. Pausing from the
guardian key works in the page; cancel, unpause, and execute are exercised from the CLI in the
testnet ceremony instead.

Part of #372.
