### PR TITLE
Refine the keeper and document governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ This is [the administrative control panel](https://nethermindeth.github.io/stell
 1. **Add/insert public keys** to the ASP membership tree - Controls which public keys are approved
 2. **Manage the exclusion list** - Block specific public keys via the non-membership Merkle tree
 
+Both writes go through the governor and need the connected wallet to hold the operator role; [the governance guide](https://nethermindeth.github.io/stellar-private-payments/docs/governance.html) covers the roles, the delays, and the incident runbook.
+
 This provides **illicit activity safeguards** while maintaining user privacy. The ASP membership trees work with the zero-knowledge proofs to prove that deposits either belong to approved accounts or don't belong to blocked accounts—without compromising privacy.
 
 #### Zero-Knowledge Circuits

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Contributing](./contributing.md)
 - [Security](./security.md)
   - [Privacy & Event Trade-offs](./privacy-tradeoffs.md)
+  - [Governance](./governance.md)
 
 - [Selective Disclosure](./disclosure.md)
 - [Global View Key](./global_view_key.md)

--- a/docs/src/governance.md
+++ b/docs/src/governance.md
@@ -1,0 +1,337 @@
+# Governance
+
+Every privileged function of the pools and the association set providers (ASPs) belongs to one
+contract, the governor. A change is queued as an operation, waits out a delay in public, and is
+then executed by anyone. Four roles divide the authority, and no single key holds both the power
+to freeze users in and the power to change the contracts.
+
+The addresses, the contract id, and the four delays live in the `governance` block of
+`deployments/<network>/deployments.json`. Every command below reads them from there.
+
+## Roles
+
+| Role | Held by | Entry points | What it may do |
+| --- | --- | --- | --- |
+| `council` | the 3-of-5 account | `schedule`, `cancel`, `unpause` | Queues any call against any contract: a new pool admin, a new ASP address, a role grant, a permission-table row, a pause with no deadline. Cancels any queued call, its own or the recovery key's. Clears any pause at once. |
+| `operator` | the compliance key | `execute_now` | Adds a leaf to the allowlist, adds one to the blocklist, removes one from the blocklist. Reaches no other function on any contract. |
+| `guardian` | the incident key | `pause` | Pauses any contract, any bits, at once. Every guardian pause carries a deadline. Cannot queue, cancel, or unpause anything. |
+| `recovery` | the cold key | `schedule`, limited to `grant_role` and `revoke_role` on the governor | Queues a new council account and the removal of the old one when the old one's keys are lost. |
+
+One address holds one role. The constructor refuses a configuration that grants two roles to
+the same address, and `grant_role` refuses the same later.
+
+## Delays
+
+Delays are counts of ledgers. The wall-clock figures assume a five-second close.
+
+| Number | Mainnet | Testnet |
+| --- | --- | --- |
+| `delay`, every operation the council schedules | 120,960 (7 days) | 360 (30 minutes) |
+| `recovery_delay`, operations the recovery key schedules | 241,920 (14 days) | 720 (1 hour) |
+| `grace`, how long a ready operation stays executable | 241,920 (14 days) | 17,280 (1 day) |
+| `guardian_pause`, how long a guardian pause holds | 138,240 (8 days) | 720 (1 hour) |
+
+A guardian pause, a council `unpause`, a council `cancel`, and an operator write through
+`execute_now` all take effect in the transaction that carries them.
+
+All four numbers are constructor arguments and the governor exposes no function that changes
+one. A different delay means deploying a new governor and handing every target to it, which is
+what `deployments/scripts/deploy.sh` does. Read the live values with `get_delays`:
+
+```bash
+NETWORK=testnet
+MANIFEST=deployments/$NETWORK/deployments.json
+GOVERNOR=$(jq -r .governance.governor "$MANIFEST")
+COUNCIL=$(jq -r .governance.council "$MANIFEST")
+
+stellar contract invoke --id "$GOVERNOR" --source-account "$COUNCIL" --network "$NETWORK" \
+  --send=no -- get_delays
+```
+
+## The council's signer set
+
+The council address is a Stellar account with five signers of weight 1, low, medium, and high
+thresholds of 3, and a master weight of 0. Three of the five sign every operation the council
+sends, and the account's own key can no longer sign anything on its own.
+
+Create one with the five signer addresses in hand:
+
+```bash
+scripts/gov/create-multisig.sh testnet --account council --threshold 3 \
+  --signer G... --signer G... --signer G... --signer G... --signer G...
+```
+
+The script puts the signers and the master weight of 0 in a single transaction, so the account
+is never left without a working signer set, and prints the signer list it reads back from the
+network.
+
+Rotating a signer is one transaction that drops the outgoing weight to 0 and adds the incoming
+signer at weight 1, signed by three of the current five. Both operations go in the same
+transaction so the count never dips below the threshold:
+
+```bash
+stellar tx new set-options --source-account "$COUNCIL" --network "$NETWORK" --build-only \
+  --inclusion-fee 200 --signer "$OUTGOING" --signer-weight 0 \
+| stellar tx operation add set-options --source-account "$COUNCIL" --network "$NETWORK" \
+  --build-only --signer "$INCOMING" --signer-weight 1 \
+| stellar tx sign --sign-with-key alice --network "$NETWORK" \
+| stellar tx sign --sign-with-key bob --network "$NETWORK" \
+| stellar tx sign --sign-with-key carol --network "$NETWORK" \
+| stellar tx send --network "$NETWORK"
+```
+
+Each operation costs the 100-stroop base fee, so `--inclusion-fee` is 100 times the number of
+operations in the transaction.
+
+One key lost leaves four, and three of them still meet the threshold. Rotate the lost signer out
+at the next opportunity. Two keys lost leaves exactly three, so every operation now needs all
+three holders present; rotate both out before anything else, because a third loss ends the
+account. Three keys lost leaves the council unable to sign, and no rotation can bring it back.
+That is what the recovery key is for: it schedules a `grant_role` of the council role to a fresh
+account and a `revoke_role` of the dead one, both against the governor, and they become
+executable after `recovery_delay`.
+
+## Running an operation
+
+An operation is the five-tuple `(target, function, args, predecessor, salt)`. `predecessor` is
+the hash of an operation that must execute first, or 32 zero bytes for none, and `salt`
+distinguishes two otherwise identical calls. `args` is a JSON array of XDR `ScVal` objects,
+because the governor forwards `Vec<Val>` and the contract spec cannot describe the element type.
+
+Build the call unsigned, collect three signatures, and send it:
+
+```bash
+ZERO=0000000000000000000000000000000000000000000000000000000000000000
+POOL=$(jq -r '.pools[0].poolContractId' "$MANIFEST")
+NEW_ASP=C...
+
+stellar contract invoke --id "$GOVERNOR" --source-account "$COUNCIL" --network "$NETWORK" \
+  --build-only \
+  -- schedule --target "$POOL" --function update_asp_membership \
+     --args "[{\"address\":\"$NEW_ASP\"}]" \
+     --predecessor "$ZERO" --salt "$ZERO" --caller "$COUNCIL" \
+| stellar tx sign --sign-with-key alice --network "$NETWORK" \
+| stellar tx sign --sign-with-key bob --network "$NETWORK" \
+| stellar tx sign --sign-with-key carol --network "$NETWORK" \
+| stellar tx send --network "$NETWORK"
+```
+
+`get_pending` lists what is queued, with the ledger at which each operation becomes ready, and
+`get_operation_state` answers for one hash. Both read without a transaction:
+
+```bash
+stellar contract invoke --id "$GOVERNOR" --source-account "$COUNCIL" --network "$NETWORK" \
+  --send=no -- get_pending
+```
+
+Once the ready ledger has passed, anyone executes the operation from any funded account. The
+call repeats the five-tuple and takes no caller:
+
+```bash
+stellar contract invoke --id "$GOVERNOR" --source-account "$ANY_ACCOUNT" --network "$NETWORK" \
+  -- execute --target "$POOL" --function update_asp_membership \
+     --args "[{\"address\":\"$NEW_ASP\"}]" --predecessor "$ZERO" --salt "$ZERO"
+```
+
+An operation nobody executes within `grace` of becoming ready returns `Expired` and has to be
+scheduled again.
+
+To withdraw a queued operation, the council sends `cancel` with the same five arguments plus its
+own address as `caller`. The guardian cannot cancel anything, and neither can anyone else.
+
+A change to the governor's own roles or permission table is an operation whose target is the
+governor. The functions are `grant_role` and `revoke_role`, each taking a member address and a
+role symbol, and `set_fn_role` and `clear_fn_role`, taking a target address, a function symbol,
+and, for `set_fn_role`, the role to require:
+
+```bash
+stellar contract invoke --id "$GOVERNOR" --source-account "$COUNCIL" --network "$NETWORK" \
+  --build-only \
+  -- schedule --target "$GOVERNOR" --function grant_role \
+     --args '[{"address":"G..."},{"symbol":"operator"}]' \
+     --predecessor "$ZERO" --salt "$ZERO" --caller "$COUNCIL"
+```
+
+The council has no instant pause. Its pause with no deadline is a queued call to the target's own
+`pause` with `until` absent, which lands after `delay` like every other operation:
+
+```bash
+stellar contract invoke --id "$GOVERNOR" --source-account "$COUNCIL" --network "$NETWORK" \
+  --build-only \
+  -- schedule --target "$POOL" --function pause --args '[{"u32":7},"void"]' \
+     --predecessor "$ZERO" --salt "$ZERO" --caller "$COUNCIL"
+```
+
+The operator's writes need no queue. They go through `execute_now`, which checks the permission
+table and forwards the call in the same transaction:
+
+```bash
+OPERATOR=$(jq -r .governance.operator "$MANIFEST")
+ASP=$(jq -r .asp_membership "$MANIFEST")
+
+stellar contract invoke --id "$GOVERNOR" --source-account operator-key --network "$NETWORK" \
+  -- execute_now --target "$ASP" --function insert_leaf \
+     --args '[{"u256":{"hi_hi":0,"hi_lo":0,"lo_hi":0,"lo_lo":7}}]' --caller "$OPERATOR"
+```
+
+## Stopping a deployment
+
+The guardian pauses one contract per transaction. There is no call that fans out, because pools
+and ASPs honor different flags and a single flag set would be refused by one of them. Walk the
+manifest instead:
+
+```bash
+GUARDIAN=$(jq -r .governance.guardian "$MANIFEST")
+pause() {
+  stellar contract invoke --id "$GOVERNOR" --source-account guardian-key --network "$NETWORK" \
+    -- pause --target "$1" --flags "$2" --caller "$GUARDIAN"
+}
+
+for pool in $(jq -r '.pools[] | select(.enabled) | .poolContractId' "$MANIFEST"); do
+  pause "$pool" 7
+done
+pause "$(jq -r .asp_membership "$MANIFEST")" 1
+pause "$(jq -r .asp_non_membership "$MANIFEST")" 1
+```
+
+A pool reads bit 1 as deposits, bit 2 as transfers, and bit 4 as withdrawals, so 7 is everything.
+Both ASPs read bit 1 as mutations and refuse any other bit. A flag set of zero is refused
+everywhere.
+
+To pause a subset of the bits rather than all of them, read `get_pause_state` on every target
+first. A lapsed pause leaves its bits set, and the new deadline covers all of them, so a leftover
+bit widens the pause past the shapes the flag set names. After a guardian pause lapses, the
+council clears the bits it set with a queued `unpause`, so the next incident pause covers only the
+shapes that incident names.
+
+## Incident playbooks
+
+### An operator key is compromised
+
+The guardian reads `get_pause_state` on each target, then pauses mutations on both ASPs and
+deposits on both pools, which holds for `guardian_pause`. The council schedules a `revoke_role`
+of the operator and a `grant_role` of a replacement on the same day, and both land after
+`delay`. The new operator then deletes the bad
+blocklist leaves. The allowlist tree is append-only, so a poisoned allowlist is answered by a
+queued re-pointing of the pool to a fresh tree, not by deletion. The sanctions list is stale for
+the days the replacement takes.
+
+Replacing a compromised guardian is the same pair against the governor, a `grant_role` for the
+new address and a `revoke_role` for the old one, and the guardian can cancel either no more than
+it can cancel anything else. Execute the grant first, or name it as the revoke's `predecessor`,
+so the deployment is never left without a guardian while the pair lands. Two addresses may hold
+the role at once; one address may not hold two.
+
+### A verifier or circuit bug
+
+The guardian pauses every bit on both pools. The council schedules the target's own `pause` with
+no deadline the same day, so the freeze survives the guardian's deadline, and schedules the ASP
+mitigations and an exit plan alongside it. The freeze ends in a coordinated reopening at an
+announced ledger, or in a migration to fresh contracts. It does not end in a patch: the pools
+are not upgradeable.
+
+### The council quorum is lost
+
+The recovery key schedules a `grant_role` of the council role to a new account. After
+`recovery_delay`, anyone executes it. The new council then schedules a `revoke_role` of the dead
+account. A live council can cancel a recovery operation, which is why recovery only succeeds when
+nobody is left to cancel.
+
+### The council key is stolen
+
+The thief's change is in `get_pending` for the whole delay, and withdrawals stay open for all of
+it. Users withdraw, and the honest team deploys fresh contracts and migrates. The guardian pauses
+deposits, which the thief undoes at once, and must not pause withdrawals. No on-chain path returns
+governance to the honest signers.
+
+## Pause bits and user funds
+
+A pool honors deposits (1), transfers (2), and withdrawals (4); an ASP honors mutations (1). No
+key can both freeze withdrawals and land a lasting change while they are frozen. The guardian's
+pause is the only instant one, and it lapses at its deadline, `guardian_pause` after the ledger
+that set it.
+
+A lapse stops the bits being honored without clearing them. `get_pause_state` still reports every
+bit an earlier pause set, and the next timed pause puts all of them under its new deadline. A
+guardian pause of deposits alone therefore re-freezes withdrawals left set by an earlier one, for
+the whole `guardian_pause` window. Once the council clears every bit on a contract, the guardian
+cannot pause that contract again before that deadline, because the deadline survives the unpause.
+
+The council's own long freeze is a queued call and therefore public for `delay` before it takes
+effect, and during a suspected council compromise the guardian does not pause withdrawals,
+because a freeze during the notice period is what would trap users. The guardian cancels
+nothing.
+
+## The guardian's two-key rule
+
+The guardian pauses withdrawals only on evidence it verifies itself, never on a report alone, and
+never while an operation sits in `get_pending`. Both halves answer the same attack: whoever holds
+the council key can call the on-call responder, claim that forged proofs are flowing, and have
+the guardian close the exit a few days before the takeover lands. Pausing deposits and transfers
+on a report is fine once `get_pause_state` shows no withdrawals bit left from an earlier pause,
+because a leftover bit turns that pause into a withdrawal freeze. Withdrawals need the responder
+to have seen the bad state.
+
+## Storage lifetimes
+
+Soroban archives persistent entries nobody renews, and an archived entry fails every call whose
+footprint touches it until it is restored. Three things keep that from happening.
+
+Each contract bumps its own instance on every call, along with the entries that call reads or
+writes; a pool also bumps its verifier's and both ASPs' instances. The `ttl-keeper` service
+covers what no call touches: idle pools, untouched root ring slots, old nullifiers, the sparse
+tree's long tail, and the governor's queue and role table. The SDK covers
+the rest for a user standing in front of an archived entry, by honoring the simulation's restore
+preamble and sending the restore before it retries the call.
+
+Run the keeper against a manifest with a funded account whose address the manifest records as
+`governance.ttlKeeper`:
+
+```bash
+TTL_KEEPER_SECRET=S... cargo run -p ttl-keeper -- \
+  --deployment deployments/testnet/deployments.json \
+  --rpc-url https://soroban-testnet.stellar.org \
+  --bootnode-url https://bootnode.example.com \
+  --state-file keeper-state.json
+```
+
+`tools/ttl-keeper/alerts.yml` carries four Prometheus rules: `KeeperRoundsFailing`,
+`KeeperClassificationMismatch`, `ContractStorageNearExpiry`, and `KeeperBalanceLow`. For the
+flags, the thresholds, and what the keeper does not cover, see
+[the keeper's README](https://github.com/NethermindEth/stellar-private-payments/blob/main/tools/ttl-keeper/README.md).
+
+The keeper has two limits. The non-membership tree names a node's children only inside that
+node's own stored value, so the walk cannot descend past an archived node, and a subtree archived
+several levels down recovers one level per round, which at the default hourly interval is one
+hour per level. The public key registry's per-user entries are not kept alive and do not
+need to be: senders resolve a recipient's keys from the registry's events, and a user who
+re-registers after their entry has archived restores it through the SDK.
+
+## The governance manifest block
+
+`deploy.sh` writes this block when it is given the governance flags, and sets the manifest's
+`admin` field to the governor id:
+
+```json
+{
+  "governance": {
+    "governor": "C...",
+    "council": "G...",
+    "operator": "G...",
+    "guardian": "G...",
+    "recovery": "G...",
+    "ttlKeeper": "G...",
+    "delay": 360,
+    "recoveryDelay": 720,
+    "grace": 17280,
+    "guardianPause": 720
+  }
+}
+```
+
+A manifest with no `governance` block describes a deployment with no governor, which the SDK, the
+admin page, and the keeper all handle. `deployments/scripts/verify-deployment.sh <network>` checks
+a manifest that has one against the chain: that every enabled pool and both ASPs name the
+governor as their admin, that each of the four holders holds its own role and that the council
+does not hold the operator role, that `get_delays` matches the block, and that the three ASP
+write rows map to the operator role while no target's `update_admin` does.

--- a/sdk/native/examples/common/mod.rs
+++ b/sdk/native/examples/common/mod.rs
@@ -34,6 +34,7 @@ use std::path::PathBuf;
 use stellar_private_payments::{
     CircuitStore, Handle, LocalProver, LocalSigner, LocalStorage, Prover, Signer,
     blocking::{Account, Client, PrivatePool},
+    chain,
     chain::LocalSigner as StellarSigner,
     types::{
         AssetDescriptor, ContractConfig, NoteAmount, NoteOwnerAddress, PoolConfigEntry,
@@ -87,9 +88,9 @@ pub fn network_passphrase(network: &str) -> Option<String> {
         return Some(value);
     }
     match network {
-        "testnet" => Some("Test SDF Network ; September 2015".to_string()),
-        "public" => Some("Public Global Stellar Network ; September 2015".to_string()),
-        "futurenet" => Some("Test SDF Future Network ; December 2023".to_string()),
+        "testnet" => Some(chain::TESTNET_PASSPHRASE.to_string()),
+        "public" => Some(chain::MAINNET_PASSPHRASE.to_string()),
+        "futurenet" => Some(chain::FUTURENET_PASSPHRASE.to_string()),
         _ => None,
     }
 }

--- a/sdk/native/src/chain/mod.rs
+++ b/sdk/native/src/chain/mod.rs
@@ -13,7 +13,18 @@ pub use contract_state::{PreparedSorobanTx, StateFetcher};
 pub use indexer::ContractDataStorage;
 pub use rpc::{Client, Client as RpcClient};
 pub use signer::{LocalSigner, Signature, auth_sign_steps, unsigned_tx_for_signing};
+pub use soroban_encode::BASE_FEE;
 pub use stellar_xdr::{Limits, ReadXdr, TransactionEnvelope, WriteXdr};
+pub use tx_assemble::apply_simulated_resources;
+
+/// Network passphrase of the public network.
+pub const MAINNET_PASSPHRASE: &str = "Public Global Stellar Network ; September 2015";
+
+/// Network passphrase of the test network.
+pub const TESTNET_PASSPHRASE: &str = "Test SDF Network ; September 2015";
+
+/// Network passphrase of the future network.
+pub const FUTURENET_PASSPHRASE: &str = "Test SDF Future Network ; October 2022";
 
 pub(crate) use contract_state::OnchainProofPublicInputs;
 pub(crate) use conversions::{

--- a/sdk/native/src/chain/tx_assemble.rs
+++ b/sdk/native/src/chain/tx_assemble.rs
@@ -129,6 +129,55 @@ fn assemble_soroban_transaction(
     }))
 }
 
+/// Applies a simulation's resource estimate to `raw`.
+///
+/// The returned envelope pays [`BASE_FEE`] on top of `resource_fee`, carries
+/// `data` as its Soroban transaction extension, and holds no signatures,
+/// because a changed fee invalidates any signature the envelope arrived with.
+///
+/// # Errors
+///
+/// Returns an error if `raw` is not a V1 transaction envelope, or if the total
+/// fee does not fit into `u32`.
+pub fn apply_simulated_resources(
+    raw: &xdr::TransactionEnvelope,
+    data: SorobanTransactionData,
+    resource_fee: u64,
+) -> Result<xdr::TransactionEnvelope> {
+    let xdr::TransactionEnvelope::Tx(v1) = raw else {
+        return Err(anyhow!("expected TransactionEnvelope::Tx"));
+    };
+    let mut tx = v1.tx.clone();
+    set_simulated_price(&mut tx, data, resource_fee)?;
+    Ok(unsigned_envelope(tx))
+}
+
+/// Sets the fee and the Soroban extension a simulation priced.
+///
+/// # Errors
+///
+/// Returns an error if the total fee does not fit into `u32`.
+fn set_simulated_price(
+    tx: &mut xdr::Transaction,
+    data: SorobanTransactionData,
+    resource_fee: u64,
+) -> Result<()> {
+    tx.fee = u64::from(BASE_FEE)
+        .saturating_add(resource_fee)
+        .try_into()
+        .map_err(|_| anyhow!("transaction fee does not fit into u32"))?;
+    tx.ext = xdr::TransactionExt::V1(data);
+    Ok(())
+}
+
+/// Wraps a transaction as an envelope with no signatures.
+fn unsigned_envelope(tx: xdr::Transaction) -> xdr::TransactionEnvelope {
+    xdr::TransactionEnvelope::Tx(xdr::TransactionV1Envelope {
+        tx,
+        signatures: xdr::VecM::default(),
+    })
+}
+
 /// Builds the `RestoreFootprint` transaction a simulation's restore preamble
 /// asks for.
 ///
@@ -145,10 +194,6 @@ fn restore_footprint_envelope(
     raw: &xdr::TransactionEnvelope,
     preamble: &RestorePreamble,
 ) -> Result<xdr::TransactionEnvelope> {
-    let xdr::TransactionEnvelope::Tx(v1) = raw else {
-        return Err(anyhow!("expected TransactionEnvelope::Tx"));
-    };
-
     let soroban_data =
         SorobanTransactionData::from_xdr_base64(&preamble.transaction_data, Limits::none())
             .map_err(|e| anyhow!("invalid restorePreamble transactionData xdr: {e}"))?;
@@ -158,25 +203,19 @@ fn restore_footprint_envelope(
             preamble.min_resource_fee
         )
     })?;
-    let fee: u32 = u64::from(BASE_FEE)
-        .saturating_add(resource_fee)
-        .try_into()
-        .map_err(|_| anyhow!("restore fee does not fit into u32"))?;
 
+    let xdr::TransactionEnvelope::Tx(v1) = raw else {
+        return Err(anyhow!("expected TransactionEnvelope::Tx"));
+    };
     let mut tx = v1.tx.clone();
-    tx.fee = fee;
     tx.operations = xdr::VecM::try_from(vec![xdr::Operation {
         source_account: None,
         body: xdr::OperationBody::RestoreFootprint(xdr::RestoreFootprintOp {
             ext: xdr::ExtensionPoint::V0,
         }),
     }])?;
-    tx.ext = xdr::TransactionExt::V1(soroban_data);
-
-    Ok(xdr::TransactionEnvelope::Tx(xdr::TransactionV1Envelope {
-        tx,
-        signatures: xdr::VecM::default(),
-    }))
+    set_simulated_price(&mut tx, soroban_data, resource_fee)?;
+    Ok(unsigned_envelope(tx))
 }
 
 impl PreparedSorobanTx {
@@ -429,6 +468,45 @@ mod tests {
         };
         assert_eq!(*data, empty_soroban_data());
         assert_eq!(v1.tx.fee, BASE_FEE + 700);
+    }
+
+    /// The keeper calls this on every extend and restore, so both of its error
+    /// arms are reachable from outside the SDK.
+    #[test]
+    fn applying_resources_refuses_an_envelope_that_is_not_v1() {
+        let v0 = xdr::TransactionEnvelope::TxV0(xdr::TransactionV0Envelope {
+            tx: xdr::TransactionV0 {
+                source_account_ed25519: xdr::Uint256([0u8; 32]),
+                fee: 100,
+                seq_num: xdr::SequenceNumber(0),
+                time_bounds: None,
+                memo: xdr::Memo::None,
+                operations: xdr::VecM::default(),
+                ext: xdr::TransactionV0Ext::V0,
+            },
+            signatures: xdr::VecM::default(),
+        });
+
+        let err = apply_simulated_resources(&v0, empty_soroban_data(), 0).expect_err("not v1");
+
+        assert!(err.to_string().contains("expected TransactionEnvelope::Tx"));
+    }
+
+    #[test]
+    fn the_priced_fee_fills_u32_and_errors_one_stroop_past_it() {
+        let raw = empty_envelope();
+        let headroom = u64::from(u32::MAX - BASE_FEE);
+
+        let envelope =
+            apply_simulated_resources(&raw, empty_soroban_data(), headroom).expect("fits");
+        let xdr::TransactionEnvelope::Tx(v1) = envelope else {
+            panic!("expected v1 envelope");
+        };
+        assert_eq!(v1.tx.fee, u32::MAX);
+
+        let err = apply_simulated_resources(&raw, empty_soroban_data(), headroom + 1)
+            .expect_err("one stroop past u32");
+        assert!(err.to_string().contains("does not fit into u32"));
     }
 
     /// The restore takes the sequence the invocation would have used, so the

--- a/tools/ttl-keeper/README.md
+++ b/tools/ttl-keeper/README.md
@@ -115,13 +115,14 @@ The non-membership tree's nodes are named only inside their parents' stored valu
 walk cannot descend past an archived node. A subtree archived several levels deep is restored
 one level per round, which at the default interval is one hour per level.
 
-The public key registry is the largest gap. The keeper extends the registry's contract
-instance and its wasm, but not the `Registration(address)` entry each user writes when they
-publish their keys, because those addresses appear only in the registry's own events and the
-keeper does not read them. `contracts/public-key-registry` bumps no lifetimes of its own
-either, so a registration that goes untouched for the archival window is lost and the user
-has to register again. Until the keeper pages those events, a deployment with real users
-needs its own job for that contract.
+The public key registry's per-user entries, one `Registration(address)` per user, are not kept
+alive, and do not need to be. Senders resolve a recipient's keys from the registry's events,
+which the indexer and the bootnode store, and the only contract code that reads the entry is
+`register` itself, as the check that suppresses a duplicate event. A user who re-registers
+after the entry has archived restores it through the SDK, which honors the simulation's
+restore preamble, at the cost of one small transaction. A client syncing without the bootnode
+sees only the registrations inside the RPC's retention window, which is a bootnode dependency
+rather than a lifetime one.
 
 A restore and an extend are independent phases. A restore that fails, for want of fee or
 balance or an RPC that is down, is logged and counted, and the extend phase still runs; the

--- a/tools/ttl-keeper/src/keys.rs
+++ b/tools/ttl-keeper/src/keys.rs
@@ -306,7 +306,7 @@ pub fn governor_keys(
 ) -> Result<Vec<LedgerKey>> {
     let governor = address(&governance.governor)?;
     let mut keys = vec![
-        data_key(&governor, "Pending", vec![])?,
+        pending_key(&governor)?,
         // Written once when the governor is constructed, and touched again
         // only on a role change, which makes it the entry most likely to be
         // archived first.
@@ -342,11 +342,7 @@ pub fn governor_keys(
         )?);
     }
     for role in ROLES {
-        keys.push(data_key(
-            &governor,
-            "RoleAccountsCount",
-            vec![symbol(role)?],
-        )?);
+        keys.push(role_count_key(&governor, role)?);
     }
     for (role, count) in role_members {
         for index in 0..*count {
@@ -519,8 +515,20 @@ async fn read_value(client: &Client, key: &LedgerKey) -> Result<Option<xdr::ScVa
         .remove(&encoded))
 }
 
-/// Reads a `u32` a contract stores under `variant`, or `None` when the ledger
-/// no longer holds it.
+/// Looks an already read entry up by its key.
+///
+/// # Errors
+///
+/// Returns an error if the key does not encode.
+fn fetched<'a>(
+    values: &'a BTreeMap<String, xdr::ScVal>,
+    key: &LedgerKey,
+) -> Result<Option<&'a xdr::ScVal>> {
+    Ok(values.get(&key.to_xdr_base64(Limits::none())?))
+}
+
+/// Returns the `u32` a contract stores under `variant`, or `None` when the
+/// ledger no longer holds it.
 ///
 /// An absent entry is the state the keeper exists to repair, so it is not an
 /// error: raising here would abort the round that would have restored it, for
@@ -529,35 +537,74 @@ async fn read_value(client: &Client, key: &LedgerKey) -> Result<Option<xdr::ScVa
 /// # Errors
 ///
 /// Returns an error if the entry is present but is not a `u32`.
-async fn read_u32(
-    client: &Client,
-    contract: &xdr::ScAddress,
-    variant: &str,
+fn fetched_u32(
+    values: &BTreeMap<String, xdr::ScVal>,
+    key: &LedgerKey,
+    what: &str,
 ) -> Result<Option<u32>> {
-    match read_value(client, &data_key(contract, variant, vec![])?).await? {
-        Some(xdr::ScVal::U32(value)) => Ok(Some(value)),
-        Some(other) => bail!("{variant} is {other:?}, expected a u32"),
+    match fetched(values, key)? {
+        Some(xdr::ScVal::U32(value)) => Ok(Some(*value)),
+        Some(other) => bail!("{what} is {other:?}, expected a u32"),
         None => Ok(None),
     }
 }
 
-/// Reads the wasm hash a contract instance runs.
+/// Builds the key of the tree depth a pool or a membership provider stores.
 ///
 /// # Errors
 ///
-/// Returns an error if the instance is absent, or runs a built-in contract
-/// rather than uploaded wasm.
-pub async fn wasm_hash(client: &Client, contract: &xdr::ScAddress) -> Result<Option<xdr::Hash>> {
-    let Some(value) = read_value(client, &instance_key(contract)).await? else {
-        return Ok(None);
-    };
+/// Returns an error if the variant is too long to be a Soroban symbol.
+fn levels_key(contract: &xdr::ScAddress) -> Result<LedgerKey> {
+    data_key(contract, "Levels", vec![])
+}
+
+/// Builds the key of the governor's list of queued operation hashes.
+///
+/// # Errors
+///
+/// Returns an error if the variant is too long to be a Soroban symbol.
+fn pending_key(governor: &xdr::ScAddress) -> Result<LedgerKey> {
+    data_key(governor, "Pending", vec![])
+}
+
+/// Builds the key of how many addresses hold `role`.
+///
+/// # Errors
+///
+/// Returns an error if `role` is too long to be a Soroban symbol.
+fn role_count_key(governor: &xdr::ScAddress, role: &str) -> Result<LedgerKey> {
+    data_key(governor, "RoleAccountsCount", vec![symbol(role)?])
+}
+
+/// Returns the wasm hash a contract instance runs, or `None` when the instance
+/// is absent or runs a built-in contract rather than uploaded wasm.
+///
+/// # Errors
+///
+/// Returns an error if the value is not a contract instance.
+fn instance_wasm(value: Option<&xdr::ScVal>) -> Result<Option<xdr::Hash>> {
     match value {
-        xdr::ScVal::ContractInstance(instance) => match instance.executable {
-            xdr::ContractExecutable::Wasm(hash) => Ok(Some(hash)),
+        None => Ok(None),
+        Some(xdr::ScVal::ContractInstance(instance)) => match &instance.executable {
+            xdr::ContractExecutable::Wasm(hash) => Ok(Some(hash.clone())),
             xdr::ContractExecutable::StellarAsset => Ok(None),
         },
-        other => bail!("contract instance is {other:?}"),
+        Some(other) => bail!("contract instance is {other:?}"),
     }
+}
+
+/// Returns every contract the manifest names.
+fn manifest_contracts(config: &ContractConfig) -> impl Iterator<Item = &str> {
+    config
+        .enabled_pools()
+        .map(|pool| pool.pool_contract_id.as_str())
+        .chain([
+            config.asp_membership.as_str(),
+            config.asp_non_membership.as_str(),
+            config.public_key_registry.as_str(),
+        ])
+        .chain(config.verifiers.values().map(String::as_str))
+        .chain(config.governance.iter().map(|g| g.governor.as_str()))
 }
 
 /// Walks the non-membership tree and returns every node it holds.
@@ -604,57 +651,99 @@ pub async fn non_membership_nodes(
 
 /// Builds every key the keeper is responsible for.
 ///
+/// One batched read answers everything the enumeration needs: every contract's
+/// instance, and the scalars a contract's key list depends on. Reading them per
+/// contract would make a round's setup cost grow with the manifest, and every
+/// extra call is another chance for the round to fail.
+///
 /// # Errors
 ///
-/// Returns an error if the manifest holds an invalid address, or a contract
-/// the manifest names is absent from the ledger.
+/// Returns an error if the manifest holds an invalid address, if the RPC
+/// refuses a read, or if an entry it returns holds a value of the wrong type.
+/// A contract the ledger no longer holds is not an error: it contributes no
+/// code key and the keeper restores what the RPC reports archived.
 pub async fn build(
     client: &Client,
     config: &ContractConfig,
     nullifiers: &BTreeMap<String, BTreeSet<String>>,
 ) -> Result<Vec<LedgerKey>> {
+    let mut keys = manifest_contracts(config)
+        .map(|id| Ok(instance_key(&address(id)?)))
+        .collect::<Result<Vec<_>>>()?;
+    keys.extend(scalar_keys(config)?);
+    let values = read_values(client, &keys).await?;
+
+    let nodes = non_membership_nodes(client, &address(&config.asp_non_membership)?).await?;
+
+    assemble(config, nullifiers, &values, &nodes)
+}
+
+/// Returns the entries [`assemble`] looks up by value rather than by name.
+///
+/// # Errors
+///
+/// Returns an error if the manifest holds an invalid address.
+fn scalar_keys(config: &ContractConfig) -> Result<Vec<LedgerKey>> {
     let mut keys = Vec::new();
-    let enabled: Vec<_> = config.pools.iter().filter(|p| p.enabled).collect();
-
-    let mut contracts: Vec<String> = enabled.iter().map(|p| p.pool_contract_id.clone()).collect();
-    contracts.push(config.asp_membership.clone());
-    contracts.push(config.asp_non_membership.clone());
-    contracts.extend(config.verifiers.values().cloned());
-    contracts.push(config.public_key_registry.clone());
-    if let Some(governance) = &config.governance {
-        contracts.push(governance.governor.clone());
+    for pool in config.enabled_pools() {
+        keys.push(levels_key(&address(&pool.pool_contract_id)?)?);
     }
-
-    for contract_id in &contracts {
-        let contract = address(contract_id)?;
-        keys.push(instance_key(&contract));
-        if let Some(hash) = wasm_hash(client, &contract).await? {
-            keys.push(code_key(hash));
+    keys.push(levels_key(&address(&config.asp_membership)?)?);
+    if let Some(governance) = &config.governance {
+        let governor = address(&governance.governor)?;
+        keys.push(pending_key(&governor)?);
+        for role in ROLES {
+            keys.push(role_count_key(&governor, role)?);
         }
     }
+    Ok(keys)
+}
 
-    for pool in &enabled {
+/// Builds the key list from the manifest, the entries already read, and the
+/// nodes the non-membership walk found.
+///
+/// # Errors
+///
+/// Returns an error if the manifest holds an invalid address, or an entry
+/// holds a value of the wrong type.
+fn assemble(
+    config: &ContractConfig,
+    nullifiers: &BTreeMap<String, BTreeSet<String>>,
+    values: &BTreeMap<String, xdr::ScVal>,
+    nodes: &[[u8; 32]],
+) -> Result<Vec<LedgerKey>> {
+    let mut keys = Vec::new();
+
+    for contract_id in manifest_contracts(config) {
+        let instance = instance_key(&address(contract_id)?);
+        if let Some(hash) = instance_wasm(fetched(values, &instance)?)? {
+            keys.push(code_key(hash));
+        }
+        keys.push(instance);
+    }
+
+    let empty = BTreeSet::new();
+    for pool in config.enabled_pools() {
         let contract = address(&pool.pool_contract_id)?;
         // A pool whose `Levels` entry is archived still gets its fixed keys, so
         // the restore that brings the entry back can run.
-        let levels = read_u32(client, &contract, "Levels").await?.unwrap_or(0);
-
-        let empty = BTreeSet::new();
+        let levels = fetched_u32(values, &levels_key(&contract)?, "Levels")?.unwrap_or(0);
         let spent = nullifiers.get(&pool.pool_contract_id).unwrap_or(&empty);
         keys.extend(pool_keys(&contract, levels, spent)?);
     }
 
     let membership = address(&config.asp_membership)?;
-    let levels = read_u32(client, &membership, "Levels").await?.unwrap_or(0);
+    let levels = fetched_u32(values, &levels_key(&membership)?, "Levels")?.unwrap_or(0);
     keys.extend(membership_keys(&membership, levels)?);
 
-    let non_membership = address(&config.asp_non_membership)?;
-    let nodes = non_membership_nodes(client, &non_membership).await?;
-    keys.extend(non_membership_keys(&non_membership, &nodes)?);
+    keys.extend(non_membership_keys(
+        &address(&config.asp_non_membership)?,
+        nodes,
+    )?);
 
     if let Some(governance) = &config.governance {
         let governor = address(&governance.governor)?;
-        let pending = match read_value(client, &data_key(&governor, "Pending", vec![])?).await? {
+        let pending = match fetched(values, &pending_key(&governor)?)? {
             Some(xdr::ScVal::Vec(Some(ids))) => ids
                 .iter()
                 .map(|id| match id {
@@ -669,12 +758,8 @@ pub async fn build(
         };
         let mut role_members = Vec::with_capacity(ROLES.len());
         for role in ROLES {
-            let key = data_key(&governor, "RoleAccountsCount", vec![symbol(role)?])?;
-            let count = match read_value(client, &key).await? {
-                Some(xdr::ScVal::U32(count)) => count,
-                _ => 0,
-            };
-            role_members.push((role.to_owned(), count));
+            let count = fetched_u32(values, &role_count_key(&governor, role)?, role)?;
+            role_members.push((role.to_owned(), count.unwrap_or(0)));
         }
 
         keys.extend(governor_keys(
@@ -1001,6 +1086,143 @@ mod tests {
             .count();
         assert_eq!(code, 1);
         assert_eq!(keys.len(), 2);
+    }
+
+    const POOL_A: &str = "CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC526";
+    const POOL_B: &str = "CABAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAFNSZ";
+    const MEMBERSHIP: &str = "CABQGAYDAMBQGAYDAMBQGAYDAMBQGAYDAMBQGAYDAMBQGAYDAMBQGCK3";
+    const NON_MEMBERSHIP: &str = "CACAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAINCW";
+    const REGISTRY: &str = "CACQKBIFAUCQKBIFAUCQKBIFAUCQKBIFAUCQKBIFAUCQKBIFAUCQLC2U";
+    const GOVERNOR: &str = "CADAMBQGAYDAMBQGAYDAMBQGAYDAMBQGAYDAMBQGAYDAMBQGAYDAMSST";
+    const WASM: [u8; 32] = [9u8; 32];
+    const POOL_A_LEVELS: u32 = 2;
+    const POOL_B_LEVELS: u32 = 5;
+    const MEMBERSHIP_LEVELS: u32 = 7;
+    const COUNCIL_MEMBERS: u32 = 2;
+
+    fn two_pools_with_governance() -> ContractConfig {
+        let pool = |id: &str, ledger: u32| {
+            format!(
+                r#"{{"poolContractId": "{id}", "tokenContractId": "{POOL_A}",
+                     "deploymentLedger": {ledger}, "enabled": true,
+                     "policyFlags": [], "asset": {{"kind": "native"}}}}"#
+            )
+        };
+        serde_json::from_str(&format!(
+            r#"{{
+                "network": "testnet",
+                "deployer": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                "admin": "{GOVERNOR}",
+                "asp_membership": "{MEMBERSHIP}",
+                "asp_non_membership": "{NON_MEMBERSHIP}",
+                "verifiers": {{}},
+                "public_key_registry": "{REGISTRY}",
+                "pools": [{}, {}],
+                "governance": {{
+                    "governor": "{GOVERNOR}",
+                    "council": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                    "operator": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                    "guardian": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                    "recovery": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                    "ttlKeeper": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                    "delay": 1, "recoveryDelay": 2, "grace": 3, "guardianPause": 4
+                }}
+            }}"#,
+            pool(POOL_A, 1),
+            pool(POOL_B, 2),
+        ))
+        .expect("manifest")
+    }
+
+    /// The entries the two batched reads bring back: one instance per contract,
+    /// one `Levels` per tree, and the governor's queue and role counts.
+    fn stored_entries(config: &ContractConfig) -> BTreeMap<String, xdr::ScVal> {
+        let encode = |key: LedgerKey| key.to_xdr_base64(Limits::none()).expect("encode key");
+        let instance = xdr::ScVal::ContractInstance(xdr::ScContractInstance {
+            executable: xdr::ContractExecutable::Wasm(xdr::Hash(WASM)),
+            storage: None,
+        });
+
+        let mut values = BTreeMap::new();
+        for contract_id in manifest_contracts(config) {
+            let contract = address(contract_id).expect("address");
+            values.insert(encode(instance_key(&contract)), instance.clone());
+        }
+
+        // Stored under the very keys `build` reads, so a lookup in `assemble`
+        // that names a different key finds nothing and the assembled
+        // list comes out short. The three role counts the zip leaves
+        // out are the ones a governor with one council holder never
+        // wrote.
+        let operation = xdr::ScVal::Bytes(xdr::ScBytes(
+            hash(5).to_vec().try_into().expect("operation id"),
+        ));
+        let scalars = scalar_keys(config).expect("scalar keys");
+        assert_eq!(
+            scalars.len(),
+            8,
+            "two depths, one depth, the queue, four counts"
+        );
+        for (key, value) in scalars.iter().zip([
+            xdr::ScVal::U32(POOL_A_LEVELS),
+            xdr::ScVal::U32(POOL_B_LEVELS),
+            xdr::ScVal::U32(MEMBERSHIP_LEVELS),
+            xdr::ScVal::Vec(Some(xdr::ScVec::try_from(vec![operation]).expect("vec"))),
+            xdr::ScVal::U32(COUNCIL_MEMBERS),
+        ]) {
+            values.insert(encode(key.clone()), value);
+        }
+        values
+    }
+
+    /// Batching moved the reads, not the enumeration. The same manifest and the
+    /// same stored entries still produce the union of the per-contract lists,
+    /// and each tree keeps the depth its own `Levels` entry gave it.
+    #[test]
+    fn the_batched_reads_assemble_the_same_key_list() {
+        let config = two_pools_with_governance();
+        let values = stored_entries(&config);
+        let nodes = [hash(8)];
+
+        let built = assemble(&config, &BTreeMap::new(), &values, &nodes).expect("assemble");
+
+        let mut expected = vec![code_key(xdr::Hash(WASM))];
+        for contract_id in manifest_contracts(&config) {
+            expected.push(instance_key(&address(contract_id).expect("address")));
+        }
+        for (contract_id, levels) in [(POOL_A, POOL_A_LEVELS), (POOL_B, POOL_B_LEVELS)] {
+            let contract = address(contract_id).expect("address");
+            expected.extend(pool_keys(&contract, levels, &BTreeSet::new()).expect("pool"));
+        }
+        expected.extend(
+            membership_keys(&address(MEMBERSHIP).expect("membership"), MEMBERSHIP_LEVELS)
+                .expect("membership"),
+        );
+        expected.extend(
+            non_membership_keys(&address(NON_MEMBERSHIP).expect("non-membership"), &nodes)
+                .expect("non-membership"),
+        );
+        let role_members = ROLES.map(|role| {
+            let count = if role == "council" {
+                COUNCIL_MEMBERS
+            } else {
+                0
+            };
+            (role.to_owned(), count)
+        });
+        expected.extend(
+            governor_keys(
+                config.governance.as_ref().expect("governance"),
+                &[hash(5)],
+                &permission_rows(&config),
+                &role_members,
+            )
+            .expect("governor"),
+        );
+        expected.sort_unstable();
+        expected.dedup();
+
+        assert_eq!(built, expected);
     }
 
     #[test]

--- a/tools/ttl-keeper/src/main.rs
+++ b/tools/ttl-keeper/src/main.rs
@@ -15,7 +15,7 @@ use metrics::{counter, gauge};
 use state::State;
 use std::{net::SocketAddr, num::NonZeroUsize, path::PathBuf, time::Duration};
 use stellar_private_payments::{
-    chain::{Client, LocalSigner},
+    chain::{Client, FUTURENET_PASSPHRASE, LocalSigner, MAINNET_PASSPHRASE, TESTNET_PASSPHRASE},
     types::ContractConfig,
 };
 use stellar_xdr::{self as xdr, LedgerKey};
@@ -153,9 +153,9 @@ async fn main() -> Result<()> {
 /// Returns an error if `network` is not one this keeper knows a passphrase for.
 fn network_passphrase(network: &str) -> Result<&'static str> {
     match network {
-        "public" | "mainnet" => Ok("Public Global Stellar Network ; September 2015"),
-        "testnet" => Ok("Test SDF Network ; September 2015"),
-        "futurenet" => Ok("Test SDF Future Network ; October 2022"),
+        "public" | "mainnet" => Ok(MAINNET_PASSPHRASE),
+        "testnet" => Ok(TESTNET_PASSPHRASE),
+        "futurenet" => Ok(FUTURENET_PASSPHRASE),
         other => bail!("no network passphrase is known for '{other}'"),
     }
 }
@@ -601,7 +601,7 @@ mod tests {
                 &rpc,
                 &bootnode,
                 &signer,
-                "Test SDF Network ; September 2015",
+                TESTNET_PASSPHRASE,
             ))
         });
 

--- a/tools/ttl-keeper/src/ops.rs
+++ b/tools/ttl-keeper/src/ops.rs
@@ -12,11 +12,8 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     time::Duration,
 };
-use stellar_private_payments::chain::{Client, LocalSigner};
+use stellar_private_payments::chain::{BASE_FEE, Client, LocalSigner, apply_simulated_resources};
 use stellar_xdr::{self as xdr, LedgerKey, Limits, ReadXdr, WriteXdr};
-
-/// Fee in stroops the transaction pays on top of the simulated resource fee.
-const BASE_FEE: u32 = 100;
 
 /// Attempts to read a transaction's outcome before giving up.
 const CONFIRM_ATTEMPTS: u32 = 30;
@@ -408,35 +405,12 @@ fn simulated(
             .to_vec(),
         None => Vec::new(),
     };
-    let envelope = with_simulated_resources(&raw, data, resource_fee)?;
+    let envelope = apply_simulated_resources(&raw, data, resource_fee)?;
     Ok(Simulated {
         envelope,
         keys,
         restore_first,
     })
-}
-
-/// Applies the resource estimate a simulation returned to `raw`.
-fn with_simulated_resources(
-    raw: &xdr::TransactionEnvelope,
-    data: xdr::SorobanTransactionData,
-    resource_fee: u64,
-) -> Result<xdr::TransactionEnvelope> {
-    let xdr::TransactionEnvelope::Tx(v1) = raw else {
-        bail!("expected a v1 transaction envelope");
-    };
-    let fee: u32 = u64::from(BASE_FEE)
-        .saturating_add(resource_fee)
-        .try_into()
-        .map_err(|_| anyhow!("transaction fee does not fit into u32"))?;
-
-    let mut tx = v1.tx.clone();
-    tx.fee = fee;
-    tx.ext = xdr::TransactionExt::V1(data);
-    Ok(xdr::TransactionEnvelope::Tx(xdr::TransactionV1Envelope {
-        tx,
-        signatures: xdr::VecM::default(),
-    }))
 }
 
 /// Signs, submits, and confirms a simulated lifetime transaction.
@@ -670,7 +644,8 @@ mod tests {
         let xdr::TransactionEnvelope::Tx(v1) = &simulated.envelope else {
             panic!("expected a v1 envelope");
         };
-        assert_eq!(v1.tx.fee, 600);
+        // An extend pays the base fee above what the simulation priced.
+        assert_eq!(v1.tx.fee, BASE_FEE + 500);
     }
 
     /// An extend whose simulation carries a restore preamble names a key the


### PR DESCRIPTION
Four follow-ups to the keeper, plus the governance guide.

- `keys::build` reads every contract's instance entries in one `getLedgerEntries` call and the
  scalar keys in a second, replacing about ten sequential round trips. The key set does not
  change, and a test pins that.
- The fee and extension handling in `restore_footprint_envelope` moves into
  `apply_simulated_resources`, exported from `chain::mod`, so the SDK and the keeper share one
  transaction assembler instead of keeping two copies. This adds to the SDK's public surface.
- `network_passphrase` gains arms for `testnet` and `futurenet` and errors on anything else. It
  previously defaulted every unrecognized network to the testnet passphrase, so a futurenet run
  signed with the wrong network id and had every transaction rejected.
- The keeper README no longer calls the public key registry its largest gap. Registrations do
  not need extending: senders resolve a recipient's keys from the registry's events, and the
  only contract code that reads the entry is `register`, which restores it through the SDK.
- `docs/src/governance.md` covers the roles, the delays, the signer lifecycle, the operation
  runbook, the incident playbooks, and the TTL runbook. Linked from `SUMMARY.md` and the README.

Closes #372.

Follow-ups: #373, #376, #455, and moving the OpenZeppelin pin once a crates.io release targets
SDK 27.
