### PR TITLE
Test a payment whose owner and signer are different accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5368,6 +5368,7 @@ dependencies = [
  "rusqlite",
  "serde_json",
  "stellar-private-payments",
+ "stellar-xdr",
  "tracing",
  "tracing-subscriber",
 ]

--- a/sdk/tests/Cargo.toml
+++ b/sdk/tests/Cargo.toml
@@ -15,6 +15,9 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 stellar-private-payments = { workspace = true }
+# Matches the version stellar-private-payments builds against, so the envelope
+# types the tests inspect are the ones the SDK produced.
+stellar-xdr = { version = "27.0.0", features = ["serde", "base64", "std", "alloc"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 

--- a/sdk/tests/src/pool.rs
+++ b/sdk/tests/src/pool.rs
@@ -1,6 +1,13 @@
 //! Test fixtures for [`stellar_private_payments::blocking::PrivatePool`].
 
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::{
+    io::{BufRead, BufReader, Read, Write},
+    net::{TcpListener, TcpStream},
+    sync::{
+        OnceLock,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
 use anyhow::Result;
 use stellar_private_payments::{
@@ -11,6 +18,7 @@ use stellar_private_payments::{
         NoteOwnerAddress, NotePublicKey, PolicyFlags, SignerAddress, TransferRecipient,
     },
 };
+use stellar_xdr::{self as xdr, Limits, WriteXdr};
 
 use crate::seed::{self, POOL_MERKLE_LEVELS};
 
@@ -36,12 +44,28 @@ const TEST_CONFIG_JSON: &str = r#"{
     }]
 }"#;
 
-const POOL_CONTRACT_ID: &str = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+pub const POOL_CONTRACT_ID: &str = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
 const ASP_MEMBERSHIP_CONTRACT_ID: &str = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
 const USER_ADDRESS: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
 /// Ed25519 secret for `SigningKey::from_bytes(&[7u8; 32])` (stellar signer unit
 /// tests).
 const TEST_SIGNER_SECRET: &str = "SADQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQP54X";
+const TESTNET_RPC_URL: &str = "https://soroban-testnet.stellar.org";
+const TEST_NETWORK_PASSPHRASE: &str = "Test SDF Network ; September 2015";
+
+/// The account the seeded notes belong to.
+pub const OWNER_ADDRESS: &str = USER_ADDRESS;
+/// The account that signs and pays in a delegated session. Owns no notes.
+pub const DELEGATE_ADDRESS: &str = "GD6ROJBYLKQMOW3E7N4M2YBPUHMZD7PL65VRHRMO24BOVSBV5H3BQRSL";
+/// Ed25519 secret for `SigningKey::from_bytes(&[9u8; 32])`, whose public key is
+/// [`DELEGATE_ADDRESS`]. The pair must match: `LocalSigner` refuses to sign for
+/// an address that is not its own key.
+const DELEGATE_SIGNER_SECRET: &str = "SAEQSCIJBEEQSCIJBEEQSCIJBEEQSCIJBEEQSCIJBEEQSCIJBEEQTDMN";
+/// A third account, neither the note owner nor the signer: where a withdrawal
+/// is asked to send its funds. Public key of `SigningKey::from_bytes(&[7u8;
+/// 32])`.
+pub const WITHDRAW_RECIPIENT_ADDRESS: &str =
+    "GDVEU3DD4KOFECV66VIHWEZOYX4ZKR3WV27L464SIIPOU2IUI3JCZA57";
 
 pub use crate::seed::TEST_NETWORK;
 
@@ -54,6 +78,34 @@ pub fn test_pool(wallet: Option<&[u64]>) -> Result<PrivatePool> {
 }
 
 fn test_client_and_account(wallet: Option<&[u64]>) -> Result<(Client, Account)> {
+    let client = test_client(wallet, TESTNET_RPC_URL)?;
+    let account = client.account(
+        NoteOwnerAddress::new(USER_ADDRESS),
+        SignerAddress::new(USER_ADDRESS),
+        test_signer()?,
+    )?;
+
+    Ok((client, account))
+}
+
+/// A session whose note owner and signer are two different accounts: the notes
+/// are seeded under [`OWNER_ADDRESS`], and [`DELEGATE_ADDRESS`] signs and pays.
+///
+/// The client talks to [`stub_rpc_url`], so
+/// [`PrivatePool::simulate`](stellar_private_payments::blocking::PrivatePool::simulate)
+/// can build a real envelope without a network.
+pub fn delegated_test_client_and_account(wallet: Option<&[u64]>) -> Result<(Client, Account)> {
+    let client = test_client(wallet, stub_rpc_url())?;
+    let account = client.account(
+        NoteOwnerAddress::new(OWNER_ADDRESS),
+        SignerAddress::new(DELEGATE_ADDRESS),
+        delegate_signer()?,
+    )?;
+
+    Ok((client, account))
+}
+
+fn test_client(wallet: Option<&[u64]>, rpc_url: &str) -> Result<Client> {
     static RUN: AtomicUsize = AtomicUsize::new(0);
     let db_path = std::env::temp_dir().join(format!(
         "stellar-sdk-test-{}-{}.sqlite",
@@ -82,25 +134,14 @@ fn test_client_and_account(wallet: Option<&[u64]>) -> Result<(Client, Account)> 
     let prover = Handle::from_box(Box::new(LocalProver::from_artifacts(&[(stem, artifacts)])?)
         as Box<dyn stellar_private_payments::Prover>);
     let contract_config: ContractConfig = serde_json::from_str(TEST_CONFIG_JSON)?;
-    let mut client = Client::init(
-        "https://soroban-testnet.stellar.org",
-        storage,
-        prover,
-        contract_config,
-        None,
-    )?;
+    let mut client = Client::init(rpc_url, storage, prover, contract_config, None)?;
     // Mode flip only — tests do not run the indexer loop.
     #[allow(unused_must_use)]
     {
         let _ = client.background_sync()?;
     }
-    let account = client.account(
-        NoteOwnerAddress::new(USER_ADDRESS),
-        SignerAddress::new(USER_ADDRESS),
-        test_signer()?,
-    )?;
 
-    Ok((client, account))
+    Ok(client)
 }
 
 pub fn test_recipient() -> TransferRecipient {
@@ -115,11 +156,129 @@ pub fn test_recipient() -> TransferRecipient {
 }
 
 fn test_signer() -> Result<Handle<dyn Signer>> {
+    local_signer(TEST_SIGNER_SECRET, USER_ADDRESS)
+}
+
+/// A signer bound to [`DELEGATE_ADDRESS`], holding that account's own key.
+pub fn delegate_signer() -> Result<Handle<dyn Signer>> {
+    local_signer(DELEGATE_SIGNER_SECRET, DELEGATE_ADDRESS)
+}
+
+fn local_signer(secret: &str, address: &str) -> Result<Handle<dyn Signer>> {
     Ok(Handle::from_box(Box::new(LocalSigner::new(
-        TEST_SIGNER_SECRET,
-        "Test SDF Network ; September 2015",
-        SignerAddress::new(USER_ADDRESS),
+        secret,
+        TEST_NETWORK_PASSPHRASE,
+        SignerAddress::new(address),
     )?) as Box<dyn Signer>))
+}
+
+/// A stand-in for the two RPC calls `PrivatePool::simulate` makes: one canned
+/// reply each, since `get_account` does not check that the entry it is handed
+/// belongs to the address it asked for. One listener per test binary.
+fn stub_rpc_url() -> &'static str {
+    static URL: OnceLock<String> = OnceLock::new();
+    URL.get_or_init(|| {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind stub rpc");
+        let url = format!(
+            "http://{}",
+            listener.local_addr().expect("stub rpc local address")
+        );
+        std::thread::spawn(move || {
+            for stream in listener.incoming().flatten() {
+                std::thread::spawn(move || {
+                    let _ = serve_stub_rpc(stream);
+                });
+            }
+        });
+        url
+    })
+}
+
+/// Answers one JSON-RPC request, chosen by the method name in the body.
+fn serve_stub_rpc(mut stream: TcpStream) -> std::io::Result<()> {
+    let mut reader = BufReader::new(stream.try_clone()?);
+    let mut content_length = 0usize;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line)? == 0 {
+            return Ok(());
+        }
+        let line = line.trim_end();
+        if line.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = line.split_once(':')
+            && name.eq_ignore_ascii_case("content-length")
+        {
+            content_length = value.trim().parse().unwrap_or(0);
+        }
+    }
+    let mut body = vec![0u8; content_length];
+    reader.read_exact(&mut body)?;
+
+    let result = if String::from_utf8_lossy(&body).contains("getLedgerEntries") {
+        stub_account_entry_result()
+    } else {
+        stub_simulation_result()
+    };
+    let payload = format!(r#"{{"jsonrpc":"2.0","id":1,"result":{result}}}"#);
+    write!(
+        stream,
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload}",
+        payload.len(),
+    )?;
+    stream.flush()
+}
+
+/// One `getLedgerEntries` entry: an account sitting at sequence 41.
+fn stub_account_entry_result() -> String {
+    let entry = xdr::LedgerEntryData::Account(xdr::AccountEntry {
+        account_id: xdr::AccountId(xdr::PublicKey::PublicKeyTypeEd25519(xdr::Uint256(
+            [0u8; 32],
+        ))),
+        balance: 0,
+        seq_num: xdr::SequenceNumber(41),
+        num_sub_entries: 0,
+        inflation_dest: None,
+        flags: 0,
+        home_domain: xdr::String32::default(),
+        thresholds: xdr::Thresholds([1, 0, 0, 0]),
+        signers: xdr::VecM::default(),
+        ext: xdr::AccountEntryExt::V0,
+    })
+    .to_xdr_base64(Limits::none())
+    .expect("account ledger entry xdr");
+    serde_json::json!({
+        "entries": [{"key": "", "xdr": entry, "lastModifiedLedgerSeq": 1}],
+        "latestLedger": 1,
+    })
+    .to_string()
+}
+
+/// A successful `simulateTransaction`: no auth entries, no footprint, a fee.
+fn stub_simulation_result() -> String {
+    let transaction_data = xdr::SorobanTransactionData {
+        ext: xdr::SorobanTransactionDataExt::V0,
+        resources: xdr::SorobanResources {
+            footprint: xdr::LedgerFootprint {
+                read_only: xdr::VecM::default(),
+                read_write: xdr::VecM::default(),
+            },
+            instructions: 0,
+            disk_read_bytes: 0,
+            write_bytes: 0,
+        },
+        resource_fee: 0,
+    }
+    .to_xdr_base64(Limits::none())
+    .expect("soroban transaction data xdr");
+    serde_json::json!({
+        "latestLedger": 1,
+        "results": [{"auth": []}],
+        "transactionData": transaction_data,
+        "minResourceFee": "100",
+    })
+    .to_string()
 }
 
 fn test_prover_artifacts() -> Result<stellar_private_payments::types::ProverArtifacts> {

--- a/sdk/tests/src/tests/plan.rs
+++ b/sdk/tests/src/tests/plan.rs
@@ -118,3 +118,264 @@ fn withdraw_zero() {
 
     assert!(matches!(err, Error::InvalidConfig(_)));
 }
+
+/// A session whose note owner and signer are different accounts: notes and key
+/// material from the owner, envelope and `sender` from the signer, withdrawal
+/// recipient from neither.
+mod divergent_owner_and_signer {
+    use crate::{
+        pool::{
+            DELEGATE_ADDRESS, OWNER_ADDRESS, POOL_CONTRACT_ID, WITHDRAW_RECIPIENT_ADDRESS,
+            delegate_signer, delegated_test_client_and_account, test_recipient,
+        },
+        seed::seeded_user_public_keys,
+    };
+    use stellar_private_payments::{
+        PreparedTransaction,
+        blocking::PrivatePool,
+        chain::{Limits, ReadXdr, TransactionEnvelope},
+        planner::{SpendSession, SpendTarget},
+        transact::PreparedTxPublic,
+        types::{ExtAmount, ExtData, Field, NoteAmount, NoteOwnerAddress, SignerAddress},
+    };
+    use stellar_xdr::{self as xdr, ScAddress};
+
+    #[test]
+    fn withdraw_spends_the_owners_notes_and_is_sourced_by_the_signer() {
+        let (client, account) =
+            delegated_test_client_and_account(Some(&[10])).expect("delegated session");
+        let pool = account.pool(POOL_CONTRACT_ID).expect("pool");
+        assert_divergent(&pool);
+
+        let wallet = pool.spendable_notes().expect("spendable notes");
+        assert_eq!(
+            wallet.iter().map(|note| note.amount).collect::<Vec<_>>(),
+            [NoteAmount::from(10u128)],
+        );
+        assert_eq!(pool.balance().expect("balance"), NoteAmount::from(10u128));
+        let signer_owned = client
+            .account(
+                NoteOwnerAddress::new(DELEGATE_ADDRESS),
+                SignerAddress::new(DELEGATE_ADDRESS),
+                delegate_signer().expect("delegate signer"),
+            )
+            .expect("signer-owned session")
+            .pool(POOL_CONTRACT_ID)
+            .expect("signer-owned pool");
+        assert!(
+            signer_owned
+                .spendable_notes()
+                .expect("signer-owned notes")
+                .is_empty(),
+            "the notes must be looked up for the owner, not for the signer",
+        );
+
+        // Key material is what a self-addressed change note is encrypted to.
+        let (note_key, encryption_key) = account.user_public_keys().expect("session keys");
+        let (owner_note_key, owner_encryption_key) =
+            seeded_user_public_keys().expect("seeded owner keys");
+        assert_eq!(note_key.0, owner_note_key.0);
+        assert_eq!(encryption_key.0, owner_encryption_key.0);
+
+        // The 10 note pays 4 out of the pool and leaves 6 behind as change.
+        let amount = NoteAmount::from(4u128);
+        let change = NoteAmount::from(6u128);
+        let plan = pool
+            .prepare_withdraw(&wallet, amount, WITHDRAW_RECIPIENT_ADDRESS)
+            .expect("a delegated session must plan a withdrawal");
+        assert_eq!(plan.tx_count(), 1);
+
+        let paid_out = ExtAmount::try_from(amount)
+            .expect("withdrawn amount fits an ext amount")
+            .checked_neg()
+            .expect("a withdrawal leaves the pool");
+
+        // `PreparedTransactionPlan` does not expose its step; this is the
+        // session `prepare_withdraw` builds, from the arguments it passes.
+        let step = SpendSession::setup(
+            wallet.clone(),
+            amount,
+            POOL_CONTRACT_ID.to_string(),
+            SpendTarget::withdraw(WITHDRAW_RECIPIENT_ADDRESS.to_string()),
+        )
+        .expect("spend session")
+        .step()
+        .expect("materialise the step")
+        .expect("a one-tx plan has a step");
+        assert_eq!(step.ext_recipient, WITHDRAW_RECIPIENT_ADDRESS);
+        assert_eq!(step.ext_amount, paid_out);
+        assert_eq!(
+            step.input_commitments,
+            wallet
+                .iter()
+                .map(|note| note.commitment)
+                .collect::<Vec<_>>(),
+            "the step must spend the owner's note",
+        );
+        assert_eq!(step.output_amounts, [change, NoteAmount::ZERO]);
+        assert!(
+            step.out_recipient_note_pubkeys.iter().all(Option::is_none),
+            "change must stay with the owner, not go to a named recipient",
+        );
+
+        let mut prepared = prepared_step(WITHDRAW_RECIPIENT_ADDRESS, paid_out, change);
+        pool.simulate(&mut prepared).expect("simulate");
+        let call = TransactCall::of(&prepared);
+        assert_eq!(call.envelope_source, address(DELEGATE_ADDRESS));
+        assert_eq!(call.sender, address(DELEGATE_ADDRESS));
+        assert_ne!(call.envelope_source, address(OWNER_ADDRESS));
+
+        // Weaker than the two above: this value came from `prepared_step`, not
+        // from the plan, so it covers the encoding and not the hop into it.
+        assert_eq!(call.ext_recipient, address(WITHDRAW_RECIPIENT_ADDRESS));
+        assert_ne!(call.ext_recipient, address(DELEGATE_ADDRESS));
+
+        pool.sign(&prepared)
+            .expect("the signer must be able to sign the envelope it sources");
+    }
+
+    #[test]
+    fn transfer_spends_the_owners_notes_and_is_sourced_by_the_signer() {
+        let (_, account) =
+            delegated_test_client_and_account(Some(&[2, 3, 5])).expect("delegated session");
+        let pool = account.pool(POOL_CONTRACT_ID).expect("pool");
+        assert_divergent(&pool);
+
+        let wallet = pool.spendable_notes().expect("spendable notes");
+        let mut amounts: Vec<_> = wallet.iter().map(|note| note.amount).collect();
+        amounts.sort();
+        assert_eq!(
+            amounts,
+            [
+                NoteAmount::from(2u128),
+                NoteAmount::from(3u128),
+                NoteAmount::from(5u128),
+            ],
+        );
+
+        // Same shape as `transfer_two_steps`, which signs as the owner.
+        let amount = NoteAmount::from(10u128);
+        let plan = pool
+            .prepare_transfer(&wallet, test_recipient(), amount)
+            .expect("a delegated session must plan a transfer");
+        assert_eq!(plan.tx_count(), 2);
+
+        // A transfer moves nothing out, so its ext recipient is the pool.
+        let mut prepared = prepared_step(POOL_CONTRACT_ID, ExtAmount::ZERO, amount);
+        pool.simulate(&mut prepared).expect("simulate");
+        let call = TransactCall::of(&prepared);
+        assert_eq!(call.envelope_source, address(DELEGATE_ADDRESS));
+        assert_eq!(call.sender, address(DELEGATE_ADDRESS));
+        assert_eq!(call.ext_recipient, address(POOL_CONTRACT_ID));
+
+        pool.sign(&prepared)
+            .expect("the signer must be able to sign the envelope it sources");
+    }
+
+    fn assert_divergent(pool: &PrivatePool) {
+        let config = pool.config();
+        assert_eq!(config.user_address.as_str(), OWNER_ADDRESS);
+        assert_eq!(config.signer_address.as_str(), DELEGATE_ADDRESS);
+        assert_ne!(
+            config.user_address.as_str(),
+            config.signer_address.as_str(),
+            "the pair must differ or the test proves nothing",
+        );
+    }
+
+    /// A `transact` step's prover output, stood in for rather than proved:
+    /// nothing from here to the envelope inspects a proof.
+    ///
+    /// Running the real `prove_next` instead is what closes the recipient gap
+    /// above. It needs the stub RPC to serve the contract-data reads and a
+    /// non-membership `find`, and costs real proving time per test.
+    fn prepared_step(
+        recipient: &str,
+        ext_amount: ExtAmount,
+        change: NoteAmount,
+    ) -> PreparedTransaction {
+        PreparedTransaction {
+            proof_uncompressed: vec![0u8; 256],
+            ext_data: ExtData {
+                recipient: recipient.to_string(),
+                ext_amount,
+                encrypted_output0: Vec::new(),
+                encrypted_output1: Vec::new(),
+            },
+            prepared: PreparedTxPublic {
+                pool_root: Field::ZERO,
+                input_nullifiers: [Field::ZERO; 2],
+                output_commitments: [Field::from(change), Field::ZERO],
+                public_amount: Field::ZERO,
+                ext_data_hash_be: [0u8; 32],
+                asp_membership_root: Field::ZERO,
+                asp_non_membership_root: Field::ZERO,
+                output_gvk_ciphertexts: None,
+                input_gvk_ciphertexts: None,
+            },
+            soroban_tx: Default::default(),
+        }
+    }
+
+    /// The three identities in a simulated pool `transact` call.
+    struct TransactCall {
+        envelope_source: ScAddress,
+        sender: ScAddress,
+        ext_recipient: ScAddress,
+    }
+
+    impl TransactCall {
+        fn of(prepared: &PreparedTransaction) -> Self {
+            let envelope =
+                TransactionEnvelope::from_xdr_base64(&prepared.soroban_tx.tx_xdr, Limits::none())
+                    .expect("prepared envelope xdr");
+            let TransactionEnvelope::Tx(v1) = envelope else {
+                panic!("expected a v1 envelope");
+            };
+            let xdr::MuxedAccount::Ed25519(source_key) = v1.tx.source_account else {
+                panic!("expected an ed25519 source account");
+            };
+            let xdr::OperationBody::InvokeHostFunction(invoke) = &v1.tx.operations[0].body else {
+                panic!("expected an invokeHostFunction operation");
+            };
+            let xdr::HostFunction::InvokeContract(args) = &invoke.host_function else {
+                panic!("expected a contract invocation");
+            };
+            assert_eq!(args.function_name.to_string(), "transact");
+
+            // `transact(proof, ext_data, sender)`.
+            let xdr::ScVal::Address(sender) = &args.args[2] else {
+                panic!("the sender argument must be an address");
+            };
+            Self {
+                envelope_source: ScAddress::Account(xdr::AccountId(
+                    xdr::PublicKey::PublicKeyTypeEd25519(source_key),
+                )),
+                sender: sender.clone(),
+                ext_recipient: ext_data_recipient(&args.args[1]),
+            }
+        }
+    }
+
+    fn ext_data_recipient(ext_data: &xdr::ScVal) -> ScAddress {
+        let xdr::ScVal::Map(Some(map)) = ext_data else {
+            panic!("expected ext_data to be a map");
+        };
+        for xdr::ScMapEntry { key, val } in map.iter() {
+            let xdr::ScVal::Symbol(name) = key else {
+                continue;
+            };
+            if name.to_utf8_string().expect("ext_data key") == "recipient" {
+                let xdr::ScVal::Address(recipient) = val else {
+                    panic!("the ext_data recipient must be an address");
+                };
+                return recipient.clone();
+            }
+        }
+        panic!("ext_data has no recipient entry");
+    }
+
+    fn address(strkey: &str) -> ScAddress {
+        strkey.parse().expect("address strkey")
+    }
+}


### PR DESCRIPTION
Two `sdk-tests` cases drive a withdrawal and a transfer from a session whose note owner and signing account are different accounts. Nothing proved a divergent pair could spend — coverage stopped at session open.

**Asserted**

- The notes spent, and the change, belong to the owner.
- The envelope's source account and the contract's `sender` argument are the signer, and the signer's own key signs it.
- The withdrawal recipient is neither account — through the planner only, see below.

**Limitation.** The prover is stood in for rather than run, by choice. Making `prove_next` work here means teaching the stub RPC the contract-data reads and a non-membership `find`, and paying for real Groth16 proving in the tests. That's the follow-up, and it's what closes the recipient's last hop out of `ext_data`; until then a break between plan and envelope would go unnoticed there.

`sdk/native` untouched. Bigger than the ~90 lines scoped, all of it fixture — every claim sits downstream of `prove_next`, so asserting the envelope at all needed a local stand-in for the two RPC methods `simulate` calls.

Workspace tests, clippy, fmt and typos clean. Mutation probes on the signer address, `pool.rs:259` and the planner's `ext_recipient` each fail the tests as they should.
