### PR TITLE
Isolate plan/prepare logic in examples

### DIFF
--- a/sdk/native/examples/SETUP.md
+++ b/sdk/native/examples/SETUP.md
@@ -239,17 +239,16 @@ required by most examples; everything else has a sensible default.
 
 | Variable | Default | Required by |
 | --- | --- | --- |
-| `STELLAR_SECRET_KEY` | — | `account_pool`, `estimate`, `deposit`, `transfer`, `withdraw` |
+| `STELLAR_SECRET_KEY` | — | `account_pool`, `estimate`, `deposit`, `transfer`, `withdraw`, `plan` |
 | `SPP_RPC_URL` | `https://soroban-testnet.stellar.org` | all examples |
 | `SPP_WALLET_PATH` | `./spp-example-wallet.sqlite` | all examples |
 | `SPP_DEPLOYMENT_JSON` | `deployments/testnet/deployments.json` | all examples |
 | `SPP_POOL_CONTRACT_ID` | first enabled pool in deployment config | account/pool/transact examples |
-| `SPP_AMOUNT_STROOPS` | `10000000` (1 XLM) | `estimate`, `deposit`, `transfer`, `withdraw` |
+| `SPP_AMOUNT_STROOPS` | `10000000` (1 XLM) | `estimate`, `deposit`, `transfer`, `withdraw`, `plan` |
 | `SPP_BOOTNODE_URL` | `https://bootnode.dev-nethermind.xyz` | all examples |
 | `SPP_NETWORK_PASSPHRASE` | derived from `network` in `deployments.json` | account/pool/transact examples |
-| `SPP_RECIPIENT_ADDRESS` | — for `transfer`; the wallet's own address for `withdraw` | `transfer` (or use `SPP_RECIPIENT_NOTE_KEY` + `SPP_RECIPIENT_ENCRYPTION_KEY`); **also read by `withdraw`** |
+| `SPP_RECIPIENT_ADDRESS` | — for `transfer`; the wallet's own address for `withdraw`/`plan` | `transfer` (or use `SPP_RECIPIENT_NOTE_KEY` + `SPP_RECIPIENT_ENCRYPTION_KEY`); **also read by `withdraw` and `plan`** |
 | `SPP_REGISTER` | unset | `account_pool` (set to `1` to call `register_public_keys`) |
-| `SPP_VERBOSE_PLAN` | unset | `deposit` (set to `1` for step-by-step logs) |
 
 > `SPP_BOOTNODE_URL` is read directly by the examples and overrides the default
 > public bootnode. Every example that opens a client reads it, not just `sync`.
@@ -292,7 +291,7 @@ cargo run --release --example account_pool
 # Deployment-level sync and operational feed.
 cargo run --release --example sync
 
-# Transaction-count estimation and plan introspection.
+# Transaction-count estimation.
 cargo run --release --example estimate
 
 # Deposit 1 XLM into the pool (proving + submission).
@@ -305,6 +304,10 @@ SPP_RECIPIENT_ADDRESS="<BOB_ADDRESS>" cargo run --release --example transfer
 # recipient exported for `transfer` above, which `withdraw` would otherwise
 # use as the withdrawal destination.
 env -u SPP_RECIPIENT_ADDRESS cargo run --release --example withdraw
+
+# Lower-level prepare_*/PreparedTransactionPlan walkthrough (deposits its own
+# 4 notes, then withdraws all of them step by step).
+env -u SPP_RECIPIENT_ADDRESS cargo run --release --example plan
 ```
 
 Run order for a full demo:
@@ -312,9 +315,10 @@ Run order for a full demo:
 1. `account_pool` to confirm the wallet is onboarded and read the pool config.
 2. `sync` to catch the wallet state up to chain tip.
 3. `deposit` — **run it twice**, so the wallet holds two notes.
-4. `estimate` to inspect the plan cursor after the deposit.
+4. `estimate` to inspect the expected transaction count after the deposit.
 5. `transfer` to send private value to the recipient (spends one note).
 6. `withdraw` to move funds back to a public address (spends the other).
+7. `plan` for the lower-level `prepare_*` API (deposits and withdraws its own notes).
 
 > **Each spend consumes a note.** With the default `SPP_AMOUNT_STROOPS`
 > (1 XLM), one `deposit` creates exactly one 1-XLM note, and `transfer` and
@@ -326,8 +330,8 @@ Run order for a full demo:
 > `transfer` and `withdraw` require spendable notes. If the wallet has none,
 > they print a skip message and exit 0. Run `deposit` first.
 
-> **Timing:** `deposit`, `transfer`, and `withdraw` invoke the local Groth16
-> prover. Measured on testnet, a single-transaction operation completes in
+> **Timing:** `deposit`, `transfer`, `withdraw`, and `plan` invoke the local
+> Groth16 prover. Measured on testnet, a single-transaction operation completes in
 > roughly 5–10 seconds end to end: about 2 seconds of proving, with most of the
 > remainder spent waiting for the ledger to close. If one of these runs takes
 > substantially longer, suspect the build rather than the prover —

--- a/sdk/native/examples/common/mod.rs
+++ b/sdk/native/examples/common/mod.rs
@@ -32,7 +32,7 @@
 use std::path::PathBuf;
 
 use stellar_private_payments::{
-    CircuitStore, Handle, LocalProver, LocalSigner, LocalStorage, Prover, Signer,
+    CircuitStore, Error, Handle, LocalProver, LocalSigner, LocalStorage, Prover, Signer,
     blocking::{Account, Client, PrivatePool},
     chain::LocalSigner as StellarSigner,
     types::{
@@ -362,64 +362,64 @@ pub fn init_transact_session() -> Result<
 
 /// Verify that the wallet account can cover a deposit of `amount` for `pool`.
 ///
-/// Only native (XLM) balances are checked automatically; for other assets the
-/// caller must ensure the account holds enough tokens. If the balance is
-/// insufficient, prints the user address and amount and exits 0.
-pub fn require_funded_for_pool(
-    client: &Client,
-    account: &Account,
-    pool: &PoolConfigEntry,
-    amount: NoteAmount,
-) -> Result<(), String> {
+/// Checks the asset balance for `pool.asset`, and, for non-native assets, that
+/// enough XLM remains to pay transaction fees.
+pub fn require_funded_for_pool(account: &Account, pool: &PoolConfigEntry, amount: NoteAmount) {
     let address = account.user_address();
-    match &pool.asset {
-        AssetDescriptor::Native => {
-            let fetcher = client
-                .state_fetcher()
-                .map_err(|e| format!("state fetcher: {e}"))?;
-            let runtime =
-                tokio::runtime::Runtime::new().map_err(|e| format!("tokio runtime: {e}"))?;
-            // Note-owner, not signer: a deposit pulls tokens from whoever
-            // sends it, so it cannot be delegated to a different account.
-            let entry = match runtime.block_on(fetcher.rpc().get_account(address.as_str())) {
-                Ok(entry) => entry,
-                Err(e) => {
-                    let msg = e.to_string();
-                    if msg.to_lowercase().contains("not found") {
-                        eprintln!(
-                            "Skipping: account {address} was not found on-chain; fund it with XLM on testnet and re-run this example."
-                        );
-                    } else {
-                        eprintln!(
-                            "Skipping: could not verify funding for {address}: {msg}\nFund the account with XLM on testnet and re-run this example."
-                        );
-                    }
-                    std::process::exit(0);
-                }
-            };
-            let balance = i128::from(entry.balance);
-            // A deposit also pays base/resource fees; require a margin so an
-            // exactly-funded account does not pass this precheck and then fail
-            // on-chain. 0.1 XLM is far above typical Soroban fees.
-            const FEE_BUFFER_STROOPS: i128 = 1_000_000;
-            let needed = i128::try_from(u128::from(amount))
-                .map_err(|_| format!("deposit amount {amount} exceeds native balance range"))?
-                .saturating_add(FEE_BUFFER_STROOPS);
-            if balance < needed {
+
+    let fetch_balance = |asset: &AssetDescriptor, label: &str| -> u128 {
+        match account.balance(asset) {
+            Ok(balance) => balance,
+            Err(Error::AccountNotFound { .. }) => {
                 eprintln!(
-                    "Skipping: account {address} has {balance} stroops but needs at least {needed} stroops to deposit (amount plus a {FEE_BUFFER_STROOPS}-stroop fee buffer)."
+                    "Skipping: account {address} was not found on-chain; fund it with {label} on testnet and re-run this example."
                 );
-                eprintln!("Fund the account with XLM on testnet and re-run this example.");
                 std::process::exit(0);
             }
+            Err(e) => panic!("could not verify {label} funding for {address}: {e}"),
         }
-        _ => {
-            println!(
-                "Note: automatic funding check is not implemented for asset {}; ensure {} is funded.",
-                pool.token_label(),
-                address
-            );
-        }
+    };
+
+    // A deposit also pays base/resource fees in XLM, regardless of which
+    // asset is deposited; require a margin so an exactly-funded account does
+    // not pass this precheck and then fail on-chain. 0.1 XLM is far above
+    // typical Soroban fees.
+    const FEE_BUFFER_STROOPS: u128 = 1_000_000;
+
+    let is_native = matches!(pool.asset, AssetDescriptor::Native);
+    let amount = u128::from(amount);
+
+    // The native balance must cover the fee buffer, plus the deposit amount
+    // itself when the deposited asset *is* native.
+    let native_needed = if is_native {
+        amount.saturating_add(FEE_BUFFER_STROOPS)
+    } else {
+        FEE_BUFFER_STROOPS
+    };
+    let native_balance = fetch_balance(&AssetDescriptor::Native, "XLM");
+    if native_balance < native_needed {
+        let purpose = if is_native {
+            "to deposit (amount plus a fee buffer)"
+        } else {
+            "to pay transaction fees"
+        };
+        eprintln!(
+            "Skipping: account {address} has {native_balance} stroops but needs at least {native_needed} stroops of XLM {purpose}."
+        );
+        eprintln!("Fund the account with XLM on testnet and re-run this example.");
+        std::process::exit(0);
     }
-    Ok(())
+    if is_native {
+        return;
+    }
+
+    let label = pool.token_label();
+    let balance = fetch_balance(&pool.asset, &label);
+    if balance < amount {
+        eprintln!(
+            "Skipping: account {address} has {balance} of {label} but needs at least {amount} to deposit."
+        );
+        eprintln!("Fund the account with {label} on testnet and re-run this example.");
+        std::process::exit(0);
+    }
 }

--- a/sdk/native/examples/deposit.rs
+++ b/sdk/native/examples/deposit.rs
@@ -31,7 +31,7 @@ use stellar_private_payments::{Error, PreparedTransaction};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     common::init_tracing()?;
 
-    let (client, account, pool, _config, pool_config) = match common::init_transact_session() {
+    let (_client, account, pool, _config, pool_config) = match common::init_transact_session() {
         Ok(session) => session,
         Err(e) if e.contains("circuit artifacts") => {
             eprintln!("Skipping: {e}");
@@ -41,7 +41,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let amount = common::amount()?;
 
-    common::require_funded_for_pool(&client, &account, &pool_config, amount)?;
+    common::require_funded_for_pool(&account, &pool_config, amount);
 
     println!("Pool:      {}", pool_config.pool_contract_id);
     println!("Asset:     {}", pool_config.token_label());

--- a/sdk/native/examples/deposit.rs
+++ b/sdk/native/examples/deposit.rs
@@ -21,12 +21,10 @@
 //!   SPP_POOL_CONTRACT_ID      default: first enabled pool in deployment config
 //!
 //!   SPP_AMOUNT_STROOPS        default: 10000000 (1 XLM)
-//!
-//!   SPP_VERBOSE_PLAN          default: unset; set to "1" for step-by-step logs
 
 mod common;
 
-use stellar_private_payments::{Error, PreparedTransaction};
+use stellar_private_payments::Error;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     common::init_tracing()?;
@@ -49,78 +47,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Address:   {}", account.user_address());
     println!();
 
-    // Plan the deposit to report its transaction count. Deliberately *not*
-    // `pool.estimate()`: that is a spend-side estimator which loads the
-    // wallet's spendable notes and asks the planner to cover `amount` from
-    // them, so on a wallet with no notes it fails with `NoSpendableNotes`.
-    // A deposit is input-only and needs no existing notes -- hence
-    // `prepare_deposit`, which takes no wallet at all. This is the same
-    // call the web client's deposit path uses.
-    println!("Planning deposit...");
-    let plan = pool.prepare_deposit(amount).map_err(|e| {
-        if common::is_retention_gap_error(&e) {
-            common::skip_on_retention_gap(&e);
+    println!("Submitting deposit (proving may take a while)...");
+    match pool.deposit(amount) {
+        Ok(result) => {
+            print_result(&result, pool_config.pool_contract_id.as_str());
         }
-        Box::new(e) as Box<dyn std::error::Error>
-    })?;
-    println!("Expected on-chain transactions: {}", plan.tx_count());
-
-    println!();
-    if common::env_or("SPP_VERBOSE_PLAN", "") == "1" {
-        println!("Running verbose deposit pipeline...");
-        run_verbose_deposit(&pool, amount)?;
-    } else {
-        println!("Submitting deposit (proving may take a while)...");
-        match pool.deposit(amount) {
-            Ok(result) => {
-                print_result(&result, pool_config.pool_contract_id.as_str());
-            }
-            Err(e) if common::is_retention_gap_error(&e) => common::skip_on_retention_gap(&e),
-            Err(Error::PlanExecution(e)) => {
-                print_plan_execution_error(&e);
-            }
-            Err(e) => return Err(Box::new(e)),
+        Err(e) if common::is_retention_gap_error(&e) => common::skip_on_retention_gap(&e),
+        Err(Error::PlanExecution(e)) => {
+            print_plan_execution_error(&e);
         }
-    }
-
-    Ok(())
-}
-
-fn run_verbose_deposit(
-    pool: &stellar_private_payments::blocking::PrivatePool,
-    amount: stellar_private_payments::types::NoteAmount,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let mut plan = pool.prepare_deposit(amount)?;
-    let mut results = Vec::new();
-    while !plan.is_complete() {
-        let step = plan.current_tx();
-        println!("Step {} of {}", step.saturating_add(1), plan.tx_count());
-
-        println!("  proving...");
-        let mut prepared: PreparedTransaction = pool.prove_next(&mut plan)?;
-
-        println!("  simulating...");
-        pool.simulate(&mut prepared)?;
-
-        println!("  signing...");
-        let signed = pool.sign(&prepared)?;
-
-        println!("  submitting...");
-        let hash = pool.submit(signed)?;
-        println!("  submitted tx hash: {hash}");
-
-        println!("  confirming...");
-        let result = pool.confirm(&hash)?;
-        results.push(result);
-    }
-
-    println!();
-    println!(
-        "Verbose pipeline complete. Confirmed transactions: {}",
-        results.len()
-    );
-    for result in results {
-        println!("  - {}", result.tx_hash);
+        Err(e) => return Err(Box::new(e)),
     }
 
     Ok(())

--- a/sdk/native/examples/estimate.rs
+++ b/sdk/native/examples/estimate.rs
@@ -1,9 +1,8 @@
 //! Demonstrates cost/plan estimation without proving or submitting.
 //!
 //! This example shows how to obtain an [`Estimate`] (transaction count) from
-//! [`PrivatePool::estimate`] and how to introspect a
-//! [`PreparedTransactionPlan`] cursor. It uses a read-only client and only
-//! plans transactions; no proof is built and nothing is submitted.
+//! [`PrivatePool::estimate`]. It uses a read-only client and only plans
+//! transactions; no proof is built and nothing is submitted.
 //!
 //! Run:
 //!   cargo run --release --example estimate
@@ -20,7 +19,7 @@
 
 mod common;
 
-use stellar_private_payments::{Error, types::TransferRecipient};
+use stellar_private_payments::Error;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     common::init_tracing()?;
@@ -39,7 +38,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Amount:    {} stroops", u128::from(amount));
     println!();
 
-    println!("Estimating transaction count...");
+    // `PrivatePool::estimate()` provides the number of transactions required to
+    // perform a transfer or withdraw. These operations may require multiple
+    // transactions because several note merges may need to be performed to
+    // create a note with the required amount. Deposits only require one
+    // transaction.
+    println!("Estimating transaction count for a transfer/withdraw...");
     match pool.estimate(amount) {
         Ok(estimate) => {
             println!(
@@ -56,52 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     println!();
-    println!("Deposit plan introspection (always a single transaction):");
-    let deposit_plan = pool.prepare_deposit(amount)?;
-    print_plan_cursor(&deposit_plan);
-
-    let notes = pool.spendable_notes().map_err(|e| {
-        if common::is_retention_gap_error(&e) {
-            common::skip_on_retention_gap(&e);
-        }
-        Box::new(e) as Box<dyn std::error::Error>
-    })?;
-    println!();
-    if notes.is_empty() {
-        println!("No spendable notes available; skipping transfer-plan demo.");
-        println!("Deposit first, then re-run this example to see a multi-tx spend plan.");
-    } else {
-        let total: u128 = notes
-            .iter()
-            .map(|n| u128::from(n.amount))
-            .fold(0u128, u128::saturating_add);
-        println!(
-            "Spend plan introspection ({} spendable note(s) totaling {} stroops):",
-            notes.len(),
-            total
-        );
-        if u128::from(amount) > total {
-            println!(
-                "Skipping: requested amount ({} stroops) exceeds available notes ({} stroops).",
-                u128::from(amount),
-                total
-            );
-            println!("Lower SPP_AMOUNT_STROOPS or deposit more to see a spend plan.");
-        } else {
-            let recipient = TransferRecipient::from(account.user_address().as_str());
-            let transfer_plan = pool.prepare_transfer(&notes, recipient, amount)?;
-            print_plan_cursor(&transfer_plan);
-        }
-    }
-
-    println!();
     println!("No transactions were built, signed, or submitted.");
 
     Ok(())
-}
-
-fn print_plan_cursor(plan: &stellar_private_payments::plan::PreparedTransactionPlan) {
-    println!("  total transactions: {}", plan.tx_count());
-    println!("  current transaction: {}", plan.current_tx());
-    println!("  is complete: {}", plan.is_complete());
 }

--- a/sdk/native/examples/plan.rs
+++ b/sdk/native/examples/plan.rs
@@ -1,0 +1,161 @@
+//! Demonstrates the lower-level `prepare_*`/[`PreparedTransactionPlan`] API:
+//! plan introspection and manual step-by-step execution (prove, simulate,
+//! sign, submit, confirm).
+//!
+//! `deposit`/`transfer`/`withdraw` cover this in one call and are the right
+//! choice for almost all integrations. This example is for callers who need
+//! to inspect or drive the plan themselves — e.g. a UI that shows per-step
+//! progress, or a caller that wants to persist/retry individual steps.
+//!
+//! To produce a plan with more than one transaction, this example deposits
+//! four separate notes and then withdraws all of them: a withdrawal that
+//! spends several notes may need to merge them across multiple on-chain
+//! transactions before the final payout.
+//!
+//! This example builds real zero-knowledge proofs and submits transactions to
+//! the Stellar testnet, so it is slower than the read-only examples. Make
+//! sure the wallet is funded. Circuit artifacts download into
+//! `target/circuits-artifacts` on first run.
+//!
+//! Run:
+//!   cargo run --release --example plan
+//!
+//! Required env var:
+//!   STELLAR_SECRET_KEY   Stellar secret key for the funded testnet account.
+//!
+//! Optional env vars:
+//!   SPP_RECIPIENT_ADDRESS     default: the wallet's own Stellar address
+//!                             (self-withdrawal, the safe demo path).
+//!
+//!   SPP_RPC_URL               default: https://soroban-testnet.stellar.org
+//!
+//!   SPP_WALLET_PATH           default: ./spp-example-wallet.sqlite
+//!
+//!   SPP_DEPLOYMENT_JSON       default: deployments/testnet/deployments.json
+//!
+//!   SPP_POOL_CONTRACT_ID      default: first enabled pool in deployment config
+//!
+//!   SPP_AMOUNT_STROOPS        default: 10000000 (1 XLM); amount of each of
+//!                             the 4 deposited notes
+
+mod common;
+
+use stellar_private_payments::{
+    PreparedTransaction, plan::PreparedTransactionPlan, types::NoteAmount,
+};
+
+const NOTE_COUNT: u32 = 4;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    common::init_tracing()?;
+
+    let (_client, account, pool, _config, pool_config) = match common::init_transact_session() {
+        Ok(session) => session,
+        Err(e) if e.contains("circuit artifacts") => {
+            eprintln!("Skipping: {e}");
+            std::process::exit(0);
+        }
+        Err(e) => return Err(e.into()),
+    };
+    let note_amount = common::amount()?;
+    common::require_funded_for_pool(&account, &pool_config, total_amount(note_amount));
+
+    println!("Pool:      {}", pool_config.pool_contract_id);
+    println!("Asset:     {}", pool_config.token_label());
+    println!("Address:   {}", account.user_address());
+    println!();
+
+    println!(
+        "Depositing {NOTE_COUNT} notes of {} stroops each...",
+        u128::from(note_amount)
+    );
+    for i in 1..=NOTE_COUNT {
+        let result = pool.deposit(note_amount).map_err(|e| {
+            if common::is_retention_gap_error(&e) {
+                common::skip_on_retention_gap(&e);
+            }
+            Box::new(e) as Box<dyn std::error::Error>
+        })?;
+        println!("  note {i} of {NOTE_COUNT}: tx {}", result.tx_hash);
+    }
+
+    println!();
+    println!("Loading spendable notes...");
+    let notes = pool.spendable_notes()?;
+    let total: u128 = notes
+        .iter()
+        .map(|n| u128::from(n.amount))
+        .fold(0u128, u128::saturating_add);
+    println!(
+        "Wallet holds {} note(s) totaling {total} stroops",
+        notes.len()
+    );
+
+    let recipient = common::env_or("SPP_RECIPIENT_ADDRESS", account.user_address().as_str());
+    println!();
+    println!("Recipient: {recipient}");
+    if recipient == account.user_address().as_str() {
+        println!("(Using self-withdrawal; funds will return to the wallet's public address.)");
+    }
+
+    println!();
+    println!("Preparing withdrawal plan for the full balance ({total} stroops)...");
+    let mut plan = pool.prepare_withdraw(&notes, NoteAmount::from(total), &recipient)?;
+    print_plan_cursor(&plan);
+
+    println!();
+    println!("Executing plan step by step...");
+    let mut results = Vec::new();
+    while !plan.is_complete() {
+        println!(
+            "Step {} of {}",
+            plan.current_tx().saturating_add(1),
+            plan.tx_count()
+        );
+
+        println!("  proving...");
+        let mut prepared: PreparedTransaction = pool.prove_next(&mut plan)?;
+
+        println!("  simulating...");
+        pool.simulate(&mut prepared)?;
+
+        println!("  signing...");
+        let signed = pool.sign(&prepared)?;
+
+        println!("  submitting...");
+        let hash = pool.submit(signed)?;
+        println!("  submitted tx hash: {hash}");
+
+        println!("  confirming...");
+        let result = pool.confirm(&hash)?;
+        println!("  confirmed");
+        results.push(result);
+
+        print_plan_cursor(&plan);
+    }
+
+    println!();
+    println!("Plan complete. Confirmed transactions:");
+    for result in &results {
+        println!("  - {}", result.tx_hash);
+        println!(
+            "    explorer: https://stellar.expert/explorer/testnet/tx/{}",
+            result.tx_hash
+        );
+    }
+
+    Ok(())
+}
+
+fn total_amount(note_amount: NoteAmount) -> NoteAmount {
+    NoteAmount::from(u128::from(note_amount).saturating_mul(u128::from(NOTE_COUNT)))
+}
+
+fn print_plan_cursor(plan: &PreparedTransactionPlan) {
+    println!(
+        "  plan: {}/{} transactions complete (is_complete: {})",
+        plan.current_tx(),
+        plan.tx_count(),
+        plan.is_complete()
+    );
+}

--- a/sdk/native/examples/transfer.rs
+++ b/sdk/native/examples/transfer.rs
@@ -89,11 +89,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!();
     println!("Estimating transaction count...");
-    // Intentional duplicate work: `pool.transfer` below re-fetches spendable
-    // notes and re-runs `prepare_transfer` internally. We build the plan here
-    // only to show the expected tx count before committing to the real submit.
-    let plan = pool.prepare_transfer(&notes, recipient.clone(), amount)?;
-    println!("Expected on-chain transactions: {}", plan.tx_count());
+    let estimate = pool.estimate(amount)?;
+    println!("Expected on-chain transactions: {}", estimate.tx_count);
 
     println!();
     println!("Submitting transfer (proving may take a while)...");

--- a/sdk/native/examples/withdraw.rs
+++ b/sdk/native/examples/withdraw.rs
@@ -88,11 +88,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!();
     println!("Estimating transaction count...");
-    // Intentional duplicate work: `pool.withdraw` below re-fetches spendable
-    // notes and re-runs `prepare_withdraw` internally. We build the plan here
-    // only to show the expected tx count before committing to the real submit.
-    let plan = pool.prepare_withdraw(&notes, amount, &recipient)?;
-    println!("Expected on-chain transactions: {}", plan.tx_count());
+    let estimate = pool.estimate(amount)?;
+    println!("Expected on-chain transactions: {}", estimate.tx_count);
 
     println!();
     println!("Submitting withdrawal (proving may take a while)...");

--- a/sdk/native/src/account.rs
+++ b/sdk/native/src/account.rs
@@ -1,9 +1,9 @@
 use crate::types::{
-    ContractConfig, EncryptionPublicKey, Field, NoteOwnerAddress, NotePublicKey, PortfolioBalance,
-    SignerAddress, UserNoteSummary,
+    AssetDescriptor, ContractConfig, EncryptionPublicKey, Field, NoteOwnerAddress, NotePublicKey,
+    PortfolioBalance, SignerAddress, UserNoteSummary,
 };
 
-use crate::chain::{Limits, ReadXdr, StateFetcher, TransactionEnvelope, submit_tx};
+use crate::chain::{Limits, ReadXdr, RpcError, StateFetcher, TransactionEnvelope, submit_tx};
 
 use crate::{
     Error, Handle, PrivatePool, Prover, Signer, Storage,
@@ -93,6 +93,36 @@ impl<S: Storage> Account<S> {
                 &self.contract_config.portfolio_pools(),
             )
             .await
+    }
+
+    /// This account's classical on-chain balance of `asset`, in its smallest
+    /// unit (stroops for native XLM).
+    ///
+    /// This is the classical account balance, not the
+    /// shielded balance held in a pool — see [`crate::PrivatePool::balance`]
+    /// for that.
+    pub async fn balance(&self, asset: &AssetDescriptor) -> Result<u128, Error> {
+        match asset {
+            AssetDescriptor::Native => {
+                match self.rpc.get_account(self.user_address.as_str()).await {
+                    Ok(entry) => u128::try_from(entry.balance).map_err(|_| {
+                        Error::Other(format!("negative account balance: {}", entry.balance))
+                    }),
+                    Err(RpcError::NotFound("Account", _)) => Err(Error::AccountNotFound {
+                        address: self.user_address.as_str().to_string(),
+                    }),
+                    Err(e) => Err(e.into()),
+                }
+            }
+            AssetDescriptor::Classic { code, issuer } => Ok(self
+                .rpc
+                .get_trustline_balance(self.user_address.as_str(), code, issuer)
+                .await?),
+            AssetDescriptor::Contract { contract_id, .. } => Ok(self
+                .rpc
+                .get_token_balance(contract_id, self.user_address.as_str())
+                .await?),
+        }
     }
 
     /// Locally derived note and encryption public keys for this account.

--- a/sdk/native/src/blocking/account.rs
+++ b/sdk/native/src/blocking/account.rs
@@ -1,8 +1,8 @@
 //! Sync wrapper around [`crate::Account`] via a shared Tokio runtime.
 
 use crate::types::{
-    EncryptionPublicKey, Field, NoteOwnerAddress, NotePublicKey, PortfolioBalance, SignerAddress,
-    UserNoteSummary,
+    AssetDescriptor, EncryptionPublicKey, Field, NoteOwnerAddress, NotePublicKey, PortfolioBalance,
+    SignerAddress, UserNoteSummary,
 };
 
 use crate::{
@@ -49,6 +49,12 @@ impl Account {
 
     pub fn portfolio(&self) -> Result<Vec<PortfolioBalance>, Error> {
         block_on(self.inner.portfolio())
+    }
+
+    /// This account's classical on-chain balance of `asset`, in its smallest
+    /// unit (stroops for native XLM).
+    pub fn balance(&self, asset: &AssetDescriptor) -> Result<u128, Error> {
+        block_on(self.inner.balance(asset))
     }
 
     pub fn user_public_keys(&self) -> Result<(NotePublicKey, EncryptionPublicKey), Error> {

--- a/sdk/native/src/chain/contract_state.rs
+++ b/sdk/native/src/chain/contract_state.rs
@@ -5,11 +5,11 @@ use super::{
     },
     rpc::{Client, ContractDataBulkRequest},
     soroban_encode::BASE_FEE,
+    tx_assemble::build_invoke_contract_tx_envelope,
 };
 use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, str::FromStr};
-use stellar_strkey::ed25519;
+use std::collections::HashMap;
 use stellar_xdr::{self as xdr, ReadXdr};
 
 use crate::types::{
@@ -668,7 +668,7 @@ impl StateFetcher {
         source_account: &str,
         key: Field,
     ) -> Result<xdr::TransactionEnvelope> {
-        Self::build_invoke_contract_tx_envelope(
+        build_invoke_contract_tx_envelope(
             source_account,
             xdr::SequenceNumber(0),
             BASE_FEE,
@@ -684,7 +684,7 @@ impl StateFetcher {
         source_account: &str,
         root: Field,
     ) -> Result<xdr::TransactionEnvelope> {
-        Self::build_invoke_contract_tx_envelope(
+        build_invoke_contract_tx_envelope(
             source_account,
             xdr::SequenceNumber(0),
             BASE_FEE,
@@ -700,7 +700,7 @@ impl StateFetcher {
         source_account: &str,
         nullifier: Field,
     ) -> Result<xdr::TransactionEnvelope> {
-        Self::build_invoke_contract_tx_envelope(
+        build_invoke_contract_tx_envelope(
             source_account,
             xdr::SequenceNumber(0),
             BASE_FEE,
@@ -709,53 +709,6 @@ impl StateFetcher {
             vec![field_to_scval_u256(nullifier)],
             Vec::new(),
         )
-    }
-
-    pub(crate) fn build_invoke_contract_tx_envelope(
-        source_account: &str,
-        seq_num: xdr::SequenceNumber,
-        fee: u32,
-        contract_id: &str,
-        function: &str,
-        args: Vec<xdr::ScVal>,
-        auth_entries: Vec<xdr::SorobanAuthorizationEntry>,
-    ) -> Result<xdr::TransactionEnvelope> {
-        let source = Self::muxed_account_from_g(source_account)?;
-        let contract_address = Self::contract_scaddress_from_str(contract_id)?;
-        let function_name =
-            xdr::ScSymbol::try_from(function).map_err(|_| anyhow!("invalid function name"))?;
-        let args = xdr::VecM::try_from(args)?;
-
-        let invoke_args = xdr::InvokeContractArgs {
-            contract_address,
-            function_name,
-            args,
-        };
-        let host_function = xdr::HostFunction::InvokeContract(invoke_args);
-        let invoke_op = xdr::InvokeHostFunctionOp {
-            host_function,
-            auth: xdr::VecM::try_from(auth_entries)?,
-        };
-        let op = xdr::Operation {
-            source_account: None,
-            body: xdr::OperationBody::InvokeHostFunction(invoke_op),
-        };
-
-        let operations = xdr::VecM::try_from(vec![op])?;
-        let tx = xdr::Transaction {
-            source_account: source,
-            fee,
-            seq_num,
-            cond: xdr::Preconditions::None,
-            memo: xdr::Memo::None,
-            operations,
-            ext: xdr::TransactionExt::V0,
-        };
-
-        Ok(xdr::TransactionEnvelope::Tx(xdr::TransactionV1Envelope {
-            tx,
-            signatures: xdr::VecM::default(),
-        }))
     }
 
     fn parse_find_result(val: &xdr::ScVal) -> Result<ParsedFindResult> {
@@ -828,18 +781,6 @@ impl StateFetcher {
             not_found_value,
             is_old0,
         })
-    }
-
-    fn muxed_account_from_g(account: &str) -> Result<xdr::MuxedAccount> {
-        let pk = ed25519::PublicKey::from_string(account)?;
-        Ok(xdr::MuxedAccount::Ed25519(xdr::Uint256(pk.0)))
-    }
-
-    fn contract_scaddress_from_str(contract_id: &str) -> Result<xdr::ScAddress> {
-        let contract = stellar_strkey::Contract::from_str(contract_id)?;
-        Ok(xdr::ScAddress::Contract(xdr::ContractId(xdr::Hash(
-            contract.0,
-        ))))
     }
 }
 

--- a/sdk/native/src/chain/rpc.rs
+++ b/sdk/native/src/chain/rpc.rs
@@ -14,6 +14,8 @@ use stellar_xdr::{
     LedgerKey, LedgerKeyAccount, Limits, PublicKey, ReadXdr, Uint256, WriteXdr,
 };
 
+use super::{soroban_encode::BASE_FEE, tx_assemble::build_invoke_contract_tx_envelope};
+
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
@@ -683,6 +685,91 @@ impl Client {
             _ => Err(Error::UnexpectedScVal(
                 "expected account ledger entry".into(),
             )),
+        }
+    }
+
+    /// Trustline balance of `address` in the classic asset `code:issuer`, in
+    /// its smallest unit.
+    pub async fn get_trustline_balance(
+        &self,
+        address: &str,
+        code: &str,
+        issuer: &str,
+    ) -> Result<u128, Error> {
+        let account_id = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+            stellar_strkey::ed25519::PublicKey::from_str(address)?.0,
+        )));
+        let issuer_id = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+            stellar_strkey::ed25519::PublicKey::from_str(issuer)?.0,
+        )));
+        let asset = match code.parse::<xdr::AssetCode4>() {
+            Ok(asset_code) => xdr::TrustLineAsset::CreditAlphanum4(xdr::AlphaNum4 {
+                asset_code,
+                issuer: issuer_id,
+            }),
+            Err(_) => xdr::TrustLineAsset::CreditAlphanum12(xdr::AlphaNum12 {
+                asset_code: code
+                    .parse()
+                    .map_err(|_| Error::UnexpectedScVal(format!("invalid asset code: {code}")))?,
+                issuer: issuer_id,
+            }),
+        };
+        let key = LedgerKey::Trustline(xdr::LedgerKeyTrustLine { account_id, asset });
+        let response = self.get_ledger_entries(&[key]).await?;
+        let entries = response.entries.unwrap_or_default();
+        let Some(entry) = entries.first() else {
+            return Ok(0);
+        };
+        match LedgerEntryData::from_xdr_base64(&entry.xdr, Limits::none())? {
+            LedgerEntryData::Trustline(entry) => u128::try_from(entry.balance).map_err(|_| {
+                Error::UnexpectedScVal(format!("negative trustline balance: {}", entry.balance))
+            }),
+            _ => Err(Error::UnexpectedScVal(
+                "expected trustline ledger entry".into(),
+            )),
+        }
+    }
+
+    /// Balance of `address` reported by the SEP-41 token contract
+    /// `contract_id`.
+    pub async fn get_token_balance(&self, contract_id: &str, address: &str) -> Result<u128, Error> {
+        let arg = address
+            .parse()
+            .map_err(|_| Error::UnexpectedScVal(format!("invalid address: {address}")))?;
+        let tx = build_invoke_contract_tx_envelope(
+            address,
+            xdr::SequenceNumber(0),
+            BASE_FEE,
+            contract_id,
+            "balance",
+            vec![xdr::ScVal::Address(arg)],
+            Vec::new(),
+        )
+        .map_err(|e| Error::UnexpectedScVal(e.to_string()))?;
+
+        let sim = self.simulate_transaction(&tx).await?;
+        let op_result = sim
+            .result
+            .or_else(|| sim.results.into_iter().next())
+            .ok_or_else(|| {
+                Error::UnexpectedScVal("simulateTransaction returned no results".into())
+            })?;
+        let retval_b64 = op_result
+            .retval
+            .or(op_result.xdr)
+            .ok_or_else(|| Error::UnexpectedScVal("simulateTransaction missing retval".into()))?;
+        match xdr::ScVal::from_xdr_base64(&retval_b64, Limits::none())? {
+            xdr::ScVal::I128(parts) => {
+                let value = i128::from(&parts);
+                u128::try_from(value).map_err(|_| {
+                    Error::UnexpectedScVal(format!(
+                        "token contract reported a negative balance: {value}"
+                    ))
+                })
+            }
+            other => Err(Error::UnexpectedScVal(format!(
+                "expected balance() to return i128, got {other:?}"
+            ))),
         }
     }
 

--- a/sdk/native/src/chain/tx_assemble.rs
+++ b/sdk/native/src/chain/tx_assemble.rs
@@ -1,4 +1,7 @@
-//! Apply Soroban RPC simulation output to an unsigned transaction envelope.
+//! Build an unsigned invoke-contract transaction envelope, and apply Soroban
+//! RPC simulation output to one.
+
+use std::str::FromStr;
 
 use anyhow::{Result, anyhow};
 use stellar_xdr::{
@@ -6,6 +9,67 @@ use stellar_xdr::{
 };
 
 use super::{contract_state::PreparedSorobanTx, rpc::SimulateTransactionResponse};
+
+/// Builds an unsigned, unsubmitted transaction envelope invoking `function`
+/// on `contract_id`, for read-only simulation.
+pub(crate) fn build_invoke_contract_tx_envelope(
+    source_account: &str,
+    seq_num: xdr::SequenceNumber,
+    fee: u32,
+    contract_id: &str,
+    function: &str,
+    args: Vec<xdr::ScVal>,
+    auth_entries: Vec<xdr::SorobanAuthorizationEntry>,
+) -> Result<xdr::TransactionEnvelope> {
+    let source = muxed_account_from_g(source_account)?;
+    let contract_address = contract_scaddress_from_str(contract_id)?;
+    let function_name =
+        xdr::ScSymbol::try_from(function).map_err(|_| anyhow!("invalid function name"))?;
+    let args = xdr::VecM::try_from(args)?;
+
+    let invoke_args = xdr::InvokeContractArgs {
+        contract_address,
+        function_name,
+        args,
+    };
+    let host_function = xdr::HostFunction::InvokeContract(invoke_args);
+    let invoke_op = xdr::InvokeHostFunctionOp {
+        host_function,
+        auth: xdr::VecM::try_from(auth_entries)?,
+    };
+    let op = xdr::Operation {
+        source_account: None,
+        body: xdr::OperationBody::InvokeHostFunction(invoke_op),
+    };
+
+    let operations = xdr::VecM::try_from(vec![op])?;
+    let tx = xdr::Transaction {
+        source_account: source,
+        fee,
+        seq_num,
+        cond: xdr::Preconditions::None,
+        memo: xdr::Memo::None,
+        operations,
+        ext: xdr::TransactionExt::V0,
+    };
+
+    Ok(xdr::TransactionEnvelope::Tx(xdr::TransactionV1Envelope {
+        tx,
+        signatures: xdr::VecM::default(),
+    }))
+}
+
+fn muxed_account_from_g(account: &str) -> Result<xdr::MuxedAccount> {
+    let pk = stellar_strkey::ed25519::PublicKey::from_str(account)?;
+    Ok(xdr::MuxedAccount::Ed25519(xdr::Uint256(pk.0)))
+}
+
+fn contract_scaddress_from_str(contract_id: &str) -> Result<xdr::ScAddress> {
+    let contract = stellar_strkey::Contract::from_str(contract_id)?;
+    Ok(xdr::ScAddress::Contract(xdr::ContractId(xdr::Hash(
+        contract.0,
+    ))))
+}
 
 impl SimulateTransactionResponse {
     /// Returns the first host-function simulation result.

--- a/sdk/native/src/chain/tx_prepare.rs
+++ b/sdk/native/src/chain/tx_prepare.rs
@@ -10,6 +10,7 @@ use super::{
         BASE_FEE, pool_ext_data_to_scval, pool_gvk_proof_to_scval, pool_proof_to_scval,
         register_account_to_scval,
     },
+    tx_assemble::build_invoke_contract_tx_envelope,
 };
 
 /// Prover output needed to prepare a pool `transact` invocation.
@@ -69,7 +70,7 @@ impl StateFetcher {
         );
 
         let seq = self.account_sequence(source_account).await?;
-        let raw = Self::build_invoke_contract_tx_envelope(
+        let raw = build_invoke_contract_tx_envelope(
             source_account,
             seq,
             BASE_FEE,
@@ -107,7 +108,7 @@ impl StateFetcher {
 
         let payer = payer.as_str();
         let seq = self.account_sequence(payer).await?;
-        let raw = Self::build_invoke_contract_tx_envelope(
+        let raw = build_invoke_contract_tx_envelope(
             payer,
             seq,
             BASE_FEE,
@@ -451,7 +452,7 @@ mod tests {
         let ext_scval = pool_ext_data_to_scval(&ext).expect("ext scval");
         let sender_scval = xdr::ScVal::Address(source.parse().expect("address"));
 
-        let raw = StateFetcher::build_invoke_contract_tx_envelope(
+        let raw = build_invoke_contract_tx_envelope(
             &source,
             next_sequence(mock.seq.clone()).expect("next seq"),
             BASE_FEE,

--- a/sdk/native/src/error.rs
+++ b/sdk/native/src/error.rs
@@ -14,6 +14,9 @@ pub enum Error {
     InvalidConfig(String),
 
     #[error(transparent)]
+    Rpc(#[from] crate::chain::RpcError),
+
+    #[error(transparent)]
     Plan(#[from] PlanError),
 
     #[error(transparent)]
@@ -44,6 +47,10 @@ pub enum Error {
         crate::types::Sensitive(owner)
     )]
     SignerIsNotNoteOwner { owner: String, signer: String },
+
+    /// The account has no ledger entry on-chain yet.
+    #[error("account {} not found on-chain", crate::types::Sensitive(address))]
+    AccountNotFound { address: String },
 
     #[error("{0}")]
     Other(String),


### PR DESCRIPTION
Simplifies to not use `prepare_*`, plan logic in main `deposit`, `transfer` and `withdraw` examples. That is lower level logic which is advised to not be used in most use-cases.
That API is now showcased in the new `plan` example.
