### PR TITLE
Add the ttl-keeper service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2883,6 +2883,7 @@ name = "governor"
 version = "0.1.0"
 dependencies = [
  "asp-membership",
+ "hex",
  "soroban-sdk",
  "soroban-utils",
  "stellar-access",
@@ -6685,6 +6686,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ttl-keeper"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "hex",
+ "serde",
+ "serde_json",
+ "stellar-private-payments",
+ "stellar-xdr",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "twox-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "sdk/web",
     "tools/ceremony-cli",
     "tools/circuit-compiler",
+    "tools/ttl-keeper",
 ]
 exclude = ["tools/bootnode"]
 resolver = "3"
@@ -85,6 +86,7 @@ stellar-access = { git = "https://github.com/OpenZeppelin/stellar-contracts", re
 stellar-governance = { git = "https://github.com/OpenZeppelin/stellar-contracts", rev = "9c5e279aa7efabf94ef84fdef29497ff13656e9d", default-features = false }
 stellar-macros = { git = "https://github.com/OpenZeppelin/stellar-contracts", rev = "9c5e279aa7efabf94ef84fdef29497ff13656e9d", default-features = false }
 stellar-private-payments = { path = "sdk/native", version = "0.1.0" }
+stellar-xdr = { version = "27.0.0", features = ["serde", "base64", "std", "alloc"] }
 taceo-poseidon2 = { version = "0.3", default-features = false, features = ["bn254", "t2", "t3", "t4"] }
 thiserror = { version = "2", default-features = false }
 time = { version = "0.3.54", default-features = false, features = ["formatting", "std"] }

--- a/contracts/governor/Cargo.toml
+++ b/contracts/governor/Cargo.toml
@@ -25,6 +25,7 @@ stellar-macros = { workspace = true }
 asp-membership = { workspace = true }
 
 # external
+hex = { workspace = true }
 soroban-sdk = { workspace = true, features = ["testutils"] }
 
 [lints]

--- a/contracts/governor/src/test.rs
+++ b/contracts/governor/src/test.rs
@@ -1,15 +1,18 @@
 #![cfg(test)]
 
+extern crate alloc;
+
 use super::*;
 use asp_membership::{ASPMembership, ASPMembershipClient};
 use soroban_sdk::{
-    Address, BytesN, Env, IntoVal, InvokeError, Symbol, U256, Val, Vec,
+    Address, Bytes, BytesN, Env, IntoVal, InvokeError, Symbol, U256, Val, Vec,
     events::Event,
     testutils::{
         Address as _, Events, Ledger as _, MockAuth, MockAuthInvoke,
         storage::{Instance as _, Persistent as _},
     },
-    vec, xdr,
+    vec,
+    xdr::{self, ToXdr},
 };
 use soroban_utils::{
     pausable::{MUTATIONS, PauseState},
@@ -506,6 +509,104 @@ fn the_constructor_extends_the_ttl_of_the_role_entries() {
             EXTEND_TO
         );
     });
+}
+
+/// The governor's storage keys as OpenZeppelin encodes them, in lowercase
+/// hexadecimal XDR.
+///
+/// The same five constants appear in `tools/ttl-keeper/src/keys.rs`, which
+/// rebuilds these keys from their variant names alone because it cannot depend
+/// on the key types. The pair of tests is what ties those names to this
+/// contract: a rename upstream fails the test below, and a wrong name in the
+/// keeper fails the keeper's own.
+const EXISTING_ROLES_XDR: &str = concat!(
+    "0000001000000001000000010000000f0000000d4578697374696e67526f6c65",
+    "73000000",
+);
+const HAS_ROLE_XDR: &str = concat!(
+    "0000001000000001000000030000000f00000007486173526f6c650000000012",
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    "00000000000000000000000f00000008677561726469616e",
+);
+const ROLE_ACCOUNTS_COUNT_XDR: &str = concat!(
+    "0000001000000001000000020000000f00000011526f6c654163636f756e7473",
+    "436f756e740000000000000f00000008677561726469616e",
+);
+const ROLE_ACCOUNTS_XDR: &str = concat!(
+    "0000001000000001000000020000000f0000000c526f6c654163636f756e7473",
+    "0000001100000001000000020000000f00000005696e64657800000000000003",
+    "000000000000000f00000004726f6c650000000f00000008677561726469616e",
+);
+const OPERATION_LEDGER_XDR: &str = concat!(
+    "0000001000000001000000020000000f0000000f4f7065726174696f6e4c6564",
+    "676572000000000d000000200707070707070707070707070707070707070707",
+    "070707070707070707070707",
+);
+
+/// The role holder the pinned `HasRole` and `RoleAccounts` keys name.
+const PINNED_HOLDER: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+/// Asserts that `key` encodes to `expected`, given as lowercase hexadecimal.
+#[track_caller]
+fn assert_key_xdr(env: &Env, key: impl IntoVal<Env, Val>, expected: &str) {
+    assert_eq!(xdr_hex(&key.to_xdr(env)), expected);
+}
+
+/// Returns `bytes` as lowercase hexadecimal.
+fn xdr_hex(bytes: &Bytes) -> alloc::string::String {
+    let len = usize::try_from(bytes.len()).expect("a key shorter than the address space");
+    let mut raw = [0u8; 256];
+    let raw = raw.get_mut(..len).expect("a key under 256 bytes");
+    bytes.copy_into_slice(raw);
+    hex::encode(raw)
+}
+
+#[test]
+fn the_openzeppelin_storage_keys_encode_as_the_keeper_expects() {
+    let env = test_env();
+    let holder = Address::from_str(&env, PINNED_HOLDER);
+    let operation = BytesN::from_array(&env, &[7u8; 32]);
+
+    assert_key_xdr(
+        &env,
+        access::AccessControlStorageKey::ExistingRoles,
+        EXISTING_ROLES_XDR,
+    );
+    assert_key_xdr(
+        &env,
+        access::AccessControlStorageKey::HasRole(holder, GUARDIAN),
+        HAS_ROLE_XDR,
+    );
+    assert_key_xdr(
+        &env,
+        access::AccessControlStorageKey::RoleAccountsCount(GUARDIAN),
+        ROLE_ACCOUNTS_COUNT_XDR,
+    );
+    assert_key_xdr(
+        &env,
+        timelock::TimelockStorageKey::OperationLedger(operation),
+        OPERATION_LEDGER_XDR,
+    );
+}
+
+/// `RoleAccounts` is the one key of the five whose type the access control
+/// module keeps private, so this reads it out of the footprint a constructed
+/// governor leaves behind rather than naming it. The key holds the role and the
+/// index and not the holder, which is what lets it match a fixed encoding.
+#[test]
+fn the_role_enumeration_key_encodes_as_the_keeper_expects() {
+    let env = test_env();
+    let s = setup(&env);
+
+    let found = env.as_contract(&s.governor, || {
+        env.storage()
+            .persistent()
+            .all()
+            .keys()
+            .iter()
+            .any(|key| xdr_hex(&key.to_xdr(&env)) == ROLE_ACCOUNTS_XDR)
+    });
+    assert!(found, "the guardian's enumeration slot is in the footprint");
 }
 
 // ------------------------------------------------------------------- schedule

--- a/sdk/native/Cargo.toml
+++ b/sdk/native/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = { workspace = true, features = ["alloc"] }
 sha2 = { workspace = true }
 sha3 = { version = "0.11", default-features = false }
 stellar-strkey = "0.0.18"
-stellar-xdr = { version = "27.0.0", features = ["serde", "base64", "std", "alloc"] }
+stellar-xdr.workspace = true
 thiserror = { workspace = true }
 time = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }

--- a/sdk/native/src/chain/rpc.rs
+++ b/sdk/native/src/chain/rpc.rs
@@ -193,6 +193,13 @@ pub struct LedgerEntryResult {
     pub xdr: String,
     #[serde(rename = "lastModifiedLedgerSeq")]
     pub last_modified_ledger: u32,
+    /// Last ledger at which the entry is still live.
+    ///
+    /// The RPC omits the field for entries that never expire, such as classic
+    /// ledger entries, and sets it to `0` for an archived entry. An archived
+    /// entry is returned; a key that was never written is not.
+    #[serde(rename = "liveUntilLedgerSeq", default)]
+    pub live_until_ledger_seq: Option<u32>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -860,6 +867,33 @@ mod tests {
             .find(|(_, name, _)| *name == "Root")
             .expect("Root spec");
         assert!(root.2);
+    }
+
+    #[test]
+    fn live_until_ledger_seq_decodes_when_present_zero_absent_or_null() {
+        let decode = |entry: serde_json::Value| {
+            serde_json::from_value::<LedgerEntryResult>(entry).expect("entry")
+        };
+        let base = json!({
+            "key": "AAAA",
+            "xdr": "BBBB",
+            "lastModifiedLedgerSeq": 12,
+        });
+
+        let mut present = base.clone();
+        present["liveUntilLedgerSeq"] = json!(3_110_400_u32);
+        assert_eq!(decode(present).live_until_ledger_seq, Some(3_110_400));
+
+        // The RPC's placeholder for an archived entry.
+        let mut archived = base.clone();
+        archived["liveUntilLedgerSeq"] = json!(0);
+        assert_eq!(decode(archived).live_until_ledger_seq, Some(0));
+
+        assert_eq!(decode(base.clone()).live_until_ledger_seq, None);
+
+        let mut null = base;
+        null["liveUntilLedgerSeq"] = json!(null);
+        assert_eq!(decode(null).live_until_ledger_seq, None);
     }
 
     #[test]

--- a/tools/ttl-keeper/Cargo.toml
+++ b/tools/ttl-keeper/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "ttl-keeper"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[[bin]]
+name = "ttl-keeper"
+path = "src/main.rs"
+
+[dependencies]
+# workspace
+stellar-private-payments.workspace = true
+
+# external
+anyhow.workspace = true
+clap.workspace = true
+hex.workspace = true
+serde = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
+stellar-xdr.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+
+[lints]
+workspace = true

--- a/tools/ttl-keeper/README.md
+++ b/tools/ttl-keeper/README.md
@@ -1,0 +1,102 @@
+# ttl-keeper
+
+Soroban archives persistent contract data that nobody touches. This service walks a
+deployment's ledger entries on a schedule, extends the lifetime of anything close to expiry,
+and restores what has already been archived.
+
+Every transaction follows from what the RPC reports. `getLedgerEntries` returns an archived
+entry with a `liveUntilLedgerSeq` of `0` and leaves out a key that was never written, so the
+keeper restores exactly the keys reported archived, extends the live keys inside the
+threshold, and never names a key the RPC did not return. It keeps no list of which keys a
+contract writes only under some conditions; the pause state, the governor's queue index, and
+the permission table rows are enumerated like every other key and come back when the RPC says
+they are gone. An archived pause entry does not reopen a pool: a call whose footprint touches
+it fails until the entry is restored, which the SDK does for the next user and the keeper
+does on its next round.
+
+The RPC has reported entry state this way since protocol 23. The keeper refuses to start
+against an older one, because such an RPC omits archived entries the way it omits never
+written ones and nothing would ever be restored.
+
+## Run it
+
+```bash
+TTL_KEEPER_SECRET=S... cargo run -p ttl-keeper -- \
+  --deployment deployments/testnet/deployments.json \
+  --rpc-url https://soroban-testnet.stellar.org \
+  --bootnode-url https://bootnode.example.com \
+  --state-file keeper-state.json
+```
+
+That runs one round an hour. Pass `--once` to run a single round and exit, which is what a
+cron job or a one-off check wants. Pass `--dry-run` to measure, log every key the round would
+restore or extend, and exit without submitting anything, which is what a new manifest or a
+new RPC endpoint wants first.
+
+The defaults extend an entry once fewer than 518,400 ledgers remain, ask for one ledger below
+the network's maximum entry lifetime, and put at most 100 keys in one transaction. The keeper
+reads that maximum from the state archival settings each round, because the network rejects
+an extension to the maximum itself and the simulation does not. `--threshold-ledgers`,
+`--extend-to-ledgers`, and `--batch` change those; a target above the cap is lowered to it.
+`--interval-secs` changes the gap between rounds.
+
+## What it needs
+
+A funded Stellar account, whose address the deployment manifest records as
+`governance.ttlKeeper`. The account pays the resource fee for every extension and restore, so
+it needs a balance that covers a round at the interval you choose. `--keeper-secret-env`
+names the environment variable holding its secret key; the key is never read from a flag or a
+file.
+
+The keeper reads pool events through the bootnode first, because public RPC keeps events for
+about a week and a pool's history is longer than that. It falls back to the RPC endpoint when
+the bootnode refuses a range.
+
+## The state file
+
+Nullifier ledger entries cannot be derived from the manifest, so the keeper accumulates them
+from the `new_nullifier_event` a pool publishes on every spend. `--state-file` holds those
+nullifiers and the event cursor the next round resumes from:
+
+```json
+{
+  "cursor": "0004669736471235-0000000000",
+  "nullifiers": {
+    "CBQH...": ["1f8a...", "77c2..."]
+  }
+}
+```
+
+The file is written through a temporary file and a rename, so a round that dies mid-write
+leaves either the previous state or the new one. Delete it to re-read every pool's events
+from its deployment ledger.
+
+## What it does not do
+
+The keeper touches only the keys it can enumerate, which are the ones the manifest names plus
+the ones a contract's own state reveals: the pool root ring, the association set trees, the
+governor's queue, and the role table for the four roles in the governance block.
+
+A permission table row added after deployment is not one of those. Until the manifest names
+its target and function, that row stays alive only through use, and a row nobody calls for
+long enough is archived. The same holds for any contract added to the deployment without
+being written into the manifest.
+
+The non-membership tree's nodes are named only inside their parents' stored values, so the
+walk cannot descend past an archived node. A subtree archived several levels deep is restored
+one level per round, which at the default interval is one hour per level.
+
+The public key registry is the largest gap. The keeper extends the registry's contract
+instance and its wasm, but not the `Registration(address)` entry each user writes when they
+publish their keys, because those addresses appear only in the registry's own events and the
+keeper does not read them. `contracts/public-key-registry` bumps no lifetimes of its own
+either, so a registration that goes untouched for the archival window is lost and the user
+has to register again. Until the keeper pages those events, a deployment with real users
+needs its own job for that contract.
+
+A restore and an extend are independent phases. A restore that fails, for want of fee or
+balance or an RPC that is down, is logged and counted, and the extend phase still runs; the
+round reports the first error once both have finished.
+
+The keeper never changes contract state. Its transactions carry one `ExtendFootprintTtl` or
+`RestoreFootprint` operation and nothing else.

--- a/tools/ttl-keeper/src/keys.rs
+++ b/tools/ttl-keeper/src/keys.rs
@@ -1,0 +1,1011 @@
+//! Ledger keys the keeper measures, restores, and extends.
+//!
+//! Every key is derived from the deployment manifest, from a contract's own
+//! stored state, or from the pool events that record spent nullifiers. A key
+//! this module cannot enumerate is one the keeper never touches.
+//!
+//! Enumeration is exhaustive rather than exact: every root ring slot, every
+//! role holder the manifest names, and every pause entry is listed whether or
+//! not the contract has written it. The RPC reports which of them exist, so a
+//! key that was never written costs one slot in a read and nothing else.
+
+use anyhow::{Context, Result, anyhow, bail};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    str::FromStr,
+};
+use stellar_private_payments::{
+    chain::Client,
+    types::{ContractConfig, GovernanceConfig},
+};
+use stellar_xdr::{self as xdr, LedgerKey, Limits, ReadXdr, WriteXdr};
+
+/// First topic of the event a pool publishes when a nullifier is spent.
+const NULLIFIER_EVENT: &str = "new_nullifier_event";
+
+/// Historical roots a pool keeps before overwriting the oldest.
+const ROOT_HISTORY_SIZE: u32 = 90;
+
+/// Events read from the RPC in one page.
+const EVENT_PAGE_SIZE: usize = 200;
+
+/// Keys the RPC accepts in one `getLedgerEntries` call.
+pub const LEDGER_KEY_CHUNK: usize = 200;
+
+/// Roles the governor's access control table holds.
+const ROLES: [&str; 4] = ["council", "operator", "guardian", "recovery"];
+
+/// Parses a contract or account address into its XDR form.
+///
+/// # Errors
+///
+/// Returns an error if `address` is not a valid strkey.
+pub fn address(address: &str) -> Result<xdr::ScAddress> {
+    xdr::ScAddress::from_str(address).with_context(|| format!("invalid address {address}"))
+}
+
+fn symbol(name: &str) -> Result<xdr::ScVal> {
+    Ok(xdr::ScVal::Symbol(
+        xdr::ScSymbol::try_from(name).map_err(|_| anyhow!("invalid symbol {name}"))?,
+    ))
+}
+
+/// Builds the persistent contract-data key a storage enum variant occupies.
+///
+/// `parts` holds the variant's arguments, in declaration order. A variant with
+/// no arguments passes an empty slice.
+///
+/// # Errors
+///
+/// Returns an error if `variant` is too long to be a Soroban symbol.
+pub fn data_key(
+    contract: &xdr::ScAddress,
+    variant: &str,
+    parts: Vec<xdr::ScVal>,
+) -> Result<LedgerKey> {
+    let mut fields = Vec::with_capacity(parts.len().saturating_add(1));
+    fields.push(symbol(variant)?);
+    fields.extend(parts);
+    Ok(LedgerKey::ContractData(xdr::LedgerKeyContractData {
+        contract: contract.clone(),
+        key: xdr::ScVal::Vec(Some(xdr::ScVec::try_from(fields)?)),
+        durability: xdr::ContractDataDurability::Persistent,
+    }))
+}
+
+/// Builds the key of a contract's instance entry.
+pub fn instance_key(contract: &xdr::ScAddress) -> LedgerKey {
+    LedgerKey::ContractData(xdr::LedgerKeyContractData {
+        contract: contract.clone(),
+        key: xdr::ScVal::LedgerKeyContractInstance,
+        durability: xdr::ContractDataDurability::Persistent,
+    })
+}
+
+/// Builds the key of the wasm a contract instance runs.
+pub fn code_key(wasm_hash: xdr::Hash) -> LedgerKey {
+    LedgerKey::ContractCode(xdr::LedgerKeyContractCode { hash: wasm_hash })
+}
+
+/// Converts 32 big-endian bytes into the four parts of an XDR `u256`.
+///
+/// # Panics
+///
+/// Panics if a fixed slice of the 32-byte input is not eight bytes, which the
+/// array's own length rules out.
+pub fn u256(bytes: [u8; 32]) -> xdr::ScVal {
+    xdr::ScVal::U256(xdr::UInt256Parts {
+        hi_hi: u64::from_be_bytes(bytes[0..8].try_into().expect("u256 hi_hi slice")),
+        hi_lo: u64::from_be_bytes(bytes[8..16].try_into().expect("u256 hi_lo slice")),
+        lo_hi: u64::from_be_bytes(bytes[16..24].try_into().expect("u256 lo_hi slice")),
+        lo_lo: u64::from_be_bytes(bytes[24..32].try_into().expect("u256 lo_lo slice")),
+    })
+}
+
+/// Converts an XDR `u256` back into 32 big-endian bytes.
+///
+/// # Errors
+///
+/// Returns an error if `value` is not a `u256`.
+pub fn u256_bytes(value: &xdr::ScVal) -> Result<[u8; 32]> {
+    let xdr::ScVal::U256(parts) = value else {
+        bail!("expected a u256 value");
+    };
+    let mut out = [0u8; 32];
+    for (chunk, part) in
+        out.chunks_exact_mut(8)
+            .zip([parts.hi_hi, parts.hi_lo, parts.lo_hi, parts.lo_lo])
+    {
+        chunk.copy_from_slice(&part.to_be_bytes());
+    }
+    Ok(out)
+}
+
+fn hex_to_bytes(text: &str) -> Result<[u8; 32]> {
+    let mut out = [0u8; 32];
+    hex::decode_to_slice(text.strip_prefix("0x").unwrap_or(text), &mut out)
+        .context("expected 64 hexadecimal digits")?;
+    Ok(out)
+}
+
+/// Renders 32 bytes as lowercase hexadecimal without a prefix.
+pub fn bytes_to_hex(bytes: &[u8; 32]) -> String {
+    hex::encode(bytes)
+}
+
+/// Returns every key a pool contract owns, apart from its instance and wasm.
+///
+/// The root ring is enumerated in full rather than up to the current index,
+/// because an unwritten slot is absent from the response and a written one
+/// must stay live for proof verification against a recent root.
+///
+/// # Errors
+///
+/// Returns an error if a nullifier is not 32 bytes of hexadecimal.
+pub fn pool_keys(
+    contract: &xdr::ScAddress,
+    levels: u32,
+    nullifiers: &BTreeSet<String>,
+) -> Result<Vec<LedgerKey>> {
+    const ENUM_KEYS: [&str; 13] = [
+        "Admin",
+        "Token",
+        "Verifier",
+        "ASPMembership",
+        "ASPNonMembership",
+        "Levels",
+        "CurrentRootIndex",
+        "NextIndex",
+        "MaximumDepositAmount",
+        "PolicyFlags",
+        "AdminViewKey",
+        "GvkMode",
+        "Pause",
+    ];
+
+    let mut keys = Vec::new();
+    for variant in ENUM_KEYS {
+        keys.push(data_key(contract, variant, vec![])?);
+    }
+    for level in 0..=levels {
+        keys.push(data_key(
+            contract,
+            "FilledSubtree",
+            vec![xdr::ScVal::U32(level)],
+        )?);
+        keys.push(data_key(contract, "Zeroes", vec![xdr::ScVal::U32(level)])?);
+    }
+    for index in 0..ROOT_HISTORY_SIZE {
+        keys.push(data_key(contract, "Root", vec![xdr::ScVal::U32(index)])?);
+    }
+    for nullifier in nullifiers {
+        keys.push(data_key(
+            contract,
+            "Nullifier",
+            vec![u256(hex_to_bytes(nullifier)?)],
+        )?);
+    }
+    Ok(keys)
+}
+
+/// Returns every key the membership association set owns.
+///
+/// # Errors
+///
+/// Returns an error if a key cannot be encoded.
+pub fn membership_keys(contract: &xdr::ScAddress, levels: u32) -> Result<Vec<LedgerKey>> {
+    let mut keys = Vec::new();
+    for variant in ["Admin", "Levels", "NextIndex", "Root", "Pause"] {
+        keys.push(data_key(contract, variant, vec![])?);
+    }
+    for level in 0..=levels {
+        keys.push(data_key(
+            contract,
+            "FilledSubtrees",
+            vec![xdr::ScVal::U32(level)],
+        )?);
+        keys.push(data_key(contract, "Zeroes", vec![xdr::ScVal::U32(level)])?);
+    }
+    Ok(keys)
+}
+
+/// Returns every key the non-membership association set owns.
+///
+/// `nodes` comes from [`walk_sparse_tree`], because the sparse tree's node
+/// hashes exist only in its own stored values.
+///
+/// # Errors
+///
+/// Returns an error if a key cannot be encoded.
+pub fn non_membership_keys(
+    contract: &xdr::ScAddress,
+    nodes: &[[u8; 32]],
+) -> Result<Vec<LedgerKey>> {
+    let mut keys = Vec::new();
+    for variant in ["Admin", "Root", "Pause"] {
+        keys.push(data_key(contract, variant, vec![])?);
+    }
+    for node in nodes {
+        keys.push(data_key(contract, "Node", vec![u256(*node)])?);
+    }
+    Ok(keys)
+}
+
+/// Returns the child hashes a sparse-tree node's stored value names.
+///
+/// An internal node holds the two hashes of its children. A leaf holds three
+/// elements and has no children. The zero hash marks an empty subtree and is
+/// not a node.
+///
+/// # Errors
+///
+/// Returns an error if the value is neither a two-element nor a three-element
+/// vector of `u256`.
+pub fn node_children(value: &xdr::ScVal) -> Result<Vec<[u8; 32]>> {
+    let xdr::ScVal::Vec(Some(elements)) = value else {
+        bail!("expected a sparse tree node vector");
+    };
+    match elements.len() {
+        3 => Ok(Vec::new()),
+        2 => {
+            let mut children = Vec::new();
+            for element in elements.iter() {
+                let child = u256_bytes(element)?;
+                if child != [0u8; 32] {
+                    children.push(child);
+                }
+            }
+            Ok(children)
+        }
+        n => bail!("expected 2 or 3 elements in a sparse tree node, got {n}"),
+    }
+}
+
+/// Returns every node reachable from `root`, without repeats.
+///
+/// `children` maps a node hash to the hashes its value names. A hash absent
+/// from the map is a node whose value was never stored, and ends that branch.
+pub fn walk_sparse_tree(
+    root: [u8; 32],
+    children: &BTreeMap<[u8; 32], Vec<[u8; 32]>>,
+) -> Vec<[u8; 32]> {
+    if root == [0u8; 32] {
+        return Vec::new();
+    }
+    let mut seen = BTreeSet::new();
+    let mut frontier = vec![root];
+    let mut visited = Vec::new();
+
+    while let Some(node) = frontier.pop() {
+        if !seen.insert(node) {
+            continue;
+        }
+        visited.push(node);
+        if let Some(kids) = children.get(&node) {
+            frontier.extend(kids.iter().filter(|k| **k != [0u8; 32]));
+        }
+    }
+    visited
+}
+
+/// Returns every key the governor owns for the roles and rows the manifest
+/// implies.
+///
+/// `operations` names the queued operations, and `functions` the permission
+/// table rows as pairs of target address and function name.
+///
+/// # Errors
+///
+/// Returns an error if an address in the governance block is not a valid
+/// strkey.
+pub fn governor_keys(
+    governance: &GovernanceConfig,
+    operations: &[[u8; 32]],
+    functions: &[(String, String)],
+    role_members: &[(String, u32)],
+) -> Result<Vec<LedgerKey>> {
+    let governor = address(&governance.governor)?;
+    let mut keys = vec![
+        data_key(&governor, "Pending", vec![])?,
+        // Written once when the governor is constructed, and touched again
+        // only on a role change, which makes it the entry most likely to be
+        // archived first.
+        data_key(&governor, "ExistingRoles", vec![])?,
+    ];
+
+    for id in operations {
+        let bytes = xdr::ScVal::Bytes(xdr::ScBytes(id.to_vec().try_into()?));
+        keys.push(data_key(&governor, "Operation", vec![bytes.clone()])?);
+        // The OpenZeppelin timelock keeps the ready ledger under its own key,
+        // so an operation whose lifetime is extended only here is half alive.
+        keys.push(data_key(&governor, "OperationLedger", vec![bytes])?);
+    }
+    for (target, function) in functions {
+        keys.push(data_key(
+            &governor,
+            "FnRole",
+            vec![xdr::ScVal::Address(address(target)?), symbol(function)?],
+        )?);
+    }
+
+    let holders = [
+        (&governance.council, "council"),
+        (&governance.operator, "operator"),
+        (&governance.guardian, "guardian"),
+        (&governance.recovery, "recovery"),
+    ];
+    for (holder, role) in holders {
+        keys.push(data_key(
+            &governor,
+            "HasRole",
+            vec![xdr::ScVal::Address(address(holder)?), symbol(role)?],
+        )?);
+    }
+    for role in ROLES {
+        keys.push(data_key(
+            &governor,
+            "RoleAccountsCount",
+            vec![symbol(role)?],
+        )?);
+    }
+    for (role, count) in role_members {
+        for index in 0..*count {
+            keys.push(data_key(
+                &governor,
+                "RoleAccounts",
+                vec![role_account_key(role, index)?],
+            )?);
+        }
+    }
+    Ok(keys)
+}
+
+/// Builds the `RoleAccountKey` struct value that indexes one role holder.
+///
+/// An `ScMap` is ordered by key symbol, so `index` precedes `role` however the
+/// struct itself declares them.
+///
+/// # Errors
+///
+/// Returns an error if `role` is too long to be a Soroban symbol.
+fn role_account_key(role: &str, index: u32) -> Result<xdr::ScVal> {
+    let field = |name: &str, value: xdr::ScVal| -> Result<xdr::ScMapEntry> {
+        Ok(xdr::ScMapEntry {
+            key: symbol(name)?,
+            val: value,
+        })
+    };
+    Ok(xdr::ScVal::Map(Some(xdr::ScMap::try_from(vec![
+        field("index", xdr::ScVal::U32(index))?,
+        field("role", symbol(role)?)?,
+    ])?)))
+}
+
+/// Returns the permission table rows the manifest implies.
+///
+/// The governor administers association set writes, so the rows it needs are
+/// the two association sets' mutating entry points.
+pub fn permission_rows(config: &ContractConfig) -> Vec<(String, String)> {
+    vec![
+        (config.asp_membership.clone(), "insert_leaf".to_owned()),
+        (config.asp_non_membership.clone(), "insert_leaf".to_owned()),
+        (config.asp_non_membership.clone(), "delete_leaf".to_owned()),
+    ]
+}
+
+/// Returns the nullifier a pool event records, or `None` for another event.
+///
+/// # Errors
+///
+/// Returns an error if the event names a nullifier that is not a `u256`.
+pub fn nullifier_from_event(topics: &[String]) -> Result<Option<[u8; 32]>> {
+    let decode = |b64: &String| -> Result<xdr::ScVal> {
+        xdr::ScVal::from_xdr_base64(b64, Limits::none()).context("decode event topic")
+    };
+    let Some(name) = topics.first().map(decode).transpose()? else {
+        return Ok(None);
+    };
+    if !matches!(&name, xdr::ScVal::Symbol(s) if s.to_string() == NULLIFIER_EVENT) {
+        return Ok(None);
+    }
+    let value = topics
+        .get(1)
+        .ok_or_else(|| anyhow!("{NULLIFIER_EVENT} carries no nullifier topic"))?;
+    u256_bytes(&decode(value)?).map(Some)
+}
+
+/// Reads every nullifier the pools published since `cursor`, keyed by the pool
+/// that published it, and the cursor to resume from.
+///
+/// All pools are paged together, because an event cursor is a position in the
+/// ledger rather than in one contract's history: resuming a second contract
+/// from the first one's cursor would skip its events entirely.
+///
+/// Reads through `bootnode` first, because public RPC keeps events for about a
+/// week and a pool's history is longer than that, and falls back to `rpc` when
+/// the bootnode refuses the range.
+///
+/// # Errors
+///
+/// Returns an error if both endpoints refuse the range, or if an event carries
+/// a nullifier that is not a `u256`.
+pub async fn nullifiers_since(
+    bootnode: &Client,
+    rpc: &Client,
+    pools: &[(String, u32)],
+    cursor: Option<String>,
+) -> Result<(BTreeMap<String, Vec<[u8; 32]>>, Option<String>)> {
+    let contracts: Vec<String> = pools.iter().map(|(id, _)| id.clone()).collect();
+    let start_ledger = pools.iter().map(|(_, from)| *from).min().unwrap_or(0);
+    let mut nullifiers: BTreeMap<String, Vec<[u8; 32]>> = BTreeMap::new();
+    let mut page_cursor = cursor;
+    let mut on_bootnode = true;
+
+    loop {
+        let client = if on_bootnode { bootnode } else { rpc };
+        let page = client
+            .get_contract_events(
+                &contracts,
+                start_ledger,
+                EVENT_PAGE_SIZE,
+                page_cursor.clone(),
+            )
+            .await;
+        let (next, events, _) = match page {
+            Ok(page) => page,
+            // The bootnode's own error type is not reachable from here, so a
+            // handoff and an unreachable bootnode look alike. Warn rather than
+            // fall back quietly: past its retention window the RPC answers
+            // with fewer events, not an error.
+            Err(e) if on_bootnode => {
+                tracing::warn!(error = %e, "bootnode_events_unavailable_falling_back_to_rpc");
+                on_bootnode = false;
+                continue;
+            }
+            Err(e) => return Err(e).context("read pool events"),
+        };
+
+        for event in &events {
+            if let Some(nullifier) = nullifier_from_event(&event.topic)? {
+                nullifiers
+                    .entry(event.contract_id.clone())
+                    .or_default()
+                    .push(nullifier);
+            }
+        }
+        if events.is_empty() || next.is_none() {
+            return Ok((nullifiers, next.or(page_cursor)));
+        }
+        page_cursor = next;
+    }
+}
+
+/// Reads the values of `keys`, keyed by their base64 XDR form.
+///
+/// A key the ledger no longer holds is absent from the result.
+///
+/// # Errors
+///
+/// Returns an error if the RPC refuses the request or an entry does not decode.
+pub async fn read_values(
+    client: &Client,
+    keys: &[LedgerKey],
+) -> Result<BTreeMap<String, xdr::ScVal>> {
+    let mut values = BTreeMap::new();
+
+    // The RPC refuses a request naming more than `LEDGER_KEY_CHUNK` keys, and
+    // the sparse tree's frontier grows with the size of the blocklist.
+    for chunk in keys.chunks(LEDGER_KEY_CHUNK) {
+        let response = client
+            .get_ledger_entries(chunk)
+            .await
+            .context("read contract data")?;
+
+        for entry in response.entries.unwrap_or_default() {
+            let data = xdr::LedgerEntryData::from_xdr_base64(&entry.xdr, Limits::none())
+                .context("decode ledger entry")?;
+            if let xdr::LedgerEntryData::ContractData(contract_data) = data {
+                values.insert(entry.key, contract_data.val);
+            }
+        }
+    }
+    Ok(values)
+}
+
+async fn read_value(client: &Client, key: &LedgerKey) -> Result<Option<xdr::ScVal>> {
+    let encoded = key.to_xdr_base64(Limits::none())?;
+    Ok(read_values(client, std::slice::from_ref(key))
+        .await?
+        .remove(&encoded))
+}
+
+/// Reads a `u32` a contract stores under `variant`, or `None` when the ledger
+/// no longer holds it.
+///
+/// An absent entry is the state the keeper exists to repair, so it is not an
+/// error: raising here would abort the round that would have restored it, for
+/// every contract in the deployment.
+///
+/// # Errors
+///
+/// Returns an error if the entry is present but is not a `u32`.
+async fn read_u32(
+    client: &Client,
+    contract: &xdr::ScAddress,
+    variant: &str,
+) -> Result<Option<u32>> {
+    match read_value(client, &data_key(contract, variant, vec![])?).await? {
+        Some(xdr::ScVal::U32(value)) => Ok(Some(value)),
+        Some(other) => bail!("{variant} is {other:?}, expected a u32"),
+        None => Ok(None),
+    }
+}
+
+/// Reads the wasm hash a contract instance runs.
+///
+/// # Errors
+///
+/// Returns an error if the instance is absent, or runs a built-in contract
+/// rather than uploaded wasm.
+pub async fn wasm_hash(client: &Client, contract: &xdr::ScAddress) -> Result<Option<xdr::Hash>> {
+    let Some(value) = read_value(client, &instance_key(contract)).await? else {
+        return Ok(None);
+    };
+    match value {
+        xdr::ScVal::ContractInstance(instance) => match instance.executable {
+            xdr::ContractExecutable::Wasm(hash) => Ok(Some(hash)),
+            xdr::ContractExecutable::StellarAsset => Ok(None),
+        },
+        other => bail!("contract instance is {other:?}"),
+    }
+}
+
+/// Walks the non-membership tree and returns every node it holds.
+///
+/// The sparse tree names its nodes only inside its own stored values, so the
+/// walk fetches one level at a time until no child is left to read.
+///
+/// # Errors
+///
+/// Returns an error if a node value does not decode.
+pub async fn non_membership_nodes(
+    client: &Client,
+    contract: &xdr::ScAddress,
+) -> Result<Vec<[u8; 32]>> {
+    let Some(root_value) = read_value(client, &data_key(contract, "Root", vec![])?).await? else {
+        return Ok(Vec::new());
+    };
+    let root = u256_bytes(&root_value)?;
+
+    let mut children: BTreeMap<[u8; 32], Vec<[u8; 32]>> = BTreeMap::new();
+    let mut frontier = vec![root];
+
+    while !frontier.is_empty() {
+        let node_keys = frontier
+            .iter()
+            .map(|node| data_key(contract, "Node", vec![u256(*node)]))
+            .collect::<Result<Vec<_>>>()?;
+        let values = read_values(client, &node_keys).await?;
+
+        let mut next = Vec::new();
+        for (node, key) in frontier.iter().zip(node_keys.iter()) {
+            let encoded = key.to_xdr_base64(Limits::none())?;
+            let Some(value) = values.get(&encoded) else {
+                continue;
+            };
+            let kids = node_children(value)?;
+            next.extend(kids.iter().filter(|k| !children.contains_key(*k)).copied());
+            children.insert(*node, kids);
+        }
+        frontier = next;
+    }
+    Ok(walk_sparse_tree(root, &children))
+}
+
+/// Builds every key the keeper is responsible for.
+///
+/// # Errors
+///
+/// Returns an error if the manifest holds an invalid address, or a contract
+/// the manifest names is absent from the ledger.
+pub async fn build(
+    client: &Client,
+    config: &ContractConfig,
+    nullifiers: &BTreeMap<String, BTreeSet<String>>,
+) -> Result<Vec<LedgerKey>> {
+    let mut keys = Vec::new();
+    let enabled: Vec<_> = config.pools.iter().filter(|p| p.enabled).collect();
+
+    let mut contracts: Vec<String> = enabled.iter().map(|p| p.pool_contract_id.clone()).collect();
+    contracts.push(config.asp_membership.clone());
+    contracts.push(config.asp_non_membership.clone());
+    contracts.extend(config.verifiers.values().cloned());
+    contracts.push(config.public_key_registry.clone());
+    if let Some(governance) = &config.governance {
+        contracts.push(governance.governor.clone());
+    }
+
+    for contract_id in &contracts {
+        let contract = address(contract_id)?;
+        keys.push(instance_key(&contract));
+        if let Some(hash) = wasm_hash(client, &contract).await? {
+            keys.push(code_key(hash));
+        }
+    }
+
+    for pool in &enabled {
+        let contract = address(&pool.pool_contract_id)?;
+        // A pool whose `Levels` entry is archived still gets its fixed keys, so
+        // the restore that brings the entry back can run.
+        let levels = read_u32(client, &contract, "Levels").await?.unwrap_or(0);
+
+        let empty = BTreeSet::new();
+        let spent = nullifiers.get(&pool.pool_contract_id).unwrap_or(&empty);
+        keys.extend(pool_keys(&contract, levels, spent)?);
+    }
+
+    let membership = address(&config.asp_membership)?;
+    let levels = read_u32(client, &membership, "Levels").await?.unwrap_or(0);
+    keys.extend(membership_keys(&membership, levels)?);
+
+    let non_membership = address(&config.asp_non_membership)?;
+    let nodes = non_membership_nodes(client, &non_membership).await?;
+    keys.extend(non_membership_keys(&non_membership, &nodes)?);
+
+    if let Some(governance) = &config.governance {
+        let governor = address(&governance.governor)?;
+        let pending = match read_value(client, &data_key(&governor, "Pending", vec![])?).await? {
+            Some(xdr::ScVal::Vec(Some(ids))) => ids
+                .iter()
+                .map(|id| match id {
+                    xdr::ScVal::Bytes(bytes) => bytes
+                        .as_slice()
+                        .try_into()
+                        .map_err(|_| anyhow!("operation id is not 32 bytes")),
+                    other => Err(anyhow!("operation id is {other:?}")),
+                })
+                .collect::<Result<Vec<[u8; 32]>>>()?,
+            _ => Vec::new(),
+        };
+        let mut role_members = Vec::with_capacity(ROLES.len());
+        for role in ROLES {
+            let key = data_key(&governor, "RoleAccountsCount", vec![symbol(role)?])?;
+            let count = match read_value(client, &key).await? {
+                Some(xdr::ScVal::U32(count)) => count,
+                _ => 0,
+            };
+            role_members.push((role.to_owned(), count));
+        }
+
+        keys.extend(governor_keys(
+            governance,
+            &pending,
+            &permission_rows(config),
+            &role_members,
+        )?);
+    }
+
+    // Two contracts that run the same wasm name the same code key, and a
+    // footprint that lists one key twice is refused.
+    keys.sort_unstable();
+    keys.dedup();
+    Ok(keys)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const POOL: &str = "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE";
+
+    fn hash(byte: u8) -> [u8; 32] {
+        [byte; 32]
+    }
+
+    fn internal(left: [u8; 32], right: [u8; 32]) -> xdr::ScVal {
+        xdr::ScVal::Vec(Some(
+            xdr::ScVec::try_from(vec![u256(left), u256(right)]).expect("vec"),
+        ))
+    }
+
+    #[test]
+    fn the_pool_key_list_covers_the_whole_root_ring() {
+        let contract = address(POOL).expect("address");
+        let keys = pool_keys(&contract, 3, &BTreeSet::new()).expect("keys");
+
+        // 13 enum keys, then FilledSubtree and Zeroes for levels 0 to 3, then
+        // the 90 root slots.
+        assert_eq!(keys.len(), 111);
+        assert!(
+            keys.contains(&data_key(&contract, "Root", vec![xdr::ScVal::U32(89)]).expect("89"))
+        );
+        assert!(
+            !keys.contains(&data_key(&contract, "Root", vec![xdr::ScVal::U32(90)]).expect("90"))
+        );
+    }
+
+    #[test]
+    fn a_nullifier_becomes_a_valued_pool_key() {
+        let contract = address(POOL).expect("address");
+        let spent = BTreeSet::from([bytes_to_hex(&hash(7))]);
+        let keys = pool_keys(&contract, 1, &spent).expect("keys");
+
+        assert!(
+            keys.contains(&data_key(&contract, "Nullifier", vec![u256(hash(7))]).expect("key"))
+        );
+    }
+
+    #[test]
+    fn the_sparse_tree_walk_visits_every_node_once_and_stops_at_zero_children() {
+        // root -> (a, b); a -> (c, zero); b is a leaf; c has no stored value.
+        let (root, a, b, c) = (hash(1), hash(2), hash(3), hash(4));
+        let children = BTreeMap::from([(root, vec![a, b]), (a, vec![c]), (b, Vec::new())]);
+
+        let mut visited = walk_sparse_tree(root, &children);
+        visited.sort_unstable();
+        assert_eq!(visited, vec![root, a, b, c]);
+    }
+
+    #[test]
+    fn a_zero_root_walks_to_nothing() {
+        assert!(walk_sparse_tree([0u8; 32], &BTreeMap::new()).is_empty());
+    }
+
+    #[test]
+    fn a_leaf_names_no_children_and_a_zero_child_is_skipped() {
+        let leaf = xdr::ScVal::Vec(Some(
+            xdr::ScVec::try_from(vec![u256(hash(1)), u256(hash(2)), xdr::ScVal::U32(1)])
+                .expect("vec"),
+        ));
+        assert!(node_children(&leaf).expect("leaf").is_empty());
+        assert_eq!(
+            node_children(&internal(hash(5), [0u8; 32])).expect("internal"),
+            vec![hash(5)]
+        );
+    }
+
+    #[test]
+    fn a_nullifier_event_decodes_and_an_unrelated_event_is_skipped() {
+        let topic = |value: &xdr::ScVal| {
+            value
+                .to_xdr_base64(Limits::none())
+                .expect("encode event topic")
+        };
+        let name = |text: &str| topic(&symbol(text).expect("symbol"));
+
+        let spent = vec![name(NULLIFIER_EVENT), topic(&u256(hash(9)))];
+        assert_eq!(nullifier_from_event(&spent).expect("decode"), Some(hash(9)));
+
+        let other = vec![name("new_commitment_event"), topic(&xdr::ScVal::U32(1))];
+        assert_eq!(nullifier_from_event(&other).expect("decode"), None);
+        assert_eq!(nullifier_from_event(&[]).expect("decode"), None);
+    }
+
+    /// The governor's storage keys as OpenZeppelin encodes them, in lowercase
+    /// hexadecimal XDR.
+    ///
+    /// The same five constants appear in `contracts/governor/src/test.rs`,
+    /// asserted there against the key types themselves. This crate cannot see
+    /// those types, so the pair of tests is what ties the variant names below
+    /// to the contract: a rename upstream fails the contract's test, and a
+    /// wrong name here fails this one.
+    const EXISTING_ROLES_XDR: &str = concat!(
+        "0000001000000001000000010000000f0000000d4578697374696e67526f6c65",
+        "73000000",
+    );
+    const HAS_ROLE_XDR: &str = concat!(
+        "0000001000000001000000030000000f00000007486173526f6c650000000012",
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "00000000000000000000000f00000008677561726469616e",
+    );
+    const ROLE_ACCOUNTS_COUNT_XDR: &str = concat!(
+        "0000001000000001000000020000000f00000011526f6c654163636f756e7473",
+        "436f756e740000000000000f00000008677561726469616e",
+    );
+    const ROLE_ACCOUNTS_XDR: &str = concat!(
+        "0000001000000001000000020000000f0000000c526f6c654163636f756e7473",
+        "0000001100000001000000020000000f00000005696e64657800000000000003",
+        "000000000000000f00000004726f6c650000000f00000008677561726469616e",
+    );
+    const OPERATION_LEDGER_XDR: &str = concat!(
+        "0000001000000001000000020000000f0000000f4f7065726174696f6e4c6564",
+        "676572000000000d000000200707070707070707070707070707070707070707",
+        "070707070707070707070707",
+    );
+    /// The role holder the pinned `HasRole` and `RoleAccounts` keys name.
+    const PINNED_HOLDER: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+    /// Returns the hexadecimal XDR of the value a contract-data key holds.
+    fn key_hex(key: &LedgerKey) -> String {
+        match key {
+            LedgerKey::ContractData(data) => hex::encode(
+                data.key
+                    .to_xdr(Limits::none())
+                    .expect("encode a contract data key"),
+            ),
+            _ => panic!("not a contract data key"),
+        }
+    }
+
+    #[test]
+    fn the_openzeppelin_key_encodings_are_pinned() {
+        let governor =
+            address("CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE").expect("governor");
+        let holder = xdr::ScVal::Address(address(PINNED_HOLDER).expect("holder"));
+        let guardian = symbol("guardian").expect("role");
+        let operation = xdr::ScVal::Bytes(xdr::ScBytes(
+            hash(7).to_vec().try_into().expect("operation id"),
+        ));
+
+        for (key, expected) in [
+            (
+                data_key(&governor, "ExistingRoles", vec![]).expect("roles"),
+                EXISTING_ROLES_XDR,
+            ),
+            (
+                data_key(&governor, "HasRole", vec![holder, guardian.clone()]).expect("has role"),
+                HAS_ROLE_XDR,
+            ),
+            (
+                data_key(&governor, "RoleAccountsCount", vec![guardian]).expect("count"),
+                ROLE_ACCOUNTS_COUNT_XDR,
+            ),
+            (
+                data_key(
+                    &governor,
+                    "RoleAccounts",
+                    vec![role_account_key("guardian", 0).expect("member")],
+                )
+                .expect("accounts"),
+                ROLE_ACCOUNTS_XDR,
+            ),
+            (
+                data_key(&governor, "OperationLedger", vec![operation]).expect("ledger"),
+                OPERATION_LEDGER_XDR,
+            ),
+        ] {
+            assert_eq!(key_hex(&key), expected);
+        }
+    }
+
+    #[test]
+    fn the_governor_key_list_covers_the_openzeppelin_entries() {
+        let governance: GovernanceConfig = serde_json::from_str(
+            r#"{
+                "governor": "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
+                "council": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                "operator": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                "guardian": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                "recovery": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                "ttlKeeper": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                "delay": 1, "recoveryDelay": 2, "grace": 3, "guardianPause": 4
+            }"#,
+        )
+        .expect("governance block");
+        let governor = address(&governance.governor).expect("address");
+        let operation = hash(5);
+
+        let keys = governor_keys(&governance, &[operation], &[], &[("council".to_owned(), 2)])
+            .expect("keys");
+
+        let bytes = xdr::ScVal::Bytes(xdr::ScBytes(operation.to_vec().try_into().expect("bytes")));
+        for expected in [
+            data_key(&governor, "ExistingRoles", vec![]).expect("roles"),
+            data_key(&governor, "OperationLedger", vec![bytes]).expect("ledger"),
+            data_key(
+                &governor,
+                "RoleAccounts",
+                vec![role_account_key("council", 1).expect("member")],
+            )
+            .expect("accounts"),
+        ] {
+            assert!(keys.contains(&expected));
+        }
+    }
+
+    fn manifest_with_governance() -> ContractConfig {
+        serde_json::from_str(
+            r#"{
+                "network": "testnet",
+                "deployer": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                "admin": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                "asp_membership": "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
+                "asp_non_membership": "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
+                "verifiers": {},
+                "public_key_registry": "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
+                "pools": [],
+                "governance": {
+                    "governor": "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
+                    "council": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                    "operator": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                    "guardian": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                    "recovery": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                    "ttlKeeper": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                    "delay": 1, "recoveryDelay": 2, "grace": 3, "guardianPause": 4
+                }
+            }"#,
+        )
+        .expect("manifest")
+    }
+
+    /// Keys a contract writes only under some conditions are enumerated all
+    /// the same: the RPC reports which exist, and an absent one costs nothing.
+    #[test]
+    fn conditionally_written_governor_keys_are_enumerated() {
+        let config = manifest_with_governance();
+        let governance = config.governance.as_ref().expect("governance");
+        let governor = address(&governance.governor).expect("address");
+
+        let listed = governor_keys(
+            governance,
+            &[],
+            &permission_rows(&config),
+            &[("operator".to_owned(), 0)],
+        )
+        .expect("keys");
+
+        for expected in [
+            data_key(&governor, "Pending", vec![]).expect("pending"),
+            data_key(
+                &governor,
+                "FnRole",
+                vec![
+                    xdr::ScVal::Address(address(&config.asp_membership).expect("asp")),
+                    symbol("insert_leaf").expect("symbol"),
+                ],
+            )
+            .expect("row"),
+            data_key(
+                &governor,
+                "HasRole",
+                vec![
+                    xdr::ScVal::Address(address(&governance.operator).expect("operator")),
+                    symbol("operator").expect("symbol"),
+                ],
+            )
+            .expect("operator role"),
+        ] {
+            assert!(listed.contains(&expected));
+        }
+    }
+
+    /// An archived `Levels` entry is the state the keeper exists to repair, so
+    /// the pool still contributes its fixed keys and the restore can name them.
+    #[test]
+    fn a_pool_whose_levels_entry_is_gone_still_yields_its_fixed_keys() {
+        let contract = address(POOL).expect("address");
+        let keys = pool_keys(&contract, 0, &BTreeSet::new()).expect("keys");
+
+        for variant in ["Admin", "Levels", "NextIndex", "CurrentRootIndex"] {
+            assert!(keys.contains(&data_key(&contract, variant, vec![]).expect("key")));
+        }
+    }
+
+    /// Two pools of the same deployment run byte-identical wasm, so they name
+    /// one `LedgerKeyContractCode`. A footprint that lists a key twice is
+    /// refused, and the extend and restore counters would double-count it.
+    #[test]
+    fn one_wasm_shared_by_two_contracts_yields_one_code_key() {
+        let hash = xdr::Hash([4u8; 32]);
+        let mut keys = vec![
+            instance_key(&address(POOL).expect("address")),
+            code_key(hash.clone()),
+            code_key(hash),
+        ];
+        keys.sort_unstable();
+        keys.dedup();
+
+        let code = keys
+            .iter()
+            .filter(|k| matches!(k, LedgerKey::ContractCode(_)))
+            .count();
+        assert_eq!(code, 1);
+        assert_eq!(keys.len(), 2);
+    }
+
+    #[test]
+    fn hexadecimal_nullifiers_round_trip() {
+        assert_eq!(hex_to_bytes(&bytes_to_hex(&hash(3))).expect("hex"), hash(3));
+        assert!(hex_to_bytes("abcd").is_err());
+    }
+}

--- a/tools/ttl-keeper/src/main.rs
+++ b/tools/ttl-keeper/src/main.rs
@@ -1,0 +1,466 @@
+//! Keeps a deployment's ledger entries from being archived.
+//!
+//! Soroban expires persistent contract data that nobody touches. The keeper
+//! enumerates every entry a deployment owns, asks the RPC which of them exist
+//! and for how long, restores what the RPC reports archived, and extends what
+//! is close to expiry.
+
+mod keys;
+mod ops;
+mod state;
+
+use anyhow::{Context, Result, bail};
+use clap::Parser;
+use state::State;
+use std::{num::NonZeroUsize, path::PathBuf, time::Duration};
+use stellar_private_payments::{
+    chain::{Client, LocalSigner},
+    types::ContractConfig,
+};
+use stellar_xdr::{self as xdr, LedgerKey};
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "ttl-keeper",
+    about = "Extends the storage lifetime of a deployment"
+)]
+struct Args {
+    /// Deployment manifest naming the contracts to keep alive.
+    #[arg(long)]
+    deployment: PathBuf,
+    /// Soroban RPC endpoint.
+    #[arg(long)]
+    rpc_url: String,
+    /// Bootnode endpoint, read first when paging pool events.
+    #[arg(long)]
+    bootnode_url: String,
+    /// Environment variable holding the keeper account's secret key.
+    #[arg(long, default_value = "TTL_KEEPER_SECRET")]
+    keeper_secret_env: String,
+    /// File holding the event cursor and the nullifiers seen so far.
+    #[arg(long)]
+    state_file: PathBuf,
+    /// Run one round and exit.
+    #[arg(long)]
+    once: bool,
+    /// Measure and log what a round would restore and extend, then exit
+    /// without submitting anything.
+    #[arg(long)]
+    dry_run: bool,
+    /// Seconds between rounds.
+    #[arg(long, default_value_t = 3_600)]
+    interval_secs: u64,
+    /// Extend an entry once its remaining lifetime falls to this many ledgers.
+    #[arg(long, default_value_t = 518_400)]
+    threshold_ledgers: u32,
+    /// Lifetime, in ledgers, an extension asks for. Without it, one ledger
+    /// below the network's maximum entry lifetime, which is the most an
+    /// extension may ask for.
+    #[arg(long)]
+    extend_to_ledgers: Option<u32>,
+    /// Keys per lifetime transaction.
+    #[arg(long, default_value = "100")]
+    batch: NonZeroUsize,
+}
+
+/// Lowest protocol version whose RPC reports archived entries.
+///
+/// Before protocol 23 the RPC left an archived entry out of `getLedgerEntries`
+/// the way it leaves out a key that was never written, so a keeper running
+/// against such an RPC would never restore anything and never know it.
+const MIN_PROTOCOL: u32 = 23;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    tracing_subscriber::registry()
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let raw = std::fs::read_to_string(&args.deployment)
+        .with_context(|| format!("read {}", args.deployment.display()))?;
+    let config: ContractConfig = serde_json::from_str(&raw)
+        .with_context(|| format!("parse {}", args.deployment.display()))?;
+
+    let secret = std::env::var(&args.keeper_secret_env)
+        .with_context(|| format!("read {}", args.keeper_secret_env))?;
+    let signer = LocalSigner::from_secret(&secret)?;
+
+    let rpc = Client::new(&args.rpc_url)?;
+    let bootnode = Client::new(&args.bootnode_url)?;
+    let passphrase = network_passphrase(&config.network)?;
+
+    let protocol = rpc.get_latest_ledger().await?.protocol_version;
+    if protocol < MIN_PROTOCOL {
+        bail!(
+            "the RPC runs protocol {protocol}; the keeper needs {MIN_PROTOCOL} or later, \
+             because earlier versions leave archived entries out of getLedgerEntries and \
+             nothing would ever be restored"
+        );
+    }
+
+    loop {
+        let outcome = round(&args, &config, &rpc, &bootnode, &signer, passphrase).await;
+        if let Err(e) = &outcome {
+            tracing::error!(error = %e, "round_failed");
+        }
+        if args.once || args.dry_run {
+            return outcome;
+        }
+        tokio::time::sleep(Duration::from_secs(args.interval_secs)).await;
+    }
+}
+
+/// Returns the network passphrase a manifest's network name implies.
+///
+/// An unknown name is an error rather than a default, because signing with a
+/// passphrase the network does not use produces transactions it refuses.
+///
+/// # Errors
+///
+/// Returns an error if `network` is not one this keeper knows a passphrase for.
+fn network_passphrase(network: &str) -> Result<&'static str> {
+    match network {
+        "public" | "mainnet" => Ok("Public Global Stellar Network ; September 2015"),
+        "testnet" => Ok("Test SDF Network ; September 2015"),
+        "futurenet" => Ok("Test SDF Future Network ; October 2022"),
+        other => bail!("no network passphrase is known for '{other}'"),
+    }
+}
+
+async fn round(
+    args: &Args,
+    config: &ContractConfig,
+    rpc: &Client,
+    bootnode: &Client,
+    signer: &LocalSigner,
+    passphrase: &str,
+) -> Result<()> {
+    run_round(args, config, rpc, bootnode, signer, passphrase).await
+}
+
+async fn run_round(
+    args: &Args,
+    config: &ContractConfig,
+    rpc: &Client,
+    bootnode: &Client,
+    signer: &LocalSigner,
+    passphrase: &str,
+) -> Result<()> {
+    let mut state = State::load(&args.state_file)?;
+    refresh_nullifiers(config, rpc, bootnode, &mut state).await?;
+    state.store(&args.state_file)?;
+
+    let keys = keys::build(rpc, config, &state.nullifiers).await?;
+    let measurement = ops::measure(rpc, &keys).await?;
+    let archived = ops::archived(&measurement);
+    let mut stale = ops::below_threshold(&measurement, args.threshold_ledgers);
+    // Read here so the plan can be logged, but not raised here: the restore
+    // phase does not need it.
+    let extend_to = ops::max_entry_ttl(rpc)
+        .await
+        .map(|max| ops::extend_target(args.extend_to_ledgers, max));
+    report_plan(
+        &measurement,
+        &archived,
+        &stale,
+        extend_to.as_ref().ok().copied(),
+        args.dry_run,
+    );
+    if args.dry_run {
+        return extend_to.map(|_| ());
+    }
+
+    // The two phases are independent: an extension needs nothing from a
+    // restore, so a restore that fails must not leave the deployment's live
+    // entries unextended. Both run, and the first error is returned last.
+    let mut restored = Vec::new();
+    let restore = submit_batches(
+        args,
+        rpc,
+        signer,
+        passphrase,
+        &archived,
+        None,
+        &mut restored,
+    )
+    .await;
+    // A restored entry comes back with the network minimum lifetime, which is
+    // inside the threshold, so it is extended in the same round.
+    stale.extend_from_slice(&restored);
+    let mut extended = Vec::new();
+    let (extend, extend_to) = match extend_to {
+        Ok(extend_to) => (
+            submit_batches(
+                args,
+                rpc,
+                signer,
+                passphrase,
+                &stale,
+                Some(extend_to),
+                &mut extended,
+            )
+            .await,
+            extend_to,
+        ),
+        Err(e) => (Err(e), 0),
+    };
+
+    report_lowest(&measurement, &extended, extend_to);
+    restore.and(extend)
+}
+
+async fn refresh_nullifiers(
+    config: &ContractConfig,
+    rpc: &Client,
+    bootnode: &Client,
+    state: &mut State,
+) -> Result<()> {
+    let pools: Vec<(String, u32)> = config
+        .pools
+        .iter()
+        .filter(|p| p.enabled)
+        .map(|p| (p.pool_contract_id.clone(), p.deployment_ledger))
+        .collect();
+    if pools.is_empty() {
+        return Ok(());
+    }
+
+    let (found, cursor) =
+        keys::nullifiers_since(bootnode, rpc, &pools, state.cursor.clone()).await?;
+    for (pool_id, nullifiers) in &found {
+        state.extend_pool(pool_id, nullifiers.iter().map(keys::bytes_to_hex));
+    }
+    state.cursor = cursor;
+    Ok(())
+}
+
+/// Submits `keys` in batches, appending the keys each confirmed transaction
+/// named to `submitted`.
+///
+/// The simulation drops a key that needs nothing from the footprint, so
+/// `submitted` can end up shorter than `keys`, and a batch whose footprint
+/// comes back empty is not submitted at all. `submitted` is an out parameter
+/// so that the batches confirmed before a failing one are still known to the
+/// caller.
+///
+/// An extend whose simulation asks for a restore first names a key the RPC's
+/// ledger-state answer called live and its simulation calls archived. The
+/// keeper restores those keys, counts the disagreement, and simulates the
+/// extend again.
+///
+/// # Errors
+///
+/// Returns an error if a simulation, a submission, or a confirmation fails,
+/// or if the RPC still asks for a restore after the keys it named have been
+/// restored.
+async fn submit_batches(
+    args: &Args,
+    rpc: &Client,
+    signer: &LocalSigner,
+    passphrase: &str,
+    keys: &[LedgerKey],
+    extend_to: Option<u32>,
+    submitted: &mut Vec<LedgerKey>,
+) -> Result<()> {
+    let operation = if extend_to.is_some() {
+        "extend"
+    } else {
+        "restore"
+    };
+
+    for chunk in keys.chunks(args.batch.get()) {
+        let mut simulated = simulate_batch(rpc, signer, chunk, extend_to).await?;
+        if !simulated.restore_first.is_empty() {
+            // One occurrence is an entry that expired between the read and the
+            // simulation; the alert rule is what notices a repeat.
+            tracing::warn!(
+                keys = simulated.restore_first.len(),
+                "rpc_simulation_calls_archived_what_its_ledger_state_called_live"
+            );
+            if extend_to.is_none() {
+                bail!("a restore simulation asked for a restore of its own keys");
+            }
+            Box::pin(submit_batches(
+                args,
+                rpc,
+                signer,
+                passphrase,
+                &simulated.restore_first,
+                None,
+                &mut Vec::new(),
+            ))
+            .await?;
+            simulated = simulate_batch(rpc, signer, chunk, extend_to).await?;
+            if !simulated.restore_first.is_empty() {
+                // Sending anyway would extend nothing for those keys and count
+                // them as extended, which is the failure this branch exists
+                // to prevent.
+                bail!(
+                    "the RPC still asks to restore {} keys after they were restored",
+                    simulated.restore_first.len()
+                );
+            }
+        }
+
+        let dropped = chunk.len().saturating_sub(simulated.keys.len());
+        if dropped > 0 {
+            tracing::info!(
+                operation,
+                dropped,
+                "keys_the_simulation_left_out_of_the_footprint"
+            );
+        }
+        if simulated.keys.is_empty() {
+            continue;
+        }
+
+        let hash = ops::send(rpc, signer, passphrase, &simulated).await?;
+        tracing::info!(
+            keys = simulated.keys.len(),
+            operation,
+            %hash,
+            "lifetime_transaction_confirmed"
+        );
+        submitted.extend(simulated.keys);
+    }
+    Ok(())
+}
+
+async fn simulate_batch(
+    rpc: &Client,
+    signer: &LocalSigner,
+    chunk: &[LedgerKey],
+    extend_to: Option<u32>,
+) -> Result<ops::Simulated> {
+    let sequence = next_sequence(rpc, signer.public_key()).await?;
+    let envelope = match extend_to {
+        Some(extend_to) => {
+            ops::extend_envelope(signer.public_key(), sequence, chunk.to_vec(), extend_to)?
+        }
+        None => ops::restore_envelope(signer.public_key(), sequence, chunk.to_vec())?,
+    };
+    ops::simulate(rpc, envelope).await
+}
+
+async fn next_sequence(rpc: &Client, address: &str) -> Result<i64> {
+    let account = rpc.get_account(address).await?;
+    account
+        .seq_num
+        .0
+        .checked_add(1)
+        .context("account sequence number overflowed")
+}
+
+/// Logs what the round found and, on a dry run, every key it would name.
+///
+/// `extend_to` is absent when the network's maximum lifetime could not be read.
+fn report_plan(
+    measurement: &ops::Measurement,
+    archived: &[LedgerKey],
+    stale: &[LedgerKey],
+    extend_to: Option<u32>,
+    dry_run: bool,
+) {
+    let absent = measurement
+        .entries
+        .iter()
+        .filter(|m| m.lifetime == ops::Lifetime::Absent)
+        .count();
+    tracing::info!(
+        entries = measurement.entries.len(),
+        latest_ledger = measurement.latest_ledger,
+        absent,
+        archived = archived.len(),
+        stale = stale.len(),
+        extend_to,
+        "round_planned"
+    );
+    if !dry_run {
+        return;
+    }
+    for key in archived {
+        tracing::info!(key = %describe(key), "would_restore");
+    }
+    // A restored entry is extended in the same round, so it is listed twice.
+    for key in stale.iter().chain(archived) {
+        tracing::info!(key = %describe(key), "would_extend");
+    }
+}
+
+/// Renders a key the way an operator reads it: the contract, the storage
+/// variant, and the variant's arguments, with a `u256` in the hexadecimal the
+/// state file uses.
+fn describe(key: &LedgerKey) -> String {
+    let argument = |part: &xdr::ScVal| match part {
+        xdr::ScVal::U32(value) => value.to_string(),
+        xdr::ScVal::U256(_) => keys::u256_bytes(part)
+            .map_or_else(|_| format!("{part:?}"), |bytes| keys::bytes_to_hex(&bytes)),
+        other => format!("{other:?}"),
+    };
+    match key {
+        LedgerKey::ContractData(data) => match &data.key {
+            xdr::ScVal::LedgerKeyContractInstance => format!("{} instance", data.contract),
+            xdr::ScVal::Vec(Some(parts)) => {
+                let mut parts = parts.iter();
+                let variant = match parts.next() {
+                    Some(xdr::ScVal::Symbol(name)) => name.to_string(),
+                    other => format!("{other:?}"),
+                };
+                let arguments: Vec<String> = parts.map(argument).collect();
+                format!("{} {variant}({})", data.contract, arguments.join(", "))
+            }
+            other => format!("{} {other:?}", data.contract),
+        },
+        LedgerKey::ContractCode(code) => format!("wasm {}", code.hash),
+        other => format!("{other:?}"),
+    }
+}
+
+/// Logs the shortest remaining lifetime each contract's entries have left.
+fn report_lowest(measurement: &ops::Measurement, extended: &[LedgerKey], extend_to: u32) {
+    let lowest = ops::lowest_by_contract(measurement, extended, extend_to);
+    for (contract, remaining_ledgers) in &lowest {
+        tracing::info!(%contract, remaining_ledgers, "contract_lowest_lifetime");
+    }
+    tracing::info!(
+        entries = measurement.entries.len(),
+        contracts = lowest.len(),
+        "round_complete"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_manifest_network_selects_the_passphrase() {
+        let of = |network| network_passphrase(network).expect("known network");
+        assert_eq!(of("public"), of("mainnet"));
+        assert_eq!(
+            of("public"),
+            "Public Global Stellar Network ; September 2015"
+        );
+        assert_eq!(of("testnet"), "Test SDF Network ; September 2015");
+        assert_eq!(of("futurenet"), "Test SDF Future Network ; October 2022");
+        assert!(network_passphrase("localnet").is_err());
+    }
+
+    #[test]
+    fn a_key_is_described_by_contract_variant_and_arguments() {
+        let contract = keys::address("CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE")
+            .expect("address");
+        let root = keys::data_key(&contract, "Root", vec![xdr::ScVal::U32(89)]).expect("key");
+        assert_eq!(
+            describe(&root),
+            "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE Root(89)"
+        );
+        let nullifier =
+            keys::data_key(&contract, "Nullifier", vec![keys::u256([7u8; 32])]).expect("key");
+        assert!(describe(&nullifier).ends_with(&format!("Nullifier({})", "07".repeat(32))));
+        assert!(describe(&keys::instance_key(&contract)).ends_with(" instance"));
+    }
+}

--- a/tools/ttl-keeper/src/ops.rs
+++ b/tools/ttl-keeper/src/ops.rs
@@ -1,0 +1,757 @@
+//! Measuring, extending, and restoring the lifetime of ledger entries.
+//!
+//! The RPC reports three states for a key: absent, archived, and live through
+//! a given ledger. Everything the keeper submits is derived from that report.
+//! A key the RPC does not return is never named in a transaction, a key it
+//! reports archived is restored, and a key it reports live is extended once
+//! its remaining lifetime falls to the threshold.
+
+use crate::keys::{LEDGER_KEY_CHUNK, address};
+use anyhow::{Context, Result, anyhow, bail};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    time::Duration,
+};
+use stellar_private_payments::chain::{Client, LocalSigner};
+use stellar_xdr::{self as xdr, LedgerKey, Limits, ReadXdr, WriteXdr};
+
+/// Fee in stroops the transaction pays on top of the simulated resource fee.
+const BASE_FEE: u32 = 100;
+
+/// Attempts to read a transaction's outcome before giving up.
+const CONFIRM_ATTEMPTS: u32 = 30;
+
+/// Seconds between two attempts to read a transaction's outcome.
+const CONFIRM_INTERVAL_SECS: u64 = 2;
+
+/// Whether the ledger holds an entry, and for how long.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Lifetime {
+    /// The RPC returned no entry: the key was never written, or was deleted.
+    Absent,
+    /// The entry exists and has expired. Only a restore brings it back.
+    ///
+    /// The RPC returns such an entry with a live-until ledger of zero, because
+    /// core does not record the ledger at which an entry was archived.
+    Archived,
+    /// The entry is live through the given ledger, inclusive.
+    Live(u32),
+}
+
+/// A key and the state the RPC reported for it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Measured {
+    /// The key the measurement was taken for.
+    pub key: LedgerKey,
+    /// The state of the entry under that key.
+    pub lifetime: Lifetime,
+}
+
+/// The states of a set of keys, as of one ledger.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Measurement {
+    /// One entry per key measured, in the order the keys were given.
+    pub entries: Vec<Measured>,
+    /// The latest ledger the RPC had closed when it answered.
+    ///
+    /// Remaining lifetimes are counted from here, so the threshold is judged
+    /// against the same ledger the entries were read at.
+    pub latest_ledger: u32,
+}
+
+/// Reads the state of every key, in chunks the RPC accepts.
+///
+/// # Errors
+///
+/// Returns an error if a key cannot be encoded, the RPC refuses a chunk, or
+/// the RPC returns an entry without a lifetime, which only a classic ledger
+/// entry has and the keeper never asks for.
+pub async fn measure(client: &Client, keys: &[LedgerKey]) -> Result<Measurement> {
+    let mut reported = Vec::with_capacity(keys.len());
+    let mut latest_ledger = 0;
+
+    for chunk in keys.chunks(LEDGER_KEY_CHUNK) {
+        let response = client
+            .get_ledger_entries(chunk)
+            .await
+            .context("read ledger entries")?;
+        let latest = u32::try_from(response.latest_ledger)
+            .context("the RPC's latest ledger does not fit into u32")?;
+        latest_ledger = latest_ledger.max(latest);
+
+        let live_by_key: HashMap<_, _> = response
+            .entries
+            .unwrap_or_default()
+            .into_iter()
+            .map(|entry| (entry.key, entry.live_until_ledger_seq))
+            .collect();
+        for key in chunk {
+            let encoded = key.to_xdr_base64(Limits::none())?;
+            reported.push((key, live_by_key.get(&encoded).copied()));
+        }
+    }
+
+    // Classify against one ledger for every chunk, so a key that expires
+    // between two reads is archived here rather than live with nothing left.
+    let entries = reported
+        .into_iter()
+        .map(|(key, live_until)| {
+            Ok(Measured {
+                key: key.clone(),
+                lifetime: lifetime(live_until, latest_ledger)
+                    .with_context(|| format!("entry {key:?}"))?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(Measurement {
+        entries,
+        latest_ledger,
+    })
+}
+
+/// Classifies one `getLedgerEntries` answer for a key.
+///
+/// `reported` is `None` when the response held no entry for the key, and
+/// otherwise carries the entry's `liveUntilLedgerSeq` field. The RPC sets
+/// that field to zero for an archived entry; an expiry ledger already behind
+/// `latest` is read the same way, so a future RPC that reports the real
+/// expiry ledger still classifies correctly.
+fn lifetime(reported: Option<Option<u32>>, latest: u32) -> Result<Lifetime> {
+    match reported {
+        None => Ok(Lifetime::Absent),
+        Some(Some(live_until)) if live_until >= latest => Ok(Lifetime::Live(live_until)),
+        Some(Some(_)) => Ok(Lifetime::Archived),
+        Some(None) => bail!("the entry has no lifetime, so it is not contract data or code"),
+    }
+}
+
+/// Reads the network's maximum entry lifetime, in ledgers.
+///
+/// An `ExtendFootprintTtl` whose target exceeds this value less one is
+/// malformed, and the simulation does not say so, so the keeper caps its
+/// target against the value the network holds rather than assuming one.
+///
+/// # Errors
+///
+/// Returns an error if the RPC refuses the request or does not return the
+/// state archival settings.
+pub async fn max_entry_ttl(client: &Client) -> Result<u32> {
+    let key = LedgerKey::ConfigSetting(xdr::LedgerKeyConfigSetting {
+        config_setting_id: xdr::ConfigSettingId::StateArchival,
+    });
+    let response = client
+        .get_ledger_entries(std::slice::from_ref(&key))
+        .await
+        .context("read the state archival settings")?;
+    let entry = response
+        .entries
+        .unwrap_or_default()
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow!("the RPC holds no state archival settings"))?;
+    max_entry_ttl_from(&xdr::LedgerEntryData::from_xdr_base64(
+        &entry.xdr,
+        Limits::none(),
+    )?)
+}
+
+/// Returns the lifetime an extension asks for.
+///
+/// `requested` is the operator's target, or `None` for the longest the network
+/// allows. Either way the answer stays below `max_entry_ttl`, because an
+/// `ExtendFootprintTtl` whose target is the maximum itself is malformed.
+pub fn extend_target(requested: Option<u32>, max_entry_ttl: u32) -> u32 {
+    let longest = max_entry_ttl.saturating_sub(1);
+    requested.map_or(longest, |target| target.min(longest))
+}
+
+fn max_entry_ttl_from(data: &xdr::LedgerEntryData) -> Result<u32> {
+    match data {
+        xdr::LedgerEntryData::ConfigSetting(xdr::ConfigSettingEntry::StateArchival(settings)) => {
+            Ok(settings.max_entry_ttl)
+        }
+        other => bail!("expected the state archival settings, got {other:?}"),
+    }
+}
+
+/// Returns the keys the RPC reported archived.
+///
+/// These are the only keys a restore may name. A key the RPC did not return
+/// was never written, and naming it in a restore fails the simulation for
+/// every other key in the batch.
+pub fn archived(measurement: &Measurement) -> Vec<LedgerKey> {
+    measurement
+        .entries
+        .iter()
+        .filter(|m| m.lifetime == Lifetime::Archived)
+        .map(|m| m.key.clone())
+        .collect()
+}
+
+/// Returns the live keys whose remaining lifetime has fallen to `threshold`
+/// or below.
+///
+/// The boundary is inclusive: a key with exactly `threshold` ledgers left is
+/// extended, so a keeper running on a fixed interval never watches an entry
+/// cross the line between two rounds.
+pub fn below_threshold(measurement: &Measurement, threshold: u32) -> Vec<LedgerKey> {
+    measurement
+        .entries
+        .iter()
+        .filter(|m| match m.lifetime {
+            Lifetime::Live(live_until) => {
+                live_until.saturating_sub(measurement.latest_ledger) <= threshold
+            }
+            Lifetime::Absent | Lifetime::Archived => false,
+        })
+        .map(|m| m.key.clone())
+        .collect()
+}
+
+/// Returns the shortest remaining lifetime of each contract's entries.
+///
+/// `extended` names the keys this round lifted to `extend_to`, which the
+/// measurement was taken before. An archived key the round did not restore
+/// reports zero, so the alert on the minimum stays raised until it is. Keys
+/// that name no contract, such as uploaded wasm, are left out: their lifetime
+/// is reported against the contracts that run them.
+pub fn lowest_by_contract(
+    measurement: &Measurement,
+    extended: &[LedgerKey],
+    extend_to: u32,
+) -> BTreeMap<String, u32> {
+    let extended: HashSet<&LedgerKey> = extended.iter().collect();
+    let mut lowest: BTreeMap<String, u32> = BTreeMap::new();
+
+    for entry in &measurement.entries {
+        let LedgerKey::ContractData(data) = &entry.key else {
+            continue;
+        };
+        let remaining = match entry.lifetime {
+            _ if extended.contains(&entry.key) => extend_to,
+            Lifetime::Live(live_until) => live_until.saturating_sub(measurement.latest_ledger),
+            Lifetime::Archived => 0,
+            Lifetime::Absent => continue,
+        };
+        lowest
+            .entry(data.contract.to_string())
+            .and_modify(|current| *current = (*current).min(remaining))
+            .or_insert(remaining);
+    }
+    lowest
+}
+
+fn footprint(
+    read_only: Vec<LedgerKey>,
+    read_write: Vec<LedgerKey>,
+) -> Result<xdr::LedgerFootprint> {
+    Ok(xdr::LedgerFootprint {
+        read_only: read_only.try_into()?,
+        read_write: read_write.try_into()?,
+    })
+}
+
+fn envelope(
+    source: &str,
+    sequence: i64,
+    operation: xdr::OperationBody,
+    footprint: xdr::LedgerFootprint,
+) -> Result<xdr::TransactionEnvelope> {
+    let xdr::ScAddress::Account(xdr::AccountId(xdr::PublicKey::PublicKeyTypeEd25519(key))) =
+        address(source)?
+    else {
+        bail!("the keeper source must be an account address");
+    };
+    let account = xdr::MuxedAccount::Ed25519(key);
+    let data = xdr::SorobanTransactionData {
+        ext: xdr::SorobanTransactionDataExt::V0,
+        resources: xdr::SorobanResources {
+            footprint,
+            instructions: 0,
+            disk_read_bytes: 0,
+            write_bytes: 0,
+        },
+        resource_fee: 0,
+    };
+    Ok(xdr::TransactionEnvelope::Tx(xdr::TransactionV1Envelope {
+        tx: xdr::Transaction {
+            source_account: account,
+            fee: BASE_FEE,
+            seq_num: xdr::SequenceNumber(sequence),
+            cond: xdr::Preconditions::None,
+            memo: xdr::Memo::None,
+            operations: vec![xdr::Operation {
+                source_account: None,
+                body: operation,
+            }]
+            .try_into()?,
+            ext: xdr::TransactionExt::V1(data),
+        },
+        signatures: xdr::VecM::default(),
+    }))
+}
+
+/// Builds the unsigned transaction that extends `keys` to `extend_to`.
+///
+/// The keys go in the read-only footprint, which is what
+/// `ExtendFootprintTtl` reads.
+///
+/// # Errors
+///
+/// Returns an error if the source account is not a valid strkey, or the
+/// footprint exceeds the XDR vector limit.
+pub fn extend_envelope(
+    source: &str,
+    sequence: i64,
+    keys: Vec<LedgerKey>,
+    extend_to: u32,
+) -> Result<xdr::TransactionEnvelope> {
+    envelope(
+        source,
+        sequence,
+        xdr::OperationBody::ExtendFootprintTtl(xdr::ExtendFootprintTtlOp {
+            ext: xdr::ExtensionPoint::V0,
+            extend_to,
+        }),
+        footprint(keys, Vec::new())?,
+    )
+}
+
+/// Builds the unsigned transaction that restores `keys`.
+///
+/// The keys go in the read-write footprint, because a restore rewrites the
+/// entries it brings back.
+///
+/// # Errors
+///
+/// Returns an error if the source account is not a valid strkey, or the
+/// footprint exceeds the XDR vector limit.
+pub fn restore_envelope(
+    source: &str,
+    sequence: i64,
+    keys: Vec<LedgerKey>,
+) -> Result<xdr::TransactionEnvelope> {
+    envelope(
+        source,
+        sequence,
+        xdr::OperationBody::RestoreFootprint(xdr::RestoreFootprintOp {
+            ext: xdr::ExtensionPoint::V0,
+        }),
+        footprint(Vec::new(), keys)?,
+    )
+}
+
+/// A lifetime transaction with the resources its simulation returned.
+///
+/// The simulation drops keys that need nothing from the footprint: a
+/// never-written key from either operation, a live key from a restore, and a
+/// key already above the target from an extend. `keys` is what remains, so
+/// an empty list means the transaction would do nothing.
+#[derive(Debug)]
+pub struct Simulated {
+    envelope: xdr::TransactionEnvelope,
+    /// The keys the simulation kept in the footprint.
+    pub keys: Vec<LedgerKey>,
+    /// The keys the RPC requires restored before this transaction can run.
+    ///
+    /// Only an extend can carry these, and only when the RPC's simulation
+    /// treats as archived a key its `getLedgerEntries` reported live.
+    pub restore_first: Vec<LedgerKey>,
+}
+
+/// Simulates one lifetime transaction and applies the resources it returns.
+///
+/// # Errors
+///
+/// Returns an error if the RPC refuses the request or reports a simulation
+/// error, which a restore naming a never-written key does.
+pub async fn simulate(client: &Client, raw: xdr::TransactionEnvelope) -> Result<Simulated> {
+    let simulation = client
+        .simulate_transaction(&raw)
+        .await
+        .context("simulate lifetime transaction")?;
+    simulation.ensure_success()?;
+    simulated(
+        raw,
+        simulation.soroban_transaction_data()?,
+        simulation.min_resource_fee_u64()?,
+        simulation
+            .restore_preamble
+            .as_ref()
+            .map(|preamble| preamble.transaction_data.as_str()),
+    )
+}
+
+/// Assembles the simulated transaction from the parts of the RPC's answer.
+///
+/// `preamble_data` is the `transactionData` of the restore preamble, when the
+/// simulation returned one.
+fn simulated(
+    raw: xdr::TransactionEnvelope,
+    data: xdr::SorobanTransactionData,
+    resource_fee: u64,
+    preamble_data: Option<&str>,
+) -> Result<Simulated> {
+    let footprint = &data.resources.footprint;
+    let keys = footprint
+        .read_only
+        .iter()
+        .chain(footprint.read_write.iter())
+        .cloned()
+        .collect();
+    let restore_first = match preamble_data {
+        Some(encoded) => xdr::SorobanTransactionData::from_xdr_base64(encoded, Limits::none())
+            .context("decode the restore preamble")?
+            .resources
+            .footprint
+            .read_write
+            .to_vec(),
+        None => Vec::new(),
+    };
+    let envelope = with_simulated_resources(&raw, data, resource_fee)?;
+    Ok(Simulated {
+        envelope,
+        keys,
+        restore_first,
+    })
+}
+
+/// Applies the resource estimate a simulation returned to `raw`.
+fn with_simulated_resources(
+    raw: &xdr::TransactionEnvelope,
+    data: xdr::SorobanTransactionData,
+    resource_fee: u64,
+) -> Result<xdr::TransactionEnvelope> {
+    let xdr::TransactionEnvelope::Tx(v1) = raw else {
+        bail!("expected a v1 transaction envelope");
+    };
+    let fee: u32 = u64::from(BASE_FEE)
+        .saturating_add(resource_fee)
+        .try_into()
+        .map_err(|_| anyhow!("transaction fee does not fit into u32"))?;
+
+    let mut tx = v1.tx.clone();
+    tx.fee = fee;
+    tx.ext = xdr::TransactionExt::V1(data);
+    Ok(xdr::TransactionEnvelope::Tx(xdr::TransactionV1Envelope {
+        tx,
+        signatures: xdr::VecM::default(),
+    }))
+}
+
+/// Signs, submits, and confirms a simulated lifetime transaction.
+///
+/// # Errors
+///
+/// Returns an error if the RPC rejects the submission, or the transaction
+/// does not succeed within the confirmation window.
+pub async fn send(
+    client: &Client,
+    signer: &LocalSigner,
+    network_passphrase: &str,
+    simulated: &Simulated,
+) -> Result<String> {
+    let signed = signer.sign_transaction(simulated.envelope.clone(), network_passphrase)?;
+    let sent = client
+        .send_transaction(&signed)
+        .await
+        .context("submit lifetime transaction")?;
+
+    for _ in 0..CONFIRM_ATTEMPTS {
+        tokio::time::sleep(Duration::from_secs(CONFIRM_INTERVAL_SECS)).await;
+        let status = client.get_transaction(&sent.hash).await?.status;
+        match status.as_str() {
+            "SUCCESS" => return Ok(sent.hash),
+            "NOT_FOUND" => continue,
+            other => bail!("transaction {} ended {other}", sent.hash),
+        }
+    }
+    bail!("transaction {} did not confirm", sent.hash)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SOURCE: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+    fn key(byte: u8) -> LedgerKey {
+        LedgerKey::ContractCode(xdr::LedgerKeyContractCode {
+            hash: xdr::Hash([byte; 32]),
+        })
+    }
+
+    fn contract(byte: u8) -> xdr::ScAddress {
+        xdr::ScAddress::Contract(xdr::ContractId(xdr::Hash([byte; 32])))
+    }
+
+    fn data(byte: u8, name: &str) -> LedgerKey {
+        LedgerKey::ContractData(xdr::LedgerKeyContractData {
+            contract: contract(byte),
+            key: xdr::ScVal::Symbol(xdr::ScSymbol::try_from(name).expect("symbol")),
+            durability: xdr::ContractDataDurability::Persistent,
+        })
+    }
+
+    fn resources(envelope: &xdr::TransactionEnvelope) -> xdr::SorobanResources {
+        let xdr::TransactionEnvelope::Tx(v1) = envelope else {
+            panic!("expected a v1 envelope");
+        };
+        let xdr::TransactionExt::V1(data) = &v1.tx.ext else {
+            panic!("expected soroban transaction data");
+        };
+        data.resources.clone()
+    }
+
+    fn operation(envelope: &xdr::TransactionEnvelope) -> xdr::OperationBody {
+        let xdr::TransactionEnvelope::Tx(v1) = envelope else {
+            panic!("expected a v1 envelope");
+        };
+        v1.tx
+            .operations
+            .first()
+            .expect("one operation")
+            .body
+            .clone()
+    }
+
+    fn transaction_data(
+        read_only: Vec<LedgerKey>,
+        read_write: Vec<LedgerKey>,
+    ) -> xdr::SorobanTransactionData {
+        xdr::SorobanTransactionData {
+            ext: xdr::SorobanTransactionDataExt::V0,
+            resources: xdr::SorobanResources {
+                footprint: footprint(read_only, read_write).expect("footprint"),
+                instructions: 0,
+                disk_read_bytes: 0,
+                write_bytes: 0,
+            },
+            resource_fee: 500,
+        }
+    }
+
+    /// The shape `getLedgerEntries` answers with on the RPC the keeper runs
+    /// against: an archived entry is returned with a live-until ledger of
+    /// zero, and a never-written key is not returned at all.
+    #[test]
+    fn the_rpc_answer_classifies_into_absent_archived_and_live() {
+        assert_eq!(lifetime(None, 1_000).expect("absent"), Lifetime::Absent);
+        assert_eq!(
+            lifetime(Some(Some(0)), 1_000).expect("archived"),
+            Lifetime::Archived
+        );
+        assert_eq!(
+            lifetime(Some(Some(1_000)), 1_000).expect("live"),
+            Lifetime::Live(1_000)
+        );
+        assert_eq!(
+            lifetime(Some(Some(4_707_343)), 1_000).expect("live"),
+            Lifetime::Live(4_707_343)
+        );
+        // An expiry ledger the RPC has already passed is archived, whatever
+        // placeholder the RPC uses.
+        assert_eq!(
+            lifetime(Some(Some(999)), 1_000).expect("expired"),
+            Lifetime::Archived
+        );
+        assert!(lifetime(Some(None), 1_000).is_err());
+    }
+
+    /// The invariant every transaction rests on: a restore names only keys
+    /// the RPC reported archived, an extend only keys it reported live, and a
+    /// key it did not report appears in neither.
+    #[test]
+    fn only_reported_keys_are_restored_or_extended() {
+        let measurement = Measurement {
+            entries: vec![
+                Measured {
+                    key: key(1),
+                    lifetime: Lifetime::Absent,
+                },
+                Measured {
+                    key: key(2),
+                    lifetime: Lifetime::Archived,
+                },
+                Measured {
+                    key: key(3),
+                    lifetime: Lifetime::Live(1_100),
+                },
+                Measured {
+                    key: key(4),
+                    lifetime: Lifetime::Live(1_101),
+                },
+            ],
+            latest_ledger: 1_000,
+        };
+
+        assert_eq!(archived(&measurement), vec![key(2)]);
+        assert_eq!(below_threshold(&measurement, 100), vec![key(3)]);
+    }
+
+    #[test]
+    fn the_maximum_entry_lifetime_is_read_from_the_state_archival_settings() {
+        let settings = xdr::LedgerEntryData::ConfigSetting(xdr::ConfigSettingEntry::StateArchival(
+            xdr::StateArchivalSettings {
+                max_entry_ttl: 3_110_400,
+                min_temporary_ttl: 16,
+                min_persistent_ttl: 120_960,
+                persistent_rent_rate_denominator: 1,
+                temp_rent_rate_denominator: 1,
+                max_entries_to_archive: 1,
+                live_soroban_state_size_window_sample_size: 1,
+                live_soroban_state_size_window_sample_period: 1,
+                eviction_scan_size: 1,
+                starting_eviction_scan_level: 1,
+            },
+        ));
+        assert_eq!(max_entry_ttl_from(&settings).expect("settings"), 3_110_400);
+
+        let other =
+            xdr::LedgerEntryData::ConfigSetting(xdr::ConfigSettingEntry::ContractMaxSizeBytes(1));
+        assert!(max_entry_ttl_from(&other).is_err());
+    }
+
+    #[test]
+    fn the_extend_target_stays_below_the_network_maximum() {
+        assert_eq!(extend_target(None, 3_110_400), 3_110_399);
+        assert_eq!(extend_target(Some(3_110_400), 3_110_400), 3_110_399);
+        assert_eq!(extend_target(Some(100), 3_110_400), 100);
+        assert_eq!(extend_target(Some(5), 0), 0);
+    }
+
+    #[test]
+    fn the_extend_transaction_reads_its_keys_and_carries_the_target_ledger() {
+        let keys = vec![key(1), key(2)];
+        let envelope = extend_envelope(SOURCE, 7, keys.clone(), 3_110_400).expect("envelope");
+
+        let footprint = resources(&envelope).footprint;
+        assert_eq!(footprint.read_only.to_vec(), keys);
+        assert!(footprint.read_write.is_empty());
+        assert_eq!(
+            operation(&envelope),
+            xdr::OperationBody::ExtendFootprintTtl(xdr::ExtendFootprintTtlOp {
+                ext: xdr::ExtensionPoint::V0,
+                extend_to: 3_110_400,
+            })
+        );
+    }
+
+    #[test]
+    fn the_restore_transaction_writes_its_keys() {
+        let keys = vec![key(3), key(4)];
+        let envelope = restore_envelope(SOURCE, 7, keys.clone()).expect("envelope");
+
+        let footprint = resources(&envelope).footprint;
+        assert_eq!(footprint.read_write.to_vec(), keys);
+        assert!(footprint.read_only.is_empty());
+        assert!(matches!(
+            operation(&envelope),
+            xdr::OperationBody::RestoreFootprint(_)
+        ));
+    }
+
+    /// The simulation prunes the footprint to the keys that need the
+    /// operation, and the keeper counts and extends only those.
+    #[test]
+    fn a_simulation_reports_the_keys_it_kept_and_the_fee_it_priced() {
+        let raw =
+            extend_envelope(SOURCE, 7, vec![key(1), key(2), key(3)], 3_110_400).expect("envelope");
+        let simulated = simulated(
+            raw,
+            transaction_data(vec![key(1), key(3)], Vec::new()),
+            500,
+            None,
+        )
+        .expect("simulated");
+
+        assert_eq!(simulated.keys, vec![key(1), key(3)]);
+        assert!(simulated.restore_first.is_empty());
+        let xdr::TransactionEnvelope::Tx(v1) = &simulated.envelope else {
+            panic!("expected a v1 envelope");
+        };
+        assert_eq!(v1.tx.fee, 600);
+    }
+
+    /// An extend whose simulation carries a restore preamble names a key the
+    /// RPC's ledger-state answer called live and its simulation calls
+    /// archived. The keys the preamble would restore are surfaced so the
+    /// round can restore them first.
+    #[test]
+    fn a_restore_preamble_surfaces_the_keys_to_restore_first() {
+        let raw = extend_envelope(SOURCE, 7, vec![key(1), key(2)], 3_110_400).expect("envelope");
+        let preamble = transaction_data(Vec::new(), vec![key(2)])
+            .to_xdr_base64(Limits::none())
+            .expect("encode preamble");
+
+        let simulated = simulated(
+            raw,
+            transaction_data(vec![key(1), key(2)], Vec::new()),
+            500,
+            Some(&preamble),
+        )
+        .expect("simulated");
+        assert_eq!(simulated.restore_first, vec![key(2)]);
+    }
+
+    #[test]
+    fn a_preamble_that_does_not_decode_is_an_error() {
+        let raw = extend_envelope(SOURCE, 7, vec![key(1)], 3_110_400).expect("envelope");
+        let result = simulated(
+            raw,
+            transaction_data(vec![key(1)], Vec::new()),
+            500,
+            Some("not xdr"),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn the_lowest_remaining_lifetime_is_reported_for_each_contract() {
+        let measurement = Measurement {
+            entries: vec![
+                Measured {
+                    key: data(1, "a"),
+                    lifetime: Lifetime::Live(1_500),
+                },
+                Measured {
+                    key: data(1, "b"),
+                    lifetime: Lifetime::Live(1_200),
+                },
+                Measured {
+                    key: data(2, "a"),
+                    lifetime: Lifetime::Live(1_900),
+                },
+                Measured {
+                    key: data(3, "a"),
+                    lifetime: Lifetime::Archived,
+                },
+                Measured {
+                    key: data(4, "a"),
+                    lifetime: Lifetime::Absent,
+                },
+                Measured {
+                    key: key(7),
+                    lifetime: Lifetime::Live(1_001),
+                },
+            ],
+            latest_ledger: 1_000,
+        };
+
+        let lowest = lowest_by_contract(&measurement, &[], 3_110_400);
+        assert_eq!(lowest.len(), 3);
+        assert_eq!(lowest[&contract(1).to_string()], 200);
+        assert_eq!(lowest[&contract(2).to_string()], 900);
+        // An archived entry nobody restored has no lifetime left, and a key
+        // that does not exist has nothing to report.
+        assert_eq!(lowest[&contract(3).to_string()], 0);
+        assert!(!lowest.contains_key(&contract(4).to_string()));
+
+        // The round lifted the shortest-lived entry, so it reports the target.
+        let lifted = lowest_by_contract(&measurement, &[data(1, "b")], 3_110_400);
+        assert_eq!(lifted[&contract(1).to_string()], 1_500 - 1_000);
+        // A restored and extended entry reports the target too.
+        let restored = lowest_by_contract(&measurement, &[data(3, "a")], 3_110_400);
+        assert_eq!(restored[&contract(3).to_string()], 3_110_400);
+    }
+}

--- a/tools/ttl-keeper/src/state.rs
+++ b/tools/ttl-keeper/src/state.rs
@@ -1,0 +1,117 @@
+//! Nullifier cursor persisted between keeper rounds.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::Path,
+};
+
+/// Nullifiers discovered from pool events, and where event paging stopped.
+///
+/// Nullifier ledger entries cannot be derived from the manifest, so the keeper
+/// accumulates them from `NewNullifierEvent` and keeps them here. Each
+/// nullifier is a 32-byte big-endian integer in lowercase hexadecimal, without
+/// a `0x` prefix.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct State {
+    /// Event cursor from the last page the keeper read, absent before the
+    /// first round.
+    #[serde(default)]
+    pub cursor: Option<String>,
+    /// Nullifiers seen so far, keyed by pool contract id.
+    ///
+    /// A set rather than a list: this is the one value in the file that grows
+    /// without bound, and every round re-reads the pages it has already seen
+    /// when a cursor is refused.
+    #[serde(default)]
+    pub nullifiers: BTreeMap<String, BTreeSet<String>>,
+}
+
+impl State {
+    /// Reads the state file, returning an empty state when it does not exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file exists but cannot be read or parsed.
+    pub fn load(path: &Path) -> Result<Self> {
+        match fs::read_to_string(path) {
+            Ok(raw) => serde_json::from_str(&raw)
+                .with_context(|| format!("parse state file {}", path.display())),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(e).with_context(|| format!("read state file {}", path.display())),
+        }
+    }
+
+    /// Writes the state through a temporary file and a rename.
+    ///
+    /// A round that dies mid-write leaves either the previous state or the new
+    /// one, never a truncated file that the next round would fail to parse.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the temporary file cannot be written or renamed.
+    pub fn store(&self, path: &Path) -> Result<()> {
+        let tmp = path.with_extension("json.tmp");
+        let encoded = serde_json::to_string_pretty(self).context("encode keeper state")?;
+        fs::write(&tmp, encoded).with_context(|| format!("write {}", tmp.display()))?;
+        fs::rename(&tmp, path).with_context(|| format!("rename {}", tmp.display()))
+    }
+
+    /// Records nullifiers against a pool.
+    pub fn extend_pool(&mut self, pool_id: &str, nullifiers: impl IntoIterator<Item = String>) {
+        self.nullifiers
+            .entry(pool_id.to_owned())
+            .or_default()
+            .extend(nullifiers);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> State {
+        let mut state = State {
+            cursor: Some("0004-000".into()),
+            nullifiers: BTreeMap::new(),
+        };
+        state.extend_pool("CPOOL", ["aa".to_string(), "bb".to_string()]);
+        state
+    }
+
+    #[test]
+    fn the_state_file_round_trips_and_survives_a_truncated_temporary_file() {
+        let dir = std::env::temp_dir().join(format!("ttl-keeper-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("keeper-state.json");
+
+        sample().store(&path).expect("store");
+        assert_eq!(State::load(&path).expect("load"), sample());
+
+        // A round killed mid-write leaves the temporary file behind; the state
+        // file itself is whole because the rename is atomic.
+        std::fs::write(path.with_extension("json.tmp"), "{\"cursor\":").expect("truncated tmp");
+        assert_eq!(State::load(&path).expect("load after crash"), sample());
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn a_missing_state_file_loads_as_empty() {
+        let path =
+            std::env::temp_dir().join(format!("ttl-keeper-absent-{}.json", std::process::id()));
+        assert_eq!(State::load(&path).expect("load"), State::default());
+    }
+
+    #[test]
+    fn appending_a_known_nullifier_does_not_duplicate_it() {
+        let mut state = sample();
+        state.extend_pool("CPOOL", ["bb".to_string(), "cc".to_string()]);
+        assert_eq!(
+            state.nullifiers["CPOOL"],
+            BTreeSet::from(["aa".to_string(), "bb".to_string(), "cc".to_string()])
+        );
+    }
+}


### PR DESCRIPTION
The contracts now extend the lifetime of every entry a call touches, and the SDK restores an
entry that has already archived. Neither reaches an entry that nothing calls. This PR adds the
service that does.

## What is left uncovered without it

A call renews only what it touches, on purpose: a `transact` that bumped all ninety root-history
slots and every level's zero hash would add over a hundred entries to its footprint and charge
every user for entries their transaction never read. What that leaves behind is an idle pool's
untouched ring slots, old nullifiers, the sparse tree's long tail, the governor's queue index and
role entries, and every pause entry. Reaching those needs something that runs without a user
transaction.

## How it decides what to touch

`ttl-keeper` reads the deployment manifest and enumerates ledger keys per contract:

- every contract in the manifest gets its instance entry and the `LedgerKeyContractCode` of the
  wasm hash read from that instance;
- pools get the enum keys plus `Pause`, `FilledSubtree(0..=levels)`, `Zeroes(0..=levels)`,
  `Root(0..90)`, and one `Nullifier(n)` per nullifier;
- `asp-membership` gets `Admin`, `Levels`, `NextIndex`, `Root`, `Pause`, and its subtree and zero
  arrays;
- `asp-non-membership` gets `Admin`, `Root`, `Pause`, and every `Node(h)` reached by a
  breadth-first walk from the root value, where an internal node's value names its two children
  and a zero child is absent;
- the governor gets `Pending`, an `Operation(id)` and `OperationLedger(id)` for each pending id,
  the permission rows the manifest implies, and OpenZeppelin's `ExistingRoles`,
  `HasRole(member, role)`, `RoleAccountsCount(role)`, and `RoleAccounts(role, i)` entries.

The blocklist ASP needs the tree walk because `asp-non-membership` is not in
`ContractConfig::all_contract_ids`, so neither the SDK nor the bootnode indexes its events.
Nullifiers come from `NewNullifierEvent`, which the SDK already stores; the keeper pages those
from the bootnode, falls back to the RPC, and keeps its cursor and the nullifier list in a state
file written through a temporary file and a rename.

`OperationLedger(id)` and `Operation(id)` share an id, and extending one without the other would
leave an operation half alive. `ExistingRoles` and the role entries are written once and touched
only on a role change, which makes them the entries most likely to archive first.

## Live, archived, or absent

Each key is classified from the `getLedgerEntries` response into three states. Absent when the
RPC returns no entry. Archived when it returns the entry with a `liveUntilLedgerSeq` of `0`,
which is the RPC's placeholder for an archived entry since protocol 23, or a value below the
response's own `latestLedger`. Live otherwise.

Only archived keys are restored, only live keys inside the threshold are extended, and an absent
key is never named in a transaction. The first commit in this PR is the seven-line SDK change
that surfaces `liveUntilLedgerSeq` from `getLedgerEntries`; the keeper is its only consumer.

The keeper refuses to start against an RPC below protocol 23, because earlier versions omit
archived entries the same way they omit keys that were never written, so nothing would ever be
restored.

Two details that cost a debugging session each:

`extend_target` reads the network's state archival settings every round and targets the maximum
minus one. An `ExtendFootprintTtl` whose target is the maximum itself is malformed on chain, and
the simulation does not say so.

An extend whose simulation comes back with a `restorePreamble` names a key the RPC reported live
and the simulation calls archived. The keeper restores those keys, counts the disagreement, and
simulates again.

## A round

Build keys, measure, restore the archived keys, then extend the live keys inside the threshold
together with the keys restored this round, since a restored entry holds the network minimum.
The two phases are independent: a restore that fails is recorded and the extend phase still
runs, and the round returns the first error once both have finished. A failed round logs and
retries on the next tick rather than exiting.

`--dry-run` logs every key the round would restore or extend and exits without submitting.
`--once` exits after one round.

## Not covered, deliberately

The keeper touches nothing it cannot enumerate from the manifest. A permission-table row added
after deployment stays alive through use until the manifest names it.

## Reading it

This is a new binary crate under `tools/ttl-keeper/` that nothing else in the tree depends on,
so it reads as one new program rather than as changes threaded through existing code. Read
`keys.rs` first: whether the key enumeration is complete is the question that matters, and it is
the one thing a reviewer cannot check by reading any other file.

Part of #372.
