### PR TITLE
Stand up the governor and monitor the keeper

### DIFF
--- a/.github/workflows/deployment-verify.yml
+++ b/.github/workflows/deployment-verify.yml
@@ -1,0 +1,53 @@
+name: Deployment Verify
+
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Network to check"
+        default: testnet
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "deployments/*/deployments.json"
+      - "deployments/scripts/verify-deployment.sh"
+      - ".github/workflows/deployment-verify.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "deployments/*/deployments.json"
+      - "deployments/scripts/verify-deployment.sh"
+      - ".github/workflows/deployment-verify.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  verify-deployment:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install Stellar CLI
+        uses: stellar/stellar-cli@8e402ea28202950b272fbabc34caad4d2f64fe87 # v27.1.0
+        with:
+          version: v27.1.0
+
+      # The trigger fires on any network's manifest, so a run with no network named checks
+      # every manifest in the tree rather than assuming one. The input reaches the shell as
+      # an environment variable, never as interpolated source.
+      - name: Verify deployment
+        env:
+          NETWORK: ${{ inputs.network }}
+        run: |
+          if [[ -n "$NETWORK" ]]; then
+            deployments/scripts/verify-deployment.sh "$NETWORK"
+          else
+            for manifest in deployments/*/deployments.json; do
+              deployments/scripts/verify-deployment.sh "$(basename "$(dirname "$manifest")")"
+            done
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,6 +212,34 @@ Allowlist + blocklist pool:
   --pool native:$(stellar contract id asset --asset native --network testnet)
 ```
 
+#### Governance
+
+The governance flags are optional as a group. Passing any of the nine makes `--council`,
+`--operator`, `--guardian`, `--recovery`, and `--ttl-keeper` required, and the four role
+addresses must be distinct. The script then deploys the governor after the pools and calls
+`update_admin` on both ASPs and every pool, so the governor becomes the admin of each one. It
+reads every target back afterwards and fails with the list of any handoff that did not take.
+The four delays are counts of ledgers: `--delay`, `--recovery-delay`, `--grace`, and
+`--guardian-pause` default to 360, 720, 17280, and 720 off mainnet. Mainnet requires all four
+and refuses a `--delay` below 120960 ledgers, seven days at a five-second close. The manifest
+gains a `governance` block holding the governor id, the five addresses, and the four delays,
+and its `admin` field becomes the governor id.
+
+```sh
+./deployments/scripts/deploy.sh testnet \
+  --deployer <identity> \
+  --policy-flags blocklist \
+  --asp-levels 10 \
+  --pool-levels 20 \
+  --max-deposit 1000000000 \
+  --pool native:$(stellar contract id asset --asset native --network testnet) \
+  --council <council> \
+  --operator <operator> \
+  --guardian <guardian> \
+  --recovery <recovery> \
+  --ttl-keeper <ttl-keeper>
+```
+
 ### End-to-End Tests
 
 The E2E tests generate real Groth16 proofs and verify them, locally, using contracts and the Soroban-SDK. To run them:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,6 +2963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -3974,6 +3975,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "indexmap 2.14.0",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "metrics",
+ "quanta",
+ "rand 0.9.5",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "minicov"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4669,6 +4716,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4856,10 +4918,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rangemap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a611d15b50743feb4c76b7d03edcb0e64f399c26961e4efe6975bc398be6aa3d"
+
+[[package]]
+name = "rapidhash"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.1",
+]
 
 [[package]]
 name = "rayon"
@@ -5703,6 +5792,12 @@ name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -6694,6 +6789,8 @@ dependencies = [
  "anyhow",
  "clap",
  "hex",
+ "metrics",
+ "metrics-exporter-prometheus",
  "serde",
  "serde_json",
  "stellar-private-payments",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,8 @@ governor = { path = "contracts/governor" }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 js-sys = "0.3"
 log = { version = "0.4", default-features = false }
+metrics = "0.24.6"
+metrics-exporter-prometheus = { version = "0.16.2", default-features = false }
 num-bigint = { version = "0.4.8", default-features = false, features = ["serde"] }
 num-integer = { version = "0.1.46", default-features = false }
 pool = { path = "contracts/pool" }

--- a/deployments/scripts/deploy.sh
+++ b/deployments/scripts/deploy.sh
@@ -53,6 +53,18 @@ Options:
   --yes                 Skip confirmation for mainnet
   -h, --help            Show this help
 
+Governance options (optional as a group; passing any one requires --council,
+--operator, --guardian, --recovery, and --ttl-keeper):
+  --council ADDRESS     Holder of the council role, which queues and cancels operations
+  --operator ADDRESS    Holder of the operator role, which writes the ASP lists
+  --guardian ADDRESS    Holder of the guardian role, which pauses without the queue
+  --recovery ADDRESS    Holder of the recovery role, which queues role changes
+  --ttl-keeper ADDRESS  Account the TTL keeper sends from, recorded in the manifest
+  --delay N             Ledgers a council operation waits (default 360 off mainnet)
+  --recovery-delay N    Ledgers a recovery operation waits (default 720 off mainnet)
+  --grace N             Ledgers a ready operation stays executable (default 17280 off mainnet)
+  --guardian-pause N    Ledgers a guardian pause holds (default 720 off mainnet)
+
 Examples:
   # Mixed policies in one deployment (two verifiers, shared ASP contracts)
   deployments/scripts/deploy.sh futurenet \
@@ -79,6 +91,9 @@ Notes:
   - Provide --vk-file/--vk-json only for ceremony allowlist-blocklist (AB) keys; other VKs
     are taken from deployments/<network>/circuit_keys/ automatically.
   - If neither --token nor --pool is provided, one native XLM pool is deployed by default.
+  - With the governance options the governor is deployed after the pools and becomes the
+    admin of both ASPs and every pool. The four role addresses must be distinct, and mainnet
+    requires all four delays.
 USAGE
   exit 2
 }
@@ -103,6 +118,15 @@ POLICY_FLAGS_SUFFIX=""
 POLICY_FLAGS_EXPLICIT=false
 SKIP_INIT=false
 YES=false
+COUNCIL=""
+OPERATOR=""
+GUARDIAN=""
+RECOVERY=""
+TTL_KEEPER=""
+DELAY=""
+RECOVERY_DELAY=""
+GRACE=""
+GUARDIAN_PAUSE=""
 
 policy_suffix_label() {
   if [[ -z "$1" ]]; then
@@ -259,6 +283,15 @@ while [[ $# -gt 0 ]]; do
     --vk-json) VK_JSON="$2"; shift 2 ;;
     --vk-file) VK_FILE="$2"; shift 2 ;;
     --skip-init) SKIP_INIT=true; shift ;;
+    --council) COUNCIL="$2"; shift 2 ;;
+    --operator) OPERATOR="$2"; shift 2 ;;
+    --guardian) GUARDIAN="$2"; shift 2 ;;
+    --recovery) RECOVERY="$2"; shift 2 ;;
+    --ttl-keeper) TTL_KEEPER="$2"; shift 2 ;;
+    --delay) DELAY="$2"; shift 2 ;;
+    --recovery-delay) RECOVERY_DELAY="$2"; shift 2 ;;
+    --grace) GRACE="$2"; shift 2 ;;
+    --guardian-pause) GUARDIAN_PAUSE="$2"; shift 2 ;;
     --yes) YES=true; shift ;;
     -h|--help) usage ;;
     *) die "unknown option: $1" ;;
@@ -362,6 +395,66 @@ else
   ADMIN_ADDR="$(resolve_address "$ADMIN")"
 fi
 
+COUNCIL_ADDR=""
+OPERATOR_ADDR=""
+GUARDIAN_ADDR=""
+RECOVERY_ADDR=""
+TTL_KEEPER_ADDR=""
+if [[ -n "$COUNCIL$OPERATOR$GUARDIAN$RECOVERY$TTL_KEEPER$DELAY$RECOVERY_DELAY$GRACE$GUARDIAN_PAUSE" ]]; then
+  [[ "$SKIP_INIT" != "true" ]] || die "the governance options need constructors; drop --skip-init"
+  [[ -n "$COUNCIL" ]] || die "--council is required with the governance options"
+  [[ -n "$OPERATOR" ]] || die "--operator is required with the governance options"
+  [[ -n "$GUARDIAN" ]] || die "--guardian is required with the governance options"
+  [[ -n "$RECOVERY" ]] || die "--recovery is required with the governance options"
+  [[ -n "$TTL_KEEPER" ]] || die "--ttl-keeper is required with the governance options"
+  # The handoff is signed by --deployer, and each target's own admin has to authorize it.
+  [[ -z "$ADMIN" || "$ADMIN_ADDR" == "$DEPLOYER_ADDR" ]] \
+    || die "--admin must be the deployer with the governance options"
+
+  COUNCIL_ADDR="$(resolve_address "$COUNCIL")"
+  OPERATOR_ADDR="$(resolve_address "$OPERATOR")"
+  GUARDIAN_ADDR="$(resolve_address "$GUARDIAN")"
+  RECOVERY_ADDR="$(resolve_address "$RECOVERY")"
+  TTL_KEEPER_ADDR="$(resolve_address "$TTL_KEEPER")"
+  # `resolve_address` echoes an unknown identity back unchanged, and the governor's
+  # constructor is the last thing the run deploys, so a typo would surface only there.
+  for pair in "--council:$COUNCIL_ADDR" "--operator:$OPERATOR_ADDR" "--guardian:$GUARDIAN_ADDR" \
+    "--recovery:$RECOVERY_ADDR" "--ttl-keeper:$TTL_KEEPER_ADDR"; do
+    [[ "${pair#*:}" =~ ^[GC][A-Z0-9]{55}$ ]] \
+      || die "${pair%%:*} does not resolve to an address: '${pair#*:}'"
+  done
+  distinct="$(printf '%s\n' "$COUNCIL_ADDR" "$OPERATOR_ADDR" "$GUARDIAN_ADDR" "$RECOVERY_ADDR" | sort -u | wc -l)"
+  [[ "$distinct" -eq 4 ]] \
+    || die "--council, --operator, --guardian and --recovery must be four distinct addresses"
+
+  if [[ "$NETWORK" == "mainnet" ]]; then
+    [[ -n "$DELAY" ]] || die "--delay is required on mainnet"
+    [[ -n "$RECOVERY_DELAY" ]] || die "--recovery-delay is required on mainnet"
+    [[ -n "$GRACE" ]] || die "--grace is required on mainnet"
+    [[ -n "$GUARDIAN_PAUSE" ]] || die "--guardian-pause is required on mainnet"
+  else
+    DELAY="${DELAY:-360}"
+    RECOVERY_DELAY="${RECOVERY_DELAY:-720}"
+    GRACE="${GRACE:-17280}"
+    GUARDIAN_PAUSE="${GUARDIAN_PAUSE:-720}"
+  fi
+  # Every check below is arithmetic, which reports a bash error rather than ours on a
+  # value like "7d".
+  for pair in "--delay:$DELAY" "--recovery-delay:$RECOVERY_DELAY" "--grace:$GRACE" \
+    "--guardian-pause:$GUARDIAN_PAUSE"; do
+    [[ "${pair#*:}" =~ ^[0-9]+$ ]] || die "${pair%%:*} must be a whole number of ledgers"
+  done
+
+  [[ "$NETWORK" != "mainnet" || "$DELAY" -ge 120960 ]] \
+    || die "--delay below 120960 ledgers (7 days) is refused on mainnet"
+  # The governor's constructor refuses every one of these, and it runs after the pools are
+  # paid for. 12 is its DELAY_FLOOR.
+  [[ "$DELAY" -ge 12 ]] || die "--delay must be at least 12 ledgers"
+  [[ "$GRACE" -gt 0 ]] || die "--grace must be at least one ledger"
+  [[ "$RECOVERY_DELAY" -ge "$DELAY" ]] || die "--recovery-delay must be at least --delay"
+  [[ "$GUARDIAN_PAUSE" -gt "$DELAY" ]] || die "--guardian-pause must exceed --delay"
+fi
+
 get_latest_ledger_seq() {
   local out seq
   out="$(stellar ledger latest --network "$NETWORK" 2>&1)" || {
@@ -398,7 +491,7 @@ build_verifier_wasm_for_suffix() {
 
 step "build contracts"
 mkdir -p "$WASM_DIR"
-for pkg in asp-membership asp-non-membership public-key-registry pool; do
+for pkg in asp-membership asp-non-membership public-key-registry pool governor; do
   stellar contract build --manifest-path "$ROOT_DIR/Cargo.toml" --out-dir "$WASM_DIR" --optimize \
     --package "$pkg" >/dev/null
 done
@@ -416,11 +509,13 @@ ASP_MEMBERSHIP_WASM="$WASM_DIR/asp_membership.wasm"
 ASP_NON_MEMBERSHIP_WASM="$WASM_DIR/asp_non_membership.wasm"
 PUBLIC_KEY_REGISTRY_WASM="$WASM_DIR/public_key_registry.wasm"
 POOL_WASM="$WASM_DIR/pool.wasm"
+GOVERNOR_WASM="$WASM_DIR/governor.wasm"
 
 [[ -f "$ASP_MEMBERSHIP_WASM" ]] || die "missing wasm: $ASP_MEMBERSHIP_WASM"
 [[ -f "$ASP_NON_MEMBERSHIP_WASM" ]] || die "missing wasm: $ASP_NON_MEMBERSHIP_WASM"
 [[ -f "$PUBLIC_KEY_REGISTRY_WASM" ]] || die "missing wasm: $PUBLIC_KEY_REGISTRY_WASM"
 [[ -f "$POOL_WASM" ]] || die "missing wasm: $POOL_WASM"
+[[ -f "$GOVERNOR_WASM" ]] || die "missing wasm: $GOVERNOR_WASM"
 
 deploy_contract() {
   local name="$1"
@@ -571,36 +666,60 @@ while [[ "$_pool_i" -lt "$_pool_len" ]]; do
   _pool_i=$((_pool_i + 1))
 done
 
-{
-  cat >&2 <<__DEPLOY_SUMMARY__
-
-  ┌─────────────────────────────────────────────────────────────────┐
-  │                    ✅ DEPLOYMENT SUCCESSFUL                      │
-  └─────────────────────────────────────────────────────────────────┘
-
-Deployment complete
-  Network:             $NETWORK
-  Deployer:            $DEPLOYER_ADDR
-  Admin:               $ADMIN_ADDR
-  ASP membership:      $ASP_MEMBERSHIP_ID
-  ASP non-membership:  $ASP_NON_MEMBERSHIP_ID
-  Public key registry: $PUBLIC_KEY_REGISTRY_ID
-  Pools deployed:      ${#POOL_IDS[@]}
-  Constructed:         $([[ "$SKIP_INIT" == "true" ]] && echo "no" || echo "yes")
-__DEPLOY_SUMMARY__
-  _vi=0
-  _vlen="$(array_len VERIFIER_SUFFIX_LIST)"
-  while [[ "$_vi" -lt "$_vlen" ]]; do
-    printf '  Verifier (%s):     %s\n' "$(policy_suffix_label "${VERIFIER_SUFFIX_LIST[$_vi]}")" "${VERIFIER_ID_LIST[$_vi]}" >&2
-    _vi=$((_vi + 1))
-  done
-  _pi=0
-  _plen="$(array_len POOL_IDS)"
-  while [[ "$_pi" -lt "$_plen" ]]; do
-    printf '  Pool[%s] (%s):       %s\n' "$_pi" "$(policy_suffix_label "${POOL_POLICY_SUFFIXES[$_pi]}")" "${POOL_IDS[$_pi]}" >&2
-    _pi=$((_pi + 1))
-  done
+# Every DataKey variant is a unit variant, which the SDK encodes as a one-symbol ScVec, so
+# `stellar contract read --key` cannot address the entry and the key is built as XDR instead.
+read_entry() {
+  local key out
+  key="$(printf '{"vec":[{"symbol":"%s"}]}' "$2" | stellar xdr encode --type ScVal)"
+  # The status is kept so a caller can tell an unreadable entry from a wrong value.
+  out="$(stellar contract read --id "$1" --network "$NETWORK" --durability persistent \
+    --key-xdr "$key" --output json)" || return 1
+  printf '%s' "$out" | tr -d '\n ' | sed 's/""/"/g'
 }
+read_address() { read_entry "$1" "$2" | grep -Eo '"address":"[GC][A-Z0-9]{55}"' | head -1 | cut -d'"' -f4; }
+
+GOVERNOR_ID=""
+handoff_failures=""
+if [[ -n "$COUNCIL_ADDR" ]]; then
+  roles_json="$(jq -cn \
+    --arg council "$COUNCIL_ADDR" --arg operator "$OPERATOR_ADDR" \
+    --arg guardian "$GUARDIAN_ADDR" --arg recovery "$RECOVERY_ADDR" \
+    '[{role:"council",member:$council},{role:"operator",member:$operator},
+      {role:"guardian",member:$guardian},{role:"recovery",member:$recovery}]')"
+  fn_roles_json="$(jq -cn \
+    --arg membership "$ASP_MEMBERSHIP_ID" --arg non_membership "$ASP_NON_MEMBERSHIP_ID" \
+    '[{target:$membership,function:"insert_leaf",role:"operator"},
+      {target:$non_membership,function:"insert_leaf",role:"operator"},
+      {target:$non_membership,function:"delete_leaf",role:"operator"}]')"
+
+  # Nothing from here on is fatal on its own. Every contract above is deployed and paid for,
+  # so the manifest that records them is written first and the failures are reported after.
+  step "deploy governor"
+  GOVERNOR_ID="$(deploy_contract governor "$GOVERNOR_WASM" \
+    --delay "$DELAY" --recovery-delay "$RECOVERY_DELAY" --grace "$GRACE" \
+    --guardian-pause "$GUARDIAN_PAUSE" --roles "$roles_json" --fn-roles "$fn_roles_json")" \
+    || handoff_failures+="  governor: deploy failed"$'\n'
+fi
+
+if [[ -n "$GOVERNOR_ID" ]]; then
+  GOVERNED_IDS=("$ASP_MEMBERSHIP_ID" "$ASP_NON_MEMBERSHIP_ID")
+  _gi=0
+  _glen="$(array_len POOL_IDS)"
+  while [[ "$_gi" -lt "$_glen" ]]; do
+    GOVERNED_IDS+=("${POOL_IDS[$_gi]}")
+    _gi=$((_gi + 1))
+  done
+
+  for target in "${GOVERNED_IDS[@]}"; do
+    step "hand $target to the governor"
+    stellar contract invoke --id "$target" --source-account "$DEPLOYER" --network "$NETWORK" \
+      -- update_admin --new-admin "$GOVERNOR_ID" >/dev/null \
+      || handoff_failures+="  $target: update_admin failed"$'\n'
+  done
+
+  ADMIN_ADDR="$GOVERNOR_ID"
+fi
+
 
 verifiers_json="\"verifiers\":{"
 _vi=0
@@ -627,10 +746,88 @@ while [[ "$_pi" -lt "$_plen" ]]; do
 done
 pools_json+="]"
 
-DEPLOY_JSON="{\"network\":\"$NETWORK\",\"deployer\":\"$DEPLOYER_ADDR\",\"admin\":\"$ADMIN_ADDR\",\"asp_membership\":\"$ASP_MEMBERSHIP_ID\",\"asp_non_membership\":\"$ASP_NON_MEMBERSHIP_ID\",${verifiers_json},\"public_key_registry\":\"$PUBLIC_KEY_REGISTRY_ID\",\"pools\":$pools_json}"
+governance_json=""
+if [[ -n "$GOVERNOR_ID" ]]; then
+  governance_json=",\"governance\":{\"governor\":\"$GOVERNOR_ID\",\"council\":\"$COUNCIL_ADDR\",\"operator\":\"$OPERATOR_ADDR\",\"guardian\":\"$GUARDIAN_ADDR\",\"recovery\":\"$RECOVERY_ADDR\",\"ttlKeeper\":\"$TTL_KEEPER_ADDR\",\"delay\":$DELAY,\"recoveryDelay\":$RECOVERY_DELAY,\"grace\":$GRACE,\"guardianPause\":$GUARDIAN_PAUSE}"
+fi
+
+DEPLOY_JSON="{\"network\":\"$NETWORK\",\"deployer\":\"$DEPLOYER_ADDR\",\"admin\":\"$ADMIN_ADDR\",\"asp_membership\":\"$ASP_MEMBERSHIP_ID\",\"asp_non_membership\":\"$ASP_NON_MEMBERSHIP_ID\",${verifiers_json},\"public_key_registry\":\"$PUBLIC_KEY_REGISTRY_ID\",\"pools\":$pools_json$governance_json}"
 
 DEPLOYMENTS_DIR="$ROOT_DIR/deployments/$NETWORK"
 mkdir -p "$DEPLOYMENTS_DIR"
 DEPLOY_JSON_PRETTY="$(printf '%s\n' "$DEPLOY_JSON" | jq .)"
 printf '%s\n' "$DEPLOY_JSON_PRETTY" > "$DEPLOYMENTS_DIR/deployments.json"
+
+if [[ -n "$GOVERNOR_ID" ]]; then
+  step "read the admin of every governed contract back"
+  for target in "${GOVERNED_IDS[@]}"; do
+    if ! admin_now="$(read_address "$target" Admin)"; then
+      handoff_failures+="  $target: could not read Admin"$'\n'
+    elif [[ "$admin_now" != "$GOVERNOR_ID" ]]; then
+      handoff_failures+="  $target: admin is '$admin_now'"$'\n'
+    fi
+  done
+fi
+
+GOVERNANCE_LINE="none"
+GOVERNANCE_ROLES=""
+if [[ -n "$GOVERNOR_ID" ]]; then
+  GOVERNANCE_LINE="governor $GOVERNOR_ID"
+  # Handing the targets over cannot be undone by the deployer, so the run echoes who holds
+  # each role for the operator to read back before anyone relies on it.
+  GOVERNANCE_ROLES="$(printf '  %-20s %s\n' \
+    "Council:" "$COUNCIL_ADDR" "Operator:" "$OPERATOR_ADDR" \
+    "Guardian:" "$GUARDIAN_ADDR" "Recovery:" "$RECOVERY_ADDR" \
+    "TTL keeper:" "$TTL_KEEPER_ADDR")"
+  GOVERNANCE_ROLES+=$'\n'"  re-check with deployments/scripts/verify-deployment.sh $NETWORK"
+fi
+[[ -z "$handoff_failures" ]] || GOVERNANCE_LINE="incomplete, see the end of this run"
+
+if [[ -z "$handoff_failures" ]]; then
+  cat >&2 <<'__DEPLOY_BANNER__'
+
+  ┌─────────────────────────────────────────────────────────────────┐
+  │                    ✅ DEPLOYMENT SUCCESSFUL                      │
+  └─────────────────────────────────────────────────────────────────┘
+__DEPLOY_BANNER__
+else
+  cat >&2 <<'__DEPLOY_BANNER__'
+
+  ┌─────────────────────────────────────────────────────────────────┐
+  │        ⚠️  CONTRACTS DEPLOYED, GOVERNANCE INCOMPLETE             │
+  └─────────────────────────────────────────────────────────────────┘
+__DEPLOY_BANNER__
+fi
+
+{
+  cat >&2 <<__DEPLOY_SUMMARY__
+Deployment complete
+  Network:             $NETWORK
+  Deployer:            $DEPLOYER_ADDR
+  Admin:               $ADMIN_ADDR
+  ASP membership:      $ASP_MEMBERSHIP_ID
+  ASP non-membership:  $ASP_NON_MEMBERSHIP_ID
+  Public key registry: $PUBLIC_KEY_REGISTRY_ID
+  Pools deployed:      ${#POOL_IDS[@]}
+  Constructed:         $([[ "$SKIP_INIT" == "true" ]] && echo "no" || echo "yes")
+  Governance:          $GOVERNANCE_LINE
+$GOVERNANCE_ROLES
+__DEPLOY_SUMMARY__
+  _vi=0
+  _vlen="$(array_len VERIFIER_SUFFIX_LIST)"
+  while [[ "$_vi" -lt "$_vlen" ]]; do
+    printf '  Verifier (%s):     %s\n' "$(policy_suffix_label "${VERIFIER_SUFFIX_LIST[$_vi]}")" "${VERIFIER_ID_LIST[$_vi]}" >&2
+    _vi=$((_vi + 1))
+  done
+  _pi=0
+  _plen="$(array_len POOL_IDS)"
+  while [[ "$_pi" -lt "$_plen" ]]; do
+    printf '  Pool[%s] (%s):       %s\n' "$_pi" "$(policy_suffix_label "${POOL_POLICY_SUFFIXES[$_pi]}")" "${POOL_IDS[$_pi]}" >&2
+    _pi=$((_pi + 1))
+  done
+}
+
 printf '%s\n' "$DEPLOY_JSON_PRETTY"
+
+[[ -z "$handoff_failures" ]] \
+  || die "the manifest is written, but the governance handoff is incomplete:"$'\n'"$handoff_failures"$'\n'"re-check with deployments/scripts/verify-deployment.sh $NETWORK"

--- a/deployments/scripts/verify-deployment.sh
+++ b/deployments/scripts/verify-deployment.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Check a deployment's on-chain state against its manifest.
+# Usage: verify-deployment.sh <network> [options]
+
+set -euo pipefail
+
+die() { echo "verify-deployment.sh: $*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || die "missing '$1'"; }
+step() { echo "==> $*" >&2; }
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: verify-deployment.sh <network> [OPTIONS]
+
+Reads a deployment manifest and checks the contracts it names against it. Every
+check prints one line, and the run reports all of them before exiting.
+
+Arguments:
+  network            Network name from Stellar CLI config (e.g. testnet, futurenet)
+
+Options:
+  --manifest PATH    Manifest to check (default deployments/<network>/deployments.json)
+  -h, --help         Show this help
+
+Exits 1 when any check failed, 0 otherwise. A manifest with no governance block
+skips the governance checks with a notice and still passes.
+USAGE
+  exit 2
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+NETWORK="${1:-}"
+shift || true
+
+MANIFEST=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --manifest) MANIFEST="$2"; shift 2 ;;
+    -h|--help) usage ;;
+    *) die "unknown option: $1" ;;
+  esac
+done
+
+[[ -n "$NETWORK" ]] || usage
+need stellar
+need jq
+
+MANIFEST="${MANIFEST:-$ROOT_DIR/deployments/$NETWORK/deployments.json}"
+[[ -f "$MANIFEST" ]] || die "manifest not found: $MANIFEST"
+
+FAILED=0
+
+check() {
+  local contract="$1" key="$2" want="$3" got="$4"
+  if [[ "$want" == "$got" ]]; then
+    printf 'ok %s %s\n' "$contract" "$key"
+  else
+    printf 'FAIL %s %s: expected %s, got %s\n' "$contract" "$key" "$want" "$got"
+    FAILED=1
+  fi
+}
+
+# Every DataKey variant is a unit variant, which the SDK encodes as a one-symbol ScVec, so
+# `stellar contract read --key` cannot address the entry and the key is built as XDR instead.
+read_entry() {
+  local key out
+  key="$(printf '{"vec":[{"symbol":"%s"}]}' "$2" | stellar xdr encode --type ScVal)"
+  # The status is kept so a caller can tell an unreadable entry from a wrong value.
+  out="$(stellar contract read --id "$1" --network "$NETWORK" --durability persistent \
+    --key-xdr "$key" --output json)" || return 1
+  printf '%s' "$out" | tr -d '\n ' | sed 's/""/"/g'
+}
+read_address() { read_entry "$1" "$2" | grep -Eo '"address":"[GC][A-Z0-9]{55}"' | head -1 | cut -d'"' -f4; }
+
+# Read-only simulation, so the source account only has to exist on the network.
+governor_call() {
+  stellar contract invoke --id "$GOVERNOR" --source-account "$SOURCE" --network "$NETWORK" \
+    --send=no -- "$@"
+}
+
+GOVERNANCE="$(jq -c '.governance // empty' "$MANIFEST")"
+if [[ -z "$GOVERNANCE" ]]; then
+  step "no governance block in $MANIFEST, skipping the governance checks"
+else
+  step "checking governance wiring in $MANIFEST"
+
+  SOURCE="$(jq -r '.deployer' "$MANIFEST")"
+  GOVERNOR="$(jq -r '.governor' <<<"$GOVERNANCE")"
+  ASP_MEMBERSHIP="$(jq -r '.asp_membership' "$MANIFEST")"
+  ASP_NON_MEMBERSHIP="$(jq -r '.asp_non_membership' "$MANIFEST")"
+
+  check manifest admin "$GOVERNOR" "$(jq -r '.admin' "$MANIFEST")"
+
+  TARGETS="$(jq -r '.asp_membership, .asp_non_membership,
+    (.pools[] | select(.enabled) | .poolContractId)' "$MANIFEST")"
+  for target in $TARGETS; do
+    check "$target" Admin "$GOVERNOR" "$(read_address "$target" Admin || echo "unreadable")"
+    check "$target" "fn_role(update_admin)" null \
+      "$(governor_call get_fn_role --target "$target" --function update_admin)"
+  done
+
+  for role in council operator guardian recovery; do
+    holder="$(jq -r --arg role "$role" '.[$role]' <<<"$GOVERNANCE")"
+    check "$GOVERNOR" "has_role($role)" true \
+      "$(governor_call has_role --member "$holder" --role "$role")"
+    # `has_role` is a point query, so it cannot see a second holder the manifest does not
+    # name. The count can, and the manifest names exactly one address per role.
+    check "$GOVERNOR" "role_member_count($role)" 1 \
+      "$(governor_call get_role_member_count --role "$role")"
+  done
+  check "$GOVERNOR" "has_role(council, operator)" false \
+    "$(governor_call has_role --member "$(jq -r '.council' <<<"$GOVERNANCE")" --role operator)"
+
+  # One failing call must not end the run, so the report still names every other check.
+  DELAYS="$(governor_call get_delays || true)"
+  check "$GOVERNOR" "get_delays(delay)" \
+    "$(jq -r '.delay' <<<"$GOVERNANCE")" "$(jq -r '.delay' <<<"$DELAYS")"
+  check "$GOVERNOR" "get_delays(recovery_delay)" \
+    "$(jq -r '.recoveryDelay' <<<"$GOVERNANCE")" "$(jq -r '.recovery_delay' <<<"$DELAYS")"
+  check "$GOVERNOR" "get_delays(grace)" \
+    "$(jq -r '.grace' <<<"$GOVERNANCE")" "$(jq -r '.grace' <<<"$DELAYS")"
+  check "$GOVERNOR" "get_delays(guardian_pause)" \
+    "$(jq -r '.guardianPause' <<<"$GOVERNANCE")" "$(jq -r '.guardian_pause' <<<"$DELAYS")"
+
+  check "$ASP_MEMBERSHIP" "fn_role(insert_leaf)" '"operator"' \
+    "$(governor_call get_fn_role --target "$ASP_MEMBERSHIP" --function insert_leaf)"
+  check "$ASP_NON_MEMBERSHIP" "fn_role(insert_leaf)" '"operator"' \
+    "$(governor_call get_fn_role --target "$ASP_NON_MEMBERSHIP" --function insert_leaf)"
+  check "$ASP_NON_MEMBERSHIP" "fn_role(delete_leaf)" '"operator"' \
+    "$(governor_call get_fn_role --target "$ASP_NON_MEMBERSHIP" --function delete_leaf)"
+fi
+
+exit "$FAILED"

--- a/scripts/gov/create-multisig.sh
+++ b/scripts/gov/create-multisig.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Turn a Stellar account into a multisig account with a signing threshold.
+# Usage: create-multisig.sh <network> [options]
+
+set -euo pipefail
+
+die() { echo "create-multisig.sh: $*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || die "missing '$1'"; }
+step() { echo "==> $*" >&2; }
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: create-multisig.sh <network> --account ALIAS --signer ADDRESS --threshold N [OPTIONS]
+
+Gives an account a set of signers, each of weight 1, sets its low, medium, and
+high thresholds to the same number, and disables its master key. One transaction
+carries all of it, so the account never sits without a working signer set.
+
+Arguments:
+  network            Network name from Stellar CLI config (e.g. testnet, futurenet)
+
+Options:
+  --account ALIAS    Stellar identity that owns the account and signs the change (required)
+  --signer ADDRESS   Signer to add with weight 1 (repeatable, required)
+  --threshold N      Signatures every later operation needs (required)
+  --fund             Fund the account before the change, on a network with a friendbot
+  --rpc-url URL      RPC to read the signer list back from (default: the network's own)
+  --yes              Skip confirmation for mainnet
+  -h, --help         Show this help
+
+Example:
+  scripts/gov/create-multisig.sh testnet --account council --threshold 3 \
+    --signer GA... --signer GB... --signer GC... --signer GD... --signer GE...
+USAGE
+  exit 2
+}
+
+NETWORK="${1:-}"
+shift || true
+
+ACCOUNT=""
+THRESHOLD=""
+RPC_URL=""
+FUND=false
+YES=false
+SIGNERS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --account) ACCOUNT="$2"; shift 2 ;;
+    --signer) SIGNERS+=("$2"); shift 2 ;;
+    --threshold) THRESHOLD="$2"; shift 2 ;;
+    --fund) FUND=true; shift ;;
+    --rpc-url) RPC_URL="$2"; shift 2 ;;
+    --yes) YES=true; shift ;;
+    -h|--help) usage ;;
+    *) die "unknown option: $1" ;;
+  esac
+done
+
+[[ -n "$NETWORK" ]] || usage
+need stellar
+need jq
+need curl
+
+[[ -n "$ACCOUNT" ]] || die "--account is required"
+[[ -n "$THRESHOLD" ]] || die "--threshold is required"
+[[ ${#SIGNERS[@]} -gt 0 ]] || die "at least one --signer is required"
+
+if [[ "$NETWORK" == "mainnet" && "$YES" != "true" ]]; then
+  die "mainnet requires --yes"
+fi
+
+[[ "$THRESHOLD" =~ ^[0-9]+$ && "$THRESHOLD" -gt 0 ]] || die "--threshold must be a positive number"
+[[ "$THRESHOLD" -le ${#SIGNERS[@]} ]] \
+  || die "--threshold $THRESHOLD is above the ${#SIGNERS[@]} signers given"
+[[ "$(printf '%s\n' "${SIGNERS[@]}" | sort -u | wc -l)" -eq ${#SIGNERS[@]} ]] \
+  || die "the same signer was given twice"
+
+# Resolved before anything is sent, because the signer list is read back over this url and
+# the built-in mainnet entry carries prose where a url would be.
+if [[ -z "$RPC_URL" ]]; then
+  RPC_URL="$(stellar network ls --long \
+    | awk -v want="Name: $NETWORK" '$0 == want { found = 1 } found && /^RPC url:/ { print $3; exit }')"
+fi
+[[ "$RPC_URL" =~ ^https?:// ]] \
+  || die "no RPC url for network '$NETWORK'; configure the network or pass --rpc-url"
+
+ACCOUNT_ADDR="$(stellar keys address "$ACCOUNT")"
+
+if [[ "$FUND" == "true" ]]; then
+  [[ "$NETWORK" != "mainnet" ]] || die "--fund has no friendbot on mainnet"
+  step "funding $ACCOUNT_ADDR"
+  stellar keys fund "$ACCOUNT" --network "$NETWORK"
+fi
+
+# The master weight drops to zero in the same transaction that adds the signers, and the
+# network checks the signature against the account as it was before the transaction, so the
+# account's own key is enough to authorize the change.
+step "building the signer set for $ACCOUNT_ADDR"
+# One operation per signer plus the one that sets the thresholds, each charged the 100-stroop
+# base fee. See https://developers.stellar.org/docs/learn/fundamentals/fees-resource-limits-metering.
+INCLUSION_FEE=$(( (${#SIGNERS[@]} + 1) * 100 ))
+TX=""
+for signer in "${SIGNERS[@]}"; do
+  if [[ -z "$TX" ]]; then
+    TX="$(stellar tx new set-options --source-account "$ACCOUNT" --network "$NETWORK" \
+      --build-only --inclusion-fee "$INCLUSION_FEE" --signer "$signer" --signer-weight 1)"
+  else
+    TX="$(stellar tx operation add set-options --source-account "$ACCOUNT" \
+      --network "$NETWORK" --build-only --signer "$signer" --signer-weight 1 <<<"$TX")"
+  fi
+done
+TX="$(stellar tx operation add set-options --source-account "$ACCOUNT" --network "$NETWORK" \
+  --build-only --low-threshold "$THRESHOLD" --med-threshold "$THRESHOLD" \
+  --high-threshold "$THRESHOLD" --master-weight 0 <<<"$TX")"
+
+step "signing with the account's own key and sending"
+stellar tx sign --sign-with-key "$ACCOUNT" --network "$NETWORK" <<<"$TX" \
+  | stellar tx send --network "$NETWORK"
+
+step "signers now on $ACCOUNT_ADDR"
+KEY="$(printf '{"account":{"account_id":"%s"}}' "$ACCOUNT_ADDR" | stellar xdr encode --type LedgerKey)"
+curl -sS -X POST "$RPC_URL" -H 'Content-Type: application/json' \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getLedgerEntries\",\"params\":{\"keys\":[\"$KEY\"]}}" \
+  | jq -r '.result.entries[0].xdr' \
+  | stellar xdr decode --type LedgerEntryData --output json \
+  | jq '.account | {signers, thresholds}'

--- a/tools/ttl-keeper/Cargo.toml
+++ b/tools/ttl-keeper/Cargo.toml
@@ -18,6 +18,8 @@ stellar-private-payments.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 hex.workspace = true
+metrics.workspace = true
+metrics-exporter-prometheus = { workspace = true, features = ["http-listener"] }
 serde = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
 stellar-xdr.workspace = true

--- a/tools/ttl-keeper/README.md
+++ b/tools/ttl-keeper/README.md
@@ -71,6 +71,35 @@ The file is written through a temporary file and a rename, so a round that dies 
 leaves either the previous state or the new one. Delete it to re-read every pool's events
 from its deployment ledger.
 
+## Metrics
+
+`--metrics-bind 127.0.0.1:9095` serves Prometheus metrics on that address. Without the flag
+the keeper records nothing.
+
+| Metric | Type | Meaning |
+| --- | --- | --- |
+| `ttl_keeper_min_ttl_ledgers{contract}` | gauge | Ledgers left on the shortest-lived entry of a contract |
+| `ttl_keeper_keeper_balance_stroops` | gauge | Balance of the keeper account |
+| `ttl_keeper_extended_total` | counter | Keys whose lifetime the keeper has extended |
+| `ttl_keeper_restored_total` | counter | Keys the keeper has restored from the archive |
+| `ttl_keeper_round_errors_total` | counter | Rounds that ended in an error |
+| `ttl_keeper_classification_mismatch_total` | counter | Keys the RPC's simulation called archived after its ledger-state answer called them live |
+
+The minimum-lifetime gauge reports an archived entry the round did not restore as zero, so
+the expiry alert stays raised until a restore lands.
+
+`alerts.yml` holds four Prometheus rules. One fires when a round ends in an error, which is
+the first thing to know because every other rule reads a gauge a failed round never updated.
+One fires on a classification mismatch: an entry expired between the read and the
+simulation, which a keeper that was down past the threshold sees once, or the RPC no longer
+reports entry state the way the keeper relies on, which repeats. The other two fire when a
+contract sits inside the extension threshold for an hour and when the keeper account drops
+below 100 XLM. Load them with:
+
+```bash
+promtool check rules tools/ttl-keeper/alerts.yml
+```
+
 ## What it does not do
 
 The keeper touches only the keys it can enumerate, which are the ones the manifest names plus

--- a/tools/ttl-keeper/alerts.yml
+++ b/tools/ttl-keeper/alerts.yml
@@ -1,0 +1,51 @@
+groups:
+  - name: ttl-keeper
+    rules:
+      - alert: KeeperRoundsFailing
+        expr: increase(ttl_keeper_round_errors_total[1h]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "The keeper is failing rounds"
+          description: >-
+            A round ended in an error, so no entry it had not already reached was
+            extended. Every other alert here reads a gauge the failed round never
+            updated, so this one fires first.
+
+      - alert: KeeperClassificationMismatch
+        expr: increase(ttl_keeper_classification_mismatch_total[1h]) > 0
+        labels:
+          severity: warning
+        annotations:
+          summary: "The RPC's simulation disagrees with its ledger state"
+          description: >-
+            An extend simulation asked for a restore of a key that getLedgerEntries
+            had reported live. The keeper restored it and carried on. Either the entry
+            expired between the read and the simulation, which a keeper that was down
+            past the threshold sees once, or the RPC no longer reports entry state the
+            way the keeper relies on; check getVersionInfo if it repeats.
+
+      - alert: ContractStorageNearExpiry
+        expr: min by (contract) (ttl_keeper_min_ttl_ledgers) < 518400
+        for: 1h
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.contract }} has less than 518400 ledgers of storage lifetime left"
+          description: >-
+            An entry of {{ $labels.contract }} is inside the extension threshold and
+            has stayed there for an hour, so the keeper is not extending it. Check
+            whether the keeper is running and whether its account is funded.
+
+      - alert: KeeperBalanceLow
+        expr: ttl_keeper_keeper_balance_stroops < 1000000000
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "The keeper account holds less than 100 XLM"
+          description: >-
+            The keeper pays the resource fee for every extension and restore. Below
+            100 XLM it will start failing rounds, and archived entries need a restore
+            rather than an extension to come back.

--- a/tools/ttl-keeper/src/main.rs
+++ b/tools/ttl-keeper/src/main.rs
@@ -11,8 +11,9 @@ mod state;
 
 use anyhow::{Context, Result, bail};
 use clap::Parser;
+use metrics::{counter, gauge};
 use state::State;
-use std::{num::NonZeroUsize, path::PathBuf, time::Duration};
+use std::{net::SocketAddr, num::NonZeroUsize, path::PathBuf, time::Duration};
 use stellar_private_payments::{
     chain::{Client, LocalSigner},
     types::ContractConfig,
@@ -62,6 +63,9 @@ struct Args {
     /// Keys per lifetime transaction.
     #[arg(long, default_value = "100")]
     batch: NonZeroUsize,
+    /// Address to serve Prometheus metrics on. Metrics are off when absent.
+    #[arg(long)]
+    metrics_bind: Option<SocketAddr>,
 }
 
 /// Lowest protocol version whose RPC reports archived entries.
@@ -70,6 +74,25 @@ struct Args {
 /// the way it leaves out a key that was never written, so a keeper running
 /// against such an RPC would never restore anything and never know it.
 const MIN_PROTOCOL: u32 = 23;
+
+/// Ledgers of lifetime left on the shortest-lived entry of each contract.
+const MIN_TTL_LEDGERS: &str = "ttl_keeper_min_ttl_ledgers";
+
+/// Balance of the keeper account, in stroops.
+const KEEPER_BALANCE_STROOPS: &str = "ttl_keeper_keeper_balance_stroops";
+
+/// Keys whose lifetime the keeper has extended.
+const EXTENDED_TOTAL: &str = "ttl_keeper_extended_total";
+
+/// Keys the keeper has restored from the archive.
+const RESTORED_TOTAL: &str = "ttl_keeper_restored_total";
+
+/// Rounds that ended in an error.
+const ROUND_ERRORS_TOTAL: &str = "ttl_keeper_round_errors_total";
+
+/// Keys the RPC's simulation called archived after its ledger-state answer
+/// called them live.
+const CLASSIFICATION_MISMATCH_TOTAL: &str = "ttl_keeper_classification_mismatch_total";
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -87,6 +110,13 @@ async fn main() -> Result<()> {
     let secret = std::env::var(&args.keeper_secret_env)
         .with_context(|| format!("read {}", args.keeper_secret_env))?;
     let signer = LocalSigner::from_secret(&secret)?;
+
+    if let Some(bind) = args.metrics_bind {
+        metrics_exporter_prometheus::PrometheusBuilder::new()
+            .with_http_listener(bind)
+            .install()
+            .context("install the Prometheus exporter")?;
+    }
 
     let rpc = Client::new(&args.rpc_url)?;
     let bootnode = Client::new(&args.bootnode_url)?;
@@ -138,7 +168,9 @@ async fn round(
     signer: &LocalSigner,
     passphrase: &str,
 ) -> Result<()> {
-    run_round(args, config, rpc, bootnode, signer, passphrase).await
+    run_round(args, config, rpc, bootnode, signer, passphrase)
+        .await
+        .inspect_err(|_| counter!(ROUND_ERRORS_TOTAL).increment(1))
 }
 
 async fn run_round(
@@ -149,6 +181,11 @@ async fn run_round(
     signer: &LocalSigner,
     passphrase: &str,
 ) -> Result<()> {
+    // Read first: an unfunded keeper fails inside the submissions below, and
+    // a balance gauge that only updates on a clean round cannot fire the alert
+    // that exists for exactly that case.
+    report_balance(rpc, signer.public_key()).await;
+
     let mut state = State::load(&args.state_file)?;
     refresh_nullifiers(config, rpc, bootnode, &mut state).await?;
     state.store(&args.state_file)?;
@@ -265,15 +302,17 @@ async fn submit_batches(
     extend_to: Option<u32>,
     submitted: &mut Vec<LedgerKey>,
 ) -> Result<()> {
-    let operation = if extend_to.is_some() {
-        "extend"
+    let (operation, total) = if extend_to.is_some() {
+        ("extend", EXTENDED_TOTAL)
     } else {
-        "restore"
+        ("restore", RESTORED_TOTAL)
     };
 
     for chunk in keys.chunks(args.batch.get()) {
         let mut simulated = simulate_batch(rpc, signer, chunk, extend_to).await?;
         if !simulated.restore_first.is_empty() {
+            let count = u64::try_from(simulated.restore_first.len()).unwrap_or(u64::MAX);
+            counter!(CLASSIFICATION_MISMATCH_TOTAL).increment(count);
             // One occurrence is an entry that expired between the read and the
             // simulation; the alert rule is what notices a repeat.
             tracing::warn!(
@@ -318,6 +357,7 @@ async fn submit_batches(
         }
 
         let hash = ops::send(rpc, signer, passphrase, &simulated).await?;
+        counter!(total).increment(u64::try_from(simulated.keys.len()).unwrap_or(u64::MAX));
         tracing::info!(
             keys = simulated.keys.len(),
             operation,
@@ -424,6 +464,7 @@ fn report_lowest(measurement: &ops::Measurement, extended: &[LedgerKey], extend_
     let lowest = ops::lowest_by_contract(measurement, extended, extend_to);
     for (contract, remaining_ledgers) in &lowest {
         tracing::info!(%contract, remaining_ledgers, "contract_lowest_lifetime");
+        gauge!(MIN_TTL_LEDGERS, "contract" => contract.clone()).set(f64::from(*remaining_ledgers));
     }
     tracing::info!(
         entries = measurement.entries.len(),
@@ -432,9 +473,30 @@ fn report_lowest(measurement: &ops::Measurement, extended: &[LedgerKey], extend_
     );
 }
 
+/// Reports the keeper account's balance, which pays for every extension.
+///
+/// A balance the RPC will not answer for is logged rather than raised: the
+/// round's work is already done, and the alert on a stale gauge is the same
+/// alert as the one on a low balance.
+async fn report_balance(rpc: &Client, address: &str) {
+    match rpc.get_account(address).await {
+        Ok(account) => {
+            // Every Prometheus value is a float. A keeper balance is far below
+            // the 2^53 stroops an f64 represents exactly.
+            #[allow(clippy::cast_precision_loss)]
+            let stroops = account.balance as f64;
+            gauge!(KEEPER_BALANCE_STROOPS).set(stroops);
+        }
+        Err(e) => tracing::warn!(error = %e, "keeper_balance_unavailable"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Reserved documentation address, which nothing answers on.
+    const UNROUTABLE: &str = "http://192.0.2.1:1";
 
     #[test]
     fn the_manifest_network_selects_the_passphrase() {
@@ -450,6 +512,28 @@ mod tests {
     }
 
     #[test]
+    fn every_metric_name_is_a_valid_prometheus_name() {
+        let valid = |name: &str| {
+            let mut chars = name.chars();
+            chars
+                .next()
+                .is_some_and(|c| c.is_ascii_alphabetic() || c == '_' || c == ':')
+                && chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == ':')
+        };
+
+        for name in [
+            MIN_TTL_LEDGERS,
+            KEEPER_BALANCE_STROOPS,
+            EXTENDED_TOTAL,
+            RESTORED_TOTAL,
+            ROUND_ERRORS_TOTAL,
+            CLASSIFICATION_MISMATCH_TOTAL,
+        ] {
+            assert!(valid(name), "{name} is not a valid Prometheus name");
+        }
+    }
+
+    #[test]
     fn a_key_is_described_by_contract_variant_and_arguments() {
         let contract = keys::address("CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE")
             .expect("address");
@@ -462,5 +546,71 @@ mod tests {
             keys::data_key(&contract, "Nullifier", vec![keys::u256([7u8; 32])]).expect("key");
         assert!(describe(&nullifier).ends_with(&format!("Nullifier({})", "07".repeat(32))));
         assert!(describe(&keys::instance_key(&contract)).ends_with(" instance"));
+    }
+
+    // A plain test rather than a `tokio::test`: the recorder is installed
+    // around a closure, and the round has to run inside it.
+    #[test]
+    fn a_round_that_cannot_reach_the_network_counts_an_error() {
+        let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        let dir = std::env::temp_dir().join(format!("ttl-keeper-round-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+
+        let config: ContractConfig = serde_json::from_str(
+            r#"{
+                "network": "testnet",
+                "deployer": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                "admin": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                "asp_membership": "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
+                "asp_non_membership": "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
+                "verifiers": {},
+                "public_key_registry": "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
+                "pools": []
+            }"#,
+        )
+        .expect("manifest");
+
+        let args = Args {
+            deployment: PathBuf::from("deployments.json"),
+            rpc_url: UNROUTABLE.to_owned(),
+            bootnode_url: UNROUTABLE.to_owned(),
+            keeper_secret_env: "TTL_KEEPER_SECRET".to_owned(),
+            state_file: dir.join("unreachable.json"),
+            once: true,
+            dry_run: false,
+            interval_secs: 3_600,
+            threshold_ledgers: 518_400,
+            extend_to_ledgers: None,
+            batch: NonZeroUsize::new(100).expect("a non-zero batch"),
+            metrics_bind: None,
+        };
+        let signer = LocalSigner::from_seed([7u8; 32]);
+        let rpc = Client::with_timeout(UNROUTABLE, 1).expect("client");
+        let bootnode = Client::with_timeout(UNROUTABLE, 1).expect("client");
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let result = metrics::with_local_recorder(&recorder, || {
+            runtime.block_on(round(
+                &args,
+                &config,
+                &rpc,
+                &bootnode,
+                &signer,
+                "Test SDF Network ; September 2015",
+            ))
+        });
+
+        assert!(result.is_err());
+        assert!(
+            handle.render().contains(ROUND_ERRORS_TOTAL),
+            "the error counter was not recorded"
+        );
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 }


### PR DESCRIPTION
Everything needed to stand a governed deployment up and watch it: the keeper's metrics and
alerts, the governor in `deploy.sh`, a CI check over the manifest, and the script that creates
the multisig accounts.

## Keeper metrics and alerts

Six metrics behind a `--metrics-bind` flag: `ttl_keeper_min_ttl_ledgers{contract}`,
`ttl_keeper_keeper_balance_stroops`, `ttl_keeper_extended_total`, `ttl_keeper_restored_total`,
`ttl_keeper_round_errors_total`, and `ttl_keeper_classification_mismatch_total`, the last
counting keys an extend simulation asked to restore after `getLedgerEntries` had reported them
live.

The minimum-TTL gauge reports an archived entry the round did not restore as zero, so the expiry
alert stays raised until a restore lands.

`alerts.yml` holds four Prometheus rules, in this order: a round that ended in an error, a
classification mismatch, any contract's minimum TTL below 518,400 ledgers for an hour, and the
keeper balance below 100 XLM. The round-error rule comes first because the gauge rules read
values a failed round never updated, so without it a keeper that has died reads as healthy. The
mismatch rule follows because it means the RPC no longer reports entry state the way the keeper
relies on.

A Prometheus rules file and no Grafana dashboard: two alerts were what was asked for, and a
dashboard JSON is boilerplate nobody reviews.

## Deploying the governor

`deploy.sh` gains `--council`, `--operator`, `--guardian`, `--recovery`, `--ttl-keeper`, and the
four delay flags. They are optional as a group and required together: give any one and all five
addresses are required, and the four role addresses must be distinct, which the script checks
before the constructor would. Testnet defaults for the delays are 360, 720, 17280, and 720. On
mainnet every delay is required, and the script refuses `--delay` below 120,960,
`--recovery-delay` below `--delay`, or `--guardian-pause` at or below `--delay` without `--yes`.

After the pools are up it deploys the governor with the roles and the three permission rows, then
runs `update_admin` on every target to hand it over, then reads each target's `Admin` entry back
and dies unless it equals the governor id. The reads happen after all the handoffs so a partial
failure is reported as a list rather than one address at a time.

No target has a public `get_admin`, and `stellar contract read --key Admin` cannot address the
entry, because every `DataKey` variant is a unit variant that the SDK encodes as a one-symbol
`ScVec`. The key is built with `stellar xdr encode --type ScVal` and passed through `--key-xdr`.

The manifest gains the `governance` block, and `"admin"` becomes the governor id.

## Verifying the wiring in CI

`verify-deployment.sh <network>` reads a manifest and checks it against the chain: the manifest's
`admin` equals `governance.governor`; every enabled pool and both ASPs have that same address in
their `Admin` entry; each of the four roles answers `has_role` true for itself and false for
another role's address; `get_role_member_count` is 1 for each role, because `has_role` is a point
query and cannot see a holder the manifest does not name; `get_delays` matches the manifest's
four numbers; and `get_fn_role` names `operator` for the three ASP write rows and nothing for
`update_admin` on each target.

Every check prints `ok` or `FAIL` with the expected and actual values and keeps going, so one run
reports everything and exits 1 at the end. With no `governance` block in the manifest every check
is skipped behind one notice, so a pre-governor manifest still passes.

The workflow runs on pull requests and pushes touching a manifest, the script, or itself, plus
`workflow_dispatch` with a network input. Read-only, no secrets.

The CLI pin is `stellar/stellar-cli@8e402ea28202950b272fbabc34caad4d2f64fe87`, v27.1.0, which
`e2e-freighter.yml` and `e2e-webclient.yml` already use, rather than `contracts-build.yml`'s
v25.1.0. `stellar contract read --key-xdr` was verified on 26.0.0 and again on 27.1.0 against an
empty config directory; no run covers 25.1.0. Worth deciding separately whether to bump
`contracts-build.yml` so one version governs the repository.


## The multisig script

`scripts/gov/create-multisig.sh <network> --account <alias> --signer G... --threshold 3` builds
one transaction that adds each signer at weight 1, sets the low, medium, and high thresholds to
the threshold, and sets the master weight to 0 last. Master weight and signers move in the same
transaction, so there is no window where the account has no working signer set.

It refuses a threshold above the signer count, a threshold of zero, a duplicate signer, and a
mainnet run without `--yes`. Source-account authorization uses the account's medium threshold,
which is the fact the whole native-account approach rests on.

Part of #372.
